### PR TITLE
chore(ci): upgrade dagger gha versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,11 +22,11 @@ jobs:
           echo 'keep' > terraform/vault/cluster/.tls/ca-chain.pem
 
       - name: Validate Terraform Opentofu configuration
-        uses: dagger/dagger-for-github@v5
+        uses: dagger/dagger-for-github@v6
         with:
           version: "latest"
           verb: call
-          module: github.com/Smana/daggerverse/pre-commit-tf@pre-commit-tf/v0.0.1
+          module: github.com/Smana/daggerverse/pre-commit-tf@pre-commit-tf/v0.1.0
           args: run --dir "." --tf-binary="tofu"
           # cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
@@ -38,19 +38,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate Flux clusters manifests
-        uses: dagger/dagger-for-github@v5
+        uses: dagger/dagger-for-github@v6
         with:
           version: "latest"
           verb: call
-          module: github.com/Smana/daggerverse/kubeconform@kubeconform/v0.0.4
+          module: github.com/Smana/daggerverse/kubeconform@kubeconform/v0.1.0
           args: validate --manifests "./clusters" --catalog
           # cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
       - name: Validate Kubernetes manifests (Kustomize directories)
-        uses: dagger/dagger-for-github@v5
+        uses: dagger/dagger-for-github@v6
         with:
           version: "latest"
           verb: call
-          module: github.com/Smana/daggerverse/kubeconform@kubeconform/v0.0.4
+          module: github.com/Smana/daggerverse/kubeconform@kubeconform/v0.1.0
           args: validate --manifests "." --kustomize --flux --env="cluster_name:foobar,region:eu-west-3,domain_name:example.com" --catalog --crds https://github.com/kubernetes-sigs/gateway-api/tree/main/config/crd/experimental
           # cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Upgraded `dagger/dagger-for-github` action from version `v5` to `v6` in the CI workflow.
- Updated `pre-commit-tf` module from `v0.0.1` to `v0.1.0` for Terraform validation.
- Updated `kubeconform` module from `v0.0.4` to `v0.1.0` for Kubernetes manifest validation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yaml</strong><dd><code>Upgrade Dagger GitHub Action and Modules in CI Workflow</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yaml

<li>Upgraded <code>dagger/dagger-for-github</code> action from version <code>v5</code> to <code>v6</code>.<br> <li> Updated <code>pre-commit-tf</code> module from <code>v0.0.1</code> to <code>v0.1.0</code>.<br> <li> Updated <code>kubeconform</code> module from <code>v0.0.4</code> to <code>v0.1.0</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/342/files#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133dd">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

