### PR TITLE
chore(dagger): missing http proxy command for tailscale

### DIFF
--- a/dagger/network.go
+++ b/dagger/network.go
@@ -105,7 +105,7 @@ kill $TS_PID
 wait $TS_PID
 
 # Relaunch the tailscaled process in the foreground
-tailscaled --tun=userspace-networking --socks5-server=:1055
+tailscaled --tun=userspace-networking --socks5-server=:1055 --outbound-http-proxy-listen=:1055
 `
 
 	svc := container.


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the `tailscaled` command by adding the `--outbound-http-proxy-listen=:1055` option.
- This change allows the `tailscaled` process to support HTTP proxy functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network.go</strong><dd><code>Add HTTP proxy support to `tailscaled` command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dagger/network.go

<li>Added <code>--outbound-http-proxy-listen=:1055</code> to the <code>tailscaled</code> command.<br> <li> Enhanced the command to support HTTP proxy functionality.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/386/files#diff-3230a0c31b8ae602eb9b66add20993aabe457f449dc45f285d3fce54c77a441c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

