### PR TITLE
fix(tailscale): missing split DNS config

### DIFF
--- a/dagger/go.mod
+++ b/dagger/go.mod
@@ -2,27 +2,11 @@ module dagger/cloud-native-ref
 
 go 1.22.5
 
+require github.com/aws/aws-sdk-go v1.55.5
+
 require (
 	github.com/99designs/gqlgen v0.17.49
 	github.com/Khan/genqlient v0.7.0
-	github.com/aws/aws-sdk-go v1.55.5
-	github.com/vektah/gqlparser/v2 v2.5.16
-	go.opentelemetry.io/otel v1.28.0
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240816180739-2db4ef2c032c
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.4.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.28.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.28.0
-	go.opentelemetry.io/otel/log v0.4.0
-	go.opentelemetry.io/otel/sdk v1.28.0
-	go.opentelemetry.io/otel/sdk/log v0.4.0
-	go.opentelemetry.io/otel/trace v1.28.0
-	go.opentelemetry.io/proto/otlp v1.3.1
-	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa
-	golang.org/x/sync v0.8.0
-	google.golang.org/grpc v1.65.0
-)
-
-require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -31,12 +15,26 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/sosodev/duration v1.3.1 // indirect
+	github.com/vektah/gqlparser/v2 v2.5.16
+	go.opentelemetry.io/otel v1.28.0
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240819085943-964f8dfeb54d
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.4.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.28.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.28.0
+	go.opentelemetry.io/otel/log v0.4.0
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.28.0
+	go.opentelemetry.io/otel/sdk/log v0.4.0
+	go.opentelemetry.io/otel/trace v1.28.0
+	go.opentelemetry.io/proto/otlp v1.3.1
+	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa
 	golang.org/x/net v0.28.0 // indirect
+	golang.org/x/sync v0.8.0
 	golang.org/x/sys v0.24.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240814211410-ddb44dafa142 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142 // indirect
+	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2 // indirect
 )

--- a/dagger/go.sum
+++ b/dagger/go.sum
@@ -43,8 +43,8 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 go.opentelemetry.io/otel v1.28.0 h1:/SqNcYk+idO0CxKEUOtKQClMK/MimZihKYMruSMViUo=
 go.opentelemetry.io/otel v1.28.0/go.mod h1:q68ijF8Fc8CnMHKyzqL6akLO46ePnjkgfIMIjUIX9z4=
