### PR TITLE
chore(observability): add cilium monitoring

### DIFF
--- a/observability/base/victoria-metrics-k8s-stack/externalsecret-alertmanager-slack-app.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/externalsecret-alertmanager-slack-app.yaml
@@ -2,6 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: victoria-metrics-k8s-stack-alertmanager-slack-app
+  namespace: observability
 spec:
   dataFrom:
     - extract:

--- a/observability/base/victoria-metrics-k8s-stack/externalsecret-grafana-admin.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/externalsecret-grafana-admin.yaml
@@ -2,6 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: victoria-metrics-k8s-stack-grafana-admin
+  namespace: observability
 spec:
   dataFrom:
     - extract:

--- a/observability/base/victoria-metrics-k8s-stack/helmrelease-single.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/helmrelease-single.yaml
@@ -2,6 +2,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: victoria-metrics-k8s-stack
+  namespace: observability
 spec:
   releaseName: victoria-metrics-k8s-stack
   chart:
@@ -28,6 +29,10 @@ spec:
           dashboards: "grafana"
       allowCrossNamespaceImport: false
 
+    vmagent:
+      externalLabels:
+        cluster: "${cluster_name}"
+
     vmsingle:
       spec:
         retentionPeriod: "1d" # Minimal retention, for tests only
@@ -38,6 +43,8 @@ spec:
           resources:
             requests:
               storage: 10Gi
+        extraArgs:
+          maxLabelsPerTimeseries: "50"
 
     alertmanager:
       enabled: true
@@ -56,14 +63,17 @@ spec:
 
         route:
           receiver: "slack-monitoring"
-
-        inhibit_rules:
-          - target_matchers:
-              - severity=info
-            source_matchers:
-              - alertname=~InfoInhibitor|Watchdog|KubeCPUOvercommit
+          routes:
+            - matchers:
+                - alertname =~ "InfoInhibitor|Watchdog|KubeCPUOvercommit"
+              receiver: "blackhole"
+            - matchers:
+                - severity=~"info|warning|critical"
+              receiver: slack-monitoring
+              continue: true
 
         receivers:
+          - name: "blackhole"
           - name: "slack-monitoring"
             slack_configs:
               - channel: "#alerts"
@@ -198,9 +208,9 @@ spec:
             url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/logs.json
             datasource: Loki
         karpenter:
-          default:
+          karpenter:
             gnetId: 20398
-            revision: 2
+            revision: 1
             datasource: VictoriaMetrics
         # Dashboards from https://github.com/dotdc/grafana-dashboards-kubernetes
         views:

--- a/observability/base/victoria-metrics-k8s-stack/helmrelease-single.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/helmrelease-single.yaml
@@ -121,6 +121,14 @@ spec:
               editable: true
               options:
                 path: /var/lib/grafana/dashboards/default
+            - name: "cilium"
+              orgId: 1
+              folder: "Cilium"
+              type: file
+              disableDeletion: true
+              editable: true
+              options:
+                path: /var/lib/grafana/dashboards/cilium
             - name: "flux"
               orgId: 1
               folder: "Flux"
@@ -159,6 +167,25 @@ spec:
           nodeexporter:
             gnetId: 1860
             revision: 22
+            datasource: VictoriaMetrics
+        cilium:
+          cilium:
+            url: https://raw.githubusercontent.com/cilium/cilium/main/install/kubernetes/cilium/files/cilium-agent/dashboards/cilium-dashboard.json
+            datasource: VictoriaMetrics
+          cilium-operator:
+            url: https://raw.githubusercontent.com/cilium/cilium/main/install/kubernetes/cilium/files/cilium-operator/dashboards/cilium-operator-dashboard.json
+            datasource: VictoriaMetrics
+          hubble:
+            url: https://raw.githubusercontent.com/cilium/cilium/main/install/kubernetes/cilium/files/hubble/dashboards/hubble-dashboard.json
+            datasource: VictoriaMetrics
+          hubble-dns-namespace:
+            url: https://raw.githubusercontent.com/cilium/cilium/main/install/kubernetes/cilium/files/hubble/dashboards/hubble-dns-namespace.json
+            datasource: VictoriaMetrics
+          hubble-l7-http-metrics:
+            url: https://raw.githubusercontent.com/cilium/cilium/main/install/kubernetes/cilium/files/hubble/dashboards/hubble-l7-http-metrics-by-workload.json
+            datasource: VictoriaMetrics
+          hubble-network-overview-namespace:
+            url: https://raw.githubusercontent.com/cilium/cilium/main/install/kubernetes/cilium/files/hubble/dashboards/hubble-network-overview-namespace.json
             datasource: VictoriaMetrics
         flux:
           flux-controlplane:

--- a/observability/base/victoria-metrics-k8s-stack/httproute-grafana.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/httproute-grafana.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: grafana
+  namespace: observability
 spec:
   parentRefs:
     - name: platform-private

--- a/observability/base/victoria-metrics-k8s-stack/httproute-vmagent.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/httproute-vmagent.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: vmagent
+  namespace: observability
 spec:
   parentRefs:
     - name: platform-private

--- a/observability/base/victoria-metrics-k8s-stack/httproute-vmalertmanager.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/httproute-vmalertmanager.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: vmalertmanager
+  namespace: observability
 spec:
   parentRefs:
     - name: platform-private

--- a/observability/base/victoria-metrics-k8s-stack/httproute-vmsingle.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/httproute-vmsingle.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: vmsingle
+  namespace: observability
 spec:
   parentRefs:
     - name: platform-private

--- a/observability/base/victoria-metrics-k8s-stack/kustomization.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
   - externalsecret-grafana-admin.yaml
   - source.yaml
   # Choose between single or cluster helm release
-  - single-helmrelease.yaml
-  # - cluster-helmrelease.yaml
+  - helmrelease-single.yaml
+  # - helmrelease-cluster.yaml
   # HttpRoutes
   - httproute-grafana.yaml
   - httproute-vmsingle.yaml # To be changed if cluster is chosen
@@ -17,3 +17,4 @@ resources:
   # Victoria Metrics Operator resources
   - vmpodscrapes
   - vmservicescrapes
+  - vmrules

--- a/observability/base/victoria-metrics-k8s-stack/kustomization.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: observability
 
 resources:
   - externalsecret-alertmanager-slack-app.yaml