-go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240816180739-2db4ef2c032c h1:28JrO2E1h9IEXPUkyEiTCgS/cqZWaFknuGK/HFcSSAY=
-go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240816180739-2db4ef2c032c/go.mod h1:p8WjcTUg9wpb6LK/v0V+D9CHKZIEJ+5A6OmbqlPKMh0=
+go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240819085943-964f8dfeb54d h1:JUOHa7+xjXP8jPDjVxFikdxQhtTi/20KVwWmP50JV/Q=
+go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240819085943-964f8dfeb54d/go.mod h1:6zyEXYVAuUMLLzMvruKd8F88aY8wV4XKMhOwWrLZDaM=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.4.0 h1:zBPZAISA9NOc5cE8zydqDiS0itvg/P/0Hn9m72a5gvM=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.4.0/go.mod h1:gcj2fFjEsqpV3fXuzAA+0Ze1p2/4MJ4T7d77AmkvueQ=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 h1:3Q/xZUyC1BBkualc9ROb4G8qkH90LXEIICcs5zv1OYY=

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -87,7 +87,7 @@ func New(
 	if container == nil {
 
 		// init a wolfi container with the necessary tools
-		container = dag.Apko().Wolfi([]string{"aws-cli-v2", "bash", "curl", "git", "jq", "opentofu"})
+		container = dag.Apko().Wolfi([]string{"aws-cli-v2", "bash", "git", "jq", "opentofu"})
 
 		// Add the environment variables to the container
 		for _, e := range env {

--- a/security/base/cert-manager/vault-clusterissuer.yaml
+++ b/security/base/cert-manager/vault-clusterissuer.yaml
@@ -11,7 +11,7 @@ spec:
     auth:
       appRole:
         path: approle
-        roleId: 55857da8-b230-606e-ae31-44bd44ed53ef # !! This value changes each time I recreate the whole platform
+        roleId: 9b15c3e4-9808-ce9f-8699-349cabfea40b # !! This value changes each time I recreate the whole platform
         secretRef:
           name: cert-manager-vault-approle
           key: secret_id

--- a/terraform/network/tailscale.tf
+++ b/terraform/network/tailscale.tf
@@ -34,9 +34,20 @@ resource "tailscale_acl" "this" {
 
 resource "tailscale_dns_nameservers" "this" {
   nameservers = [
-    "1.1.1.1",                             // Cloudflare
-    cidrhost(module.vpc.vpc_cidr_block, 2) // https://tailscale.com/kb/1141/aws-rds/#step-3-add-aws-dns-for-your-tailnet
+    "1.1.1.1" // Cloudflare
   ]
+}
+
+resource "tailscale_dns_split_nameservers" "private" {
+  domain = var.private_domain_name
+
+  nameservers = [cidrhost(module.vpc.vpc_cidr_block, 2)]
+}
+
+resource "tailscale_dns_split_nameservers" "ec2" {
+  domain = "${var.region}.compute.internal"
+
+  nameservers = [cidrhost(module.vpc.vpc_cidr_block, 2)]
 }
 
 resource "tailscale_dns_search_paths" "this" {

--- a/tooling/mycluster-0/kustomization.yaml
+++ b/tooling/mycluster-0/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   # Uncomment the following resources to include them in the kustomization
   # - ../base/dagger-engine
   # - ../base/gha-runners
-  #  - ../base/harbor
+  # - ../base/harbor


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added split DNS configuration for Tailscale by introducing `tailscale_dns_split_nameservers` for private and EC2 domains.
- Updated the `roleId` for Vault AppRole authentication in cert-manager configuration.
- Reorganized and updated Go module dependencies in `dagger/go.mod`.
- Enabled `cloud-token` for DAGGER_CLOUD_TOKEN in GitHub CI workflow.
- Added Flux sync manifest and kustomization for `mycluster-0`.
- Included dagger-engine and gha-runners in kustomization resources.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tailscale.tf</strong><dd><code>Add split DNS configuration for Tailscale</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/network/tailscale.tf

<li>Added <code>tailscale_dns_split_nameservers</code> resources for private and EC2 <br>domains.<br> <li> Removed AWS DNS from <code>tailscale_dns_nameservers</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/382/files#diff-9bccc9b98249891cd0a1c37be2f13ddc22b5f88bcbafb74e041c6f762c8eabaa">+13/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vault-clusterissuer.yaml</strong><dd><code>Update Vault AppRole roleId for cert-manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

security/base/cert-manager/vault-clusterissuer.yaml

- Updated the `roleId` for Vault AppRole authentication.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/382/files#diff-ef454d0ddaf31b989827e79a4c946cfe5c38277fbdd2545c54dd6ea97708ac22">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ci.yaml</strong><dd><code>Enable cloud-token in GitHub CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yaml

- Uncommented `cloud-token` for DAGGER_CLOUD_TOKEN in CI workflow.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/382/files#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133dd">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gotk-sync.yaml</strong><dd><code>Add Flux sync manifest for mycluster-0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

clusters/mycluster-0/flux-system/gotk-sync.yaml

- Added Flux sync manifest for GitRepository and Kustomization.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/382/files#diff-7c786712425fc16e05c70e441dacc8f3641371ba4b308d216e298b0fb2bed98a">+27/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Include dagger-engine and gha-runners in kustomization</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tooling/mycluster-0/kustomization.yaml

- Uncommented resources for dagger-engine and gha-runners.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/382/files#diff-e82fe1bc16944a41a1957f040e6e7d53faf5f72ebeaeb41ab43e19412ac35ca4">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Add kustomization for Flux components and sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

clusters/mycluster-0/flux-system/kustomization.yaml

- Added kustomization for gotk-components and gotk-sync.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/382/files#diff-d66e48138dfb49082f730b653910bfb2649f85569de0e57b18945db3885ee99d">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Reorganize and update Go module dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dagger/go.mod

<li>Reorganized dependencies, moving some to the main <code>require</code> block.<br> <li> Added and updated indirect dependencies.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/382/files#diff-32fbd4eba7f897491c71e39ef6705a3a1a7d6890cd2df436261e58298683d422">+14/-16</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Additional files (token-limit)</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gotk-components.yaml</strong><dd><code>...</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

clusters/mycluster-0/flux-system/gotk-components.yaml

...



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/382/files#diff-47c737309c78154a3f8e0ad507753bc5228ff3a72aa4df3be363c64d6067d526">+12386/-1</a></td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