--- a/observability/base/victoria-metrics-k8s-stack/vmrules/cilium.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmrules/cilium.yaml
@@ -1,0 +1,73 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  groups:
+    - name: cilium-agent
+      rules:
+        - alert: CiliumAgentUnreachableHealthEndpoints
+          expr: |
+            max by (namespace, pod) (cilium_unreachable_health_endpoints) > 0
+            and on()
+            (
+              (
+                count(changes(kube_pod_info{created_by_name="agent",namespace="kube-system"}[2m])) -
+                count(kube_pod_info{created_by_name="agent",namespace="kube-system"} offset 2m)
+              ) == 0
+            )
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Some node's health endpoints are not reachable by agent {{ $labels.namespace }}/{{ $labels.pod }}.
+            description: |
+              Check what's going on: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
+            runbook_url: "https://runbook.url"
+            dashboard: "https://dashboard.url"
+            link_url: "https://link.url"
+
+        - alert: CiliumAgentMetricNotFound
+          expr: (count by (namespace,pod) (cilium_unreachable_health_endpoints) OR count by (namespace,pod) (cilium_endpoint_state)) != 1
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Some of the metrics are not coming from the agent {{ $labels.namespace }}/{{ $labels.pod }}.
+            description: |
+              Use the following commands to check what's going on:
+              - `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
+              - `kubectl -n {{ $labels.namespace }} exec -ti {{ $labels.pod }} cilium-health status`
+              We need to cross-check the metrics with the neighboring agent.
+              Also, the absence of metrics is an indirect sign that new pods cannot be created on the node because of the inability to connect to the agent.
+              It is important to get a more specific way of determining the above situation and create a more accurate alert for the inability to connect new pods to the agent.
+            runbook_url: "https://runbook.url"
+            dashboard: "https://dashboard.url"
+            link_url: "https://link.url"
+
+        - alert: CiliumAgentEndpointsNotReady
+          expr: sum by (namespace, pod) (cilium_endpoint_state{endpoint_state="ready"} / cilium_endpoint_state) < 0.5
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: More than half of all known Endpoints are not ready in agent {{ $labels.namespace }}/{{ $labels.pod }}.
+            description: |
+              Check what's going on: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
+            runbook_url: "https://runbook.url"
+            dashboard: "https://dashboard.url"
+            link_url: "https://link.url"
+
+        - alert: CiliumAgentPolicyImportErrors
+          expr: sum by (namespace, pod) (rate(cilium_policy_import_errors_total[2m]) > 0)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Agent {{ $labels.namespace }}/{{ $labels.pod }} fails to import policies.
+            description: |
+              Check what's going on: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
+            runbook_url: "https://runbook.url"
+            dashboard: "https://dashboard.url"
+            link_url: "https://link.url"

--- a/observability/base/victoria-metrics-k8s-stack/vmrules/cilium.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmrules/cilium.yaml
@@ -21,12 +21,11 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: Some node's health endpoints are not reachable by agent {{ $labels.namespace }}/{{ $labels.pod }}.
+            message: Some node's health endpoints are not reachable by agent {{ $labels.namespace }}/{{ $labels.pod }}.
             description: |
               Check what's going on: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
-            runbook_url: "https://runbook.url"
-            dashboard: "https://dashboard.url"
-            link_url: "https://link.url"
+            runbook_url: "https://docs.cilium.io/en/stable/operations/troubleshooting/"
+            dashboard: "https://grafana.priv.${domain_name}/dashboards"
 
         - alert: CiliumAgentMetricNotFound
           expr: (count by (namespace,pod) (cilium_unreachable_health_endpoints) OR count by (namespace,pod) (cilium_endpoint_state)) != 1
@@ -34,7 +33,7 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: Some of the metrics are not coming from the agent {{ $labels.namespace }}/{{ $labels.pod }}.
+            message: Some of the metrics are not coming from the agent {{ $labels.namespace }}/{{ $labels.pod }}.
             description: |
               Use the following commands to check what's going on:
               - `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
@@ -42,9 +41,8 @@ spec:
               We need to cross-check the metrics with the neighboring agent.
               Also, the absence of metrics is an indirect sign that new pods cannot be created on the node because of the inability to connect to the agent.
               It is important to get a more specific way of determining the above situation and create a more accurate alert for the inability to connect new pods to the agent.
-            runbook_url: "https://runbook.url"
-            dashboard: "https://dashboard.url"
-            link_url: "https://link.url"
+            runbook_url: "https://docs.cilium.io/en/stable/operations/troubleshooting/"
+            dashboard: "https://grafana.priv.${domain_name}/dashboards"
 
         - alert: CiliumAgentEndpointsNotReady
           expr: sum by (namespace, pod) (cilium_endpoint_state{endpoint_state="ready"} / cilium_endpoint_state) < 0.5
@@ -55,9 +53,8 @@ spec:
             summary: More than half of all known Endpoints are not ready in agent {{ $labels.namespace }}/{{ $labels.pod }}.
             description: |
               Check what's going on: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
-            runbook_url: "https://runbook.url"
-            dashboard: "https://dashboard.url"
-            link_url: "https://link.url"
+            runbook_url: "https://docs.cilium.io/en/stable/operations/troubleshooting/"
+            dashboard: "https://grafana.priv.${domain_name}/dashboards"
 
         - alert: CiliumAgentPolicyImportErrors
           expr: sum by (namespace, pod) (rate(cilium_policy_import_errors_total[2m]) > 0)
@@ -68,6 +65,5 @@ spec:
             summary: Agent {{ $labels.namespace }}/{{ $labels.pod }} fails to import policies.
             description: |
               Check what's going on: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
-            runbook_url: "https://runbook.url"
-            dashboard: "https://dashboard.url"
-            link_url: "https://link.url"
+            runbook_url: "https://docs.cilium.io/en/stable/operations/troubleshooting/"
+            dashboard: "https://grafana.priv.${domain_name}/dashboards"

--- a/observability/base/victoria-metrics-k8s-stack/vmrules/flux.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmrules/flux.yaml
@@ -1,0 +1,43 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  labels:
+    prometheus-instance: main
+  name: flux-system
+  namespace: flux-system
+spec:
+  groups:
+    - name: flux-system
+      rules:
+        - alert: FluxReconciliationFailure
+          annotations:
+            message: Flux resource has been unhealthy for more than 5m
+            description: "{{ $labels.kind }} {{ $labels.exported_namespace }}/{{ $labels.name }} reconciliation has been failing for more than ten minutes."
+            runbook_url: "https://fluxcd.io/flux/cheatsheets/troubleshooting/"
+            dashboard: "https://grafana.priv.${domain_name}/dashboards"
+          expr: max(gotk_reconcile_condition{status="False",type="Ready"}) by (exported_namespace, name, kind) + on(exported_namespace, name, kind) (max(gotk_reconcile_condition{status="Deleted"}) by (exported_namespace, name, kind)) * 2 == 1
+          for: 10m
+          labels:
+            severity: warning
+        - alert: FluxHelmOperatorErrors
+          annotations:
+            message: Flux Helm operator errors
+            description: >
+              There is an issue deploying `{{ $labels.release_name }}` release helm chart.
+              Errors count `{{ $value }}`.
+            runbook_url: "https://fluxcd.io/flux/cheatsheets/troubleshooting/"
+            dashboard: "https://grafana.priv.${domain_name}/dashboards"
+          for: 5m
+          expr: sum(increase(flux_helm_operator_release_duration_seconds_count{success="false"}[5m])) by (release_name) > 0
+          labels:
+            severity: warning
+        - alert: FluxSuspended
+          annotations:
+            message: (Flux) Resource suspended for more than 45m
+            description: "`{{ $labels.kind }}` `{{ $labels.name  }}` in namespace `{{ $labels.exported_namespace }}` is suspended."
+            runbook_url: "https://fluxcd.io/flux/cheatsheets/troubleshooting/"
+            dashboard: "https://grafana.priv.${domain_name}/dashboards"
+          expr: sum(gotk_suspend_status) by (name, kind, exported_namespace) > 0
+          for: 5m
+          labels:
+            severity: warning

--- a/observability/base/victoria-metrics-k8s-stack/vmrules/karpenter.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmrules/karpenter.yaml
@@ -15,12 +15,11 @@ spec:
           labels:
             severity: warning
           annotations:
+            message: Problem with registering new nodes in the cluster.
             description: |
               Karpenter in the nodepool {{ $labels.nodeppol }} launched new nodes, but some of the nodes did not register in the cluster during 15 minutes.
-            summary: Problem with registering new nodes in the cluster.
-            runbook_url: "https://runbook.url"
-            dashboard: "https://dashboard.url"
-            link_url: "https://link.url"
+            runbook_url: "https://karpenter.sh/docs/troubleshooting/"
+            dashboard: "https://grafana.priv.${domain_name}/dashboards"
 
         - alert: KarpenterNodepoolAlmostFull
           expr: sum by (nodepool,resource_type) (karpenter_nodepool_usage) / sum by (nodepool,resource_type) (karpenter_nodepool_limit) * 100 > 80
@@ -28,12 +27,11 @@ spec:
           labels:
             severity: warning
           annotations:
+            message: Nodepool almost full, you should increase limits.
             description: |
               Nodepool {{ $labels.nodeppol }} has launched {{ $value }}% of {{ $labels.resource_type }} resources of the limit.
-            summary: Nodepool almost full, you should increase limits.
-            runbook_url: "https://runbook.url"
-            dashboard: "https://dashboard.url"
-            link_url: "https://link.url"
+            runbook_url: "https://karpenter.sh/docs/troubleshooting/"
+            dashboard: "https://grafana.priv.${domain_name}/dashboards"
 
         - alert: KarpenterCloudproviderErrors
           expr: increase(karpenter_cloudprovider_errors_total[10m]) > 0
@@ -41,9 +39,8 @@ spec:
           labels:
             severity: warning
           annotations:
+            message: Cloud provider errors detected by Karpenter.
             description: |
               Karpenter received an error during an API call to the cloud provider.
-            summary: Cloud provider errors detected by Karpenter.
-            runbook_url: "https://runbook.url"
-            dashboard: "https://dashboard.url"
-            link_url: "https://link.url"
+            runbook_url: "https://karpenter.sh/docs/troubleshooting/"
+            dashboard: "https://grafana.priv.${domain_name}/dashboards"

--- a/observability/base/victoria-metrics-k8s-stack/vmrules/karpenter.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmrules/karpenter.yaml
@@ -1,0 +1,49 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  labels:
+    app: karpenter
+  name: karpenter
+  namespace: karpenter
+spec:
+  groups:
+    - name: karpenter
+      rules:
+        - alert: KarpenterCanNotRegisterNewNodes
+          expr: sum by (nodepool) (karpenter_nodeclaims_launched) - sum by (nodepool)(karpenter_nodeclaims_registered) != 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            description: |
+              Karpenter in the nodepool {{ $labels.nodeppol }} launched new nodes, but some of the nodes did not register in the cluster during 15 minutes.
+            summary: Problem with registering new nodes in the cluster.
+            runbook_url: "https://runbook.url"
+            dashboard: "https://dashboard.url"
+            link_url: "https://link.url"
+
+        - alert: KarpenterNodepoolAlmostFull
+          expr: sum by (nodepool,resource_type) (karpenter_nodepool_usage) / sum by (nodepool,resource_type) (karpenter_nodepool_limit) * 100 > 80
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            description: |
+              Nodepool {{ $labels.nodeppol }} has launched {{ $value }}% of {{ $labels.resource_type }} resources of the limit.
+            summary: Nodepool almost full, you should increase limits.
+            runbook_url: "https://runbook.url"
+            dashboard: "https://dashboard.url"
+            link_url: "https://link.url"
+
+        - alert: KarpenterCloudproviderErrors
+          expr: increase(karpenter_cloudprovider_errors_total[10m]) > 0
+          for: 1m
+          labels:
+            severity: warning
+          annotations:
+            description: |
+              Karpenter received an error during an API call to the cloud provider.
+            summary: Cloud provider errors detected by Karpenter.
+            runbook_url: "https://runbook.url"
+            dashboard: "https://dashboard.url"
+            link_url: "https://link.url"

--- a/observability/base/victoria-metrics-k8s-stack/vmrules/kustomization.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmrules/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 
 resources:
   - cilium.yaml
+  - flux.yaml
   - karpenter.yaml

--- a/observability/base/victoria-metrics-k8s-stack/vmrules/kustomization.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmrules/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cilium.yaml
+  - karpenter.yaml

--- a/observability/base/victoria-metrics-k8s-stack/vmservicescrapes/cilium.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmservicescrapes/cilium.yaml
@@ -1,3 +1,24 @@
+# Agent
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-agent
+  namespace: kube-system
+  labels:
+    k8s-app: cilium
+    app.kubernetes.io/name: cilium-agent
+    app.kubernetes.io/part-of: cilium
+spec:
+  clusterIP: None
+  type: ClusterIP
+  selector:
+    k8s-app: cilium
+  ports:
+    - name: metrics
+      port: 9962
+      protocol: TCP
+      targetPort: prometheus
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
@@ -18,22 +39,34 @@ spec:
       interval: "10s"
       honorLabels: true
       path: /metrics
-      relabelings:
-        - replacement: ${1}
-          sourceLabels:
-            - __meta_kubernetes_pod_node_name
-          targetLabel: node
-    - port: envoy-metrics
-      interval: "10s"
-      honorLabels: true
-      path: /metrics
-      relabelings:
-        - replacement: ${1}
+      relabelConfigs:
+        - action: replace
           sourceLabels:
             - __meta_kubernetes_pod_node_name
           targetLabel: node
   targetLabels:
     - k8s-app
+# Envoy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-envoy
+  namespace: kube-system
+  labels:
+    k8s-app: cilium-envoy
+    app.kubernetes.io/name: cilium-envoy
+    app.kubernetes.io/part-of: cilium
+spec:
+  clusterIP: None
+  type: ClusterIP
+  selector:
+    k8s-app: cilium-envoy
+  ports:
+    - name: metrics
+      port: 9964
+      protocol: TCP
+      targetPort: envoy-metrics
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
@@ -48,24 +81,49 @@ spec:
       k8s-app: cilium-envoy
   namespaceSelector:
     matchNames:
-      - default
+      - kube-system
   endpoints:
-    - port: envoy-metrics
+    - port: metrics
       interval: "10s"
       honorLabels: true
       path: /metrics
-      relabelings:
-        - replacement: ${1}
+      targetPort: envoy-metrics
+      relabelConfigs:
+        - action: replace
           sourceLabels:
             - __meta_kubernetes_pod_node_name
           targetLabel: node
   targetLabels:
     - k8s-app
+# Operator
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: cilium-operator
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: 9963
+      protocol: TCP
+      targetPort: prometheus
+  selector:
+    io.cilium/app: operator
+    name: cilium-operator
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
 metadata:
   name: cilium-operator
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: cilium-operator
 spec:
@@ -75,7 +133,7 @@ spec:
       name: cilium-operator
   namespaceSelector:
     matchNames:
-      - default
+      - kube-system
   endpoints:
     - port: metrics
       interval: "10s"

--- a/observability/base/victoria-metrics-k8s-stack/vmservicescrapes/cilium.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmservicescrapes/cilium.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: cilium-agent
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: cilium-agent
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  endpoints:
+    - port: metrics
+      interval: "10s"
+      honorLabels: true
+      path: /metrics
+      relabelings:
+        - replacement: ${1}
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: node
+    - port: envoy-metrics
+      interval: "10s"
+      honorLabels: true
+      path: /metrics
+      relabelings:
+        - replacement: ${1}
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: node
+  targetLabels:
+    - k8s-app
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: cilium-envoy
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: cilium-envoy
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-envoy
+  namespaceSelector:
+    matchNames:
+      - default
+  endpoints:
+    - port: envoy-metrics
+      interval: "10s"
+      honorLabels: true
+      path: /metrics
+      relabelings:
+        - replacement: ${1}
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: node
+  targetLabels:
+    - k8s-app
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: cilium-operator
+  labels:
+    app.kubernetes.io/name: cilium-operator
+spec:
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  namespaceSelector:
+    matchNames:
+      - default
+  endpoints:
+    - port: metrics
+      interval: "10s"
+      honorLabels: true
+      path: /metrics
+  targetLabels:
+    - io.cilium/app

--- a/observability/base/victoria-metrics-k8s-stack/vmservicescrapes/kustomization.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmservicescrapes/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: observability
 
 resources:
+  - cilium.yaml
   - karpenter.yaml

--- a/security/base/cert-manager/vault-clusterissuer.yaml
+++ b/security/base/cert-manager/vault-clusterissuer.yaml
@@ -11,7 +11,7 @@ spec:
     auth:
       appRole:
         path: approle
-        roleId: c757e1ed-e564-6e88-4e42-96cba8a925ae # !! This value changes each time I recreate the whole platform
+        roleId: 661958fc-dda1-b8e4-397e-2c404ef81ca4 # !! This value changes each time I recreate the whole platform
         secretRef:
           name: cert-manager-vault-approle
           key: secret_id


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added Cilium monitoring by introducing VMServiceScrape and VMRule configurations for Cilium components.
- Enhanced HelmRelease with new alertmanager configurations and additional dashboards for Cilium and Flux.
- Updated Kustomization files to include new VM rules and service scrapes.
- Added namespaces to various resources for better organization and management.
- Updated Vault ClusterIssuer with a new `roleId`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>externalsecret-alertmanager-slack-app.yaml</strong><dd><code>Add namespace to Alertmanager Slack app ExternalSecret</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/externalsecret-alertmanager-slack-app.yaml

- Added `namespace: observability` to the metadata.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-bd21b7437d9140163e53c1d2eed663232cfb9b3ede89b6ed3b7981a35ed2da1c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>externalsecret-grafana-admin.yaml</strong><dd><code>Add namespace to Grafana admin ExternalSecret</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/externalsecret-grafana-admin.yaml

- Added `namespace: observability` to the metadata.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-15397f8adaa83c71301084075163fd1ac7547c3786cbc96ea0143c007bd45a54">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>httproute-grafana.yaml</strong><dd><code>Add namespace to Grafana HTTPRoute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/httproute-grafana.yaml

- Added `namespace: observability` to the metadata.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-9139223300d63befc303a10c618369fec20abd969b79dd60da3440f28d16700f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>httproute-vmagent.yaml</strong><dd><code>Add namespace to VMAgent HTTPRoute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/httproute-vmagent.yaml

- Added `namespace: observability` to the metadata.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-413da2a5d1c69f67a935a347bb768af402120ffb56e7388e44ab22778f3ffe5d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>httproute-vmalertmanager.yaml</strong><dd><code>Add namespace to VMAlertmanager HTTPRoute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/httproute-vmalertmanager.yaml

- Added `namespace: observability` to the metadata.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-107d8700e925b344a6b8dc1b1a232c3ede7aadf8051042db3ed6982b09d29db0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>httproute-vmsingle.yaml</strong><dd><code>Add namespace to VMSingle HTTPRoute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/httproute-vmsingle.yaml

- Added `namespace: observability` to the metadata.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-4fe4d6574f392da51720269dcd49fd3274a3d7f5ef9b341c521a1dc0cede7710">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Update Kustomization with new VM rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/kustomization.yaml

- Updated resource references to include new VM rules.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-c41e7450df5a04489c8629c0eaf013861c41ee5972f8599ea6aacb37b0d99292">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Add Kustomization for VM rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/vmrules/kustomization.yaml

- Added Kustomization for VM rules.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-46fccbcf1b11760c7c3dbff11535e39c56b5e73c170c989c1c94c70552ee5080">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Update VMServiceScrape Kustomization with Cilium</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/vmservicescrapes/kustomization.yaml

- Added Cilium to VMServiceScrape resources.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-c7dfb67e75c4aead579567a29ca94bc400f0783b5c7d9e60c7e35ebb66aebe2c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>vault-clusterissuer.yaml</strong><dd><code>Update Vault ClusterIssuer roleId</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

security/base/cert-manager/vault-clusterissuer.yaml

- Updated `roleId` for Vault ClusterIssuer.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-ef454d0ddaf31b989827e79a4c946cfe5c38277fbdd2545c54dd6ea97708ac22">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>helmrelease-single.yaml</strong><dd><code>Enhance HelmRelease with Cilium monitoring and alertmanager </code><br><code>configuration</code></dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/helmrelease-single.yaml

<li>Added <code>namespace: observability</code> to the metadata.<br> <li> Configured <code>vmagent</code> with external labels.<br> <li> Updated alertmanager routes and receivers.<br> <li> Added Cilium and Flux dashboards.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-f6dfe46a720473ecbc15eef1ec66332962a1b9cd3334075507e1d3f725129b32">+45/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cilium.yaml</strong><dd><code>Add Cilium VMRule for monitoring and alerts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/vmrules/cilium.yaml

- Added VMRule for Cilium with multiple alerts.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-c4216e48e2894eb596f73ad82c4d77dc40a2b80d131f1efd12763cda599447c7">+69/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>flux.yaml</strong><dd><code>Add Flux VMRule for monitoring and alerts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/vmrules/flux.yaml

- Added VMRule for Flux with multiple alerts.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-8c93c6c50e8c0efd6b5e15a1ce77b7083b68c509fd4bffabae25650576c55023">+43/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>karpenter.yaml</strong><dd><code>Add Karpenter VMRule for monitoring and alerts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/vmrules/karpenter.yaml

- Added VMRule for Karpenter with multiple alerts.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-bfcd46c1069578baa876f51a6e60b05d00e8efd99505d4b6125b38c55ae2a3a9">+46/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cilium.yaml</strong><dd><code>Add VMServiceScrape for Cilium monitoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/vmservicescrapes/cilium.yaml

- Added VMServiceScrape for Cilium components.



</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/396/files#diff-337449be1e3b6ffa25cfa94f2947275a81d97faf8a9c194bf3bf703582032035">+143/-0</a>&nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

