### PR TITLE
Tailscale subnet router monitoring

### DIFF
--- a/dagger/README.md
+++ b/dagger/README.md
@@ -55,8 +55,7 @@ git checkout -b <flux_branch>
 
 2. Run the `bootstrap` function
 ```console
-dagger call --access-key-id=env:AWS_ACCESS_KEY_ID --secret-access-key=env:AWS_SECRET_ACCESS_KEY --ts-key=env:TAILSCALE_APIKEY \
-bootstrap --source "." --branch <flux_branch>
+dagger call --access-key-id=env:AWS_ACCESS_KEY_ID --secret-access-key=env:AWS_SECRET_ACCESS_KEY --ts-key=env:TAILSCALE_APIKEY bootstrap --branch <flux_branch>
  ```
 
 It takes over 20 minutes to get everything up and running. You should see an output similar to the following:
@@ -80,6 +79,5 @@ git push
 ⚠️ Really everything will be deleted
 
 ```console
-dagger call --access-key-id=env:AWS_ACCESS_KEY_ID --secret-access-key=env:AWS_SECRET_ACCESS_KEY --ts-key=env:TAILSCALE_APIKEY \
-destroy --source "." --branch <flux_branch>
+dagger call --access-key-id=env:AWS_ACCESS_KEY_ID --secret-access-key=env:AWS_SECRET_ACCESS_KEY --ts-key=env:TAILSCALE_APIKEY destroy --branch <flux_branch>
 ```

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -142,7 +142,8 @@ func (m *CloudNativeRef) Plan(
 	ctx context.Context,
 
 	// source is the directory where the Terraform configuration is stored
-	// +required
+	// +defaultPath="./.."
+	// +ignore=["!**/terraform"]
 	source *dagger.Directory,
 
 	// The directory where the AWS authentication files will be stored
@@ -206,7 +207,8 @@ func (m *CloudNativeRef) Network(
 	ctx context.Context,
 
 	// source is the directory where the Terraform configuration is stored
-	// +required
+	// +defaultPath="./.."
+	// +ignore=["!**/terraform"]
 	source *dagger.Directory,
 
 	// env is a list of environment variables, expected in (key:value) format
@@ -240,7 +242,8 @@ func (m *CloudNativeRef) Vault(
 	ctx context.Context,
 
 	// source is the directory where the Terraform configuration is stored
-	// +required
+	// +defaultPath="./.."
+	// +ignore=["!**/terraform"]
 	source *dagger.Directory,
 
 	// privateDomainName is the private domain name to use
@@ -335,7 +338,8 @@ func (m *CloudNativeRef) EKS(
 	ctx context.Context,
 
 	// source is the directory where the Terraform configuration is stored
-	// +required
+	// +defaultPath="./.."
+	// +ignore=["!**/terraform"]
 	source *dagger.Directory,
 
 	// branch is the branch to use for flux bootstrap
@@ -364,7 +368,8 @@ func (m *CloudNativeRef) UpdateKustomization(
 	ctx context.Context,
 
 	// source is the directory where the Terraform configuration is stored
-	// +required
+	// +defaultPath="./.."
+	// +ignore=["!**/terraform"]
 	source *dagger.Directory,
 
 	// kustPath is the path to the kustomize directory
@@ -393,7 +398,8 @@ func (m *CloudNativeRef) Bootstrap(
 	ctx context.Context,
 
 	// source is the directory where the Terraform configuration is stored
-	// +required
+	// +defaultPath="./.."
+	// +ignore=["!**/terraform"]
 	source *dagger.Directory,
 
 	// branch is the branch to use for flux bootstrap
@@ -476,7 +482,8 @@ func (m *CloudNativeRef) Destroy(
 	ctx context.Context,
 
 	// source is the directory where the Terraform configuration is stored
-	// +required
+	// +defaultPath="./.."
+	// +ignore=["!**/terraform"]
 	source *dagger.Directory,
 
 	// branch is the branch to use for flux bootstrap

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -551,7 +551,7 @@ func (m *CloudNativeRef) Destroy(
 
 	go func() {
 		defer wg.Done()
-		err := destroyEKS(ctx, container, sess, branch)
+		err := destroyEKS(ctx, container, branch)
 		if err != nil {
 			errChan <- fmt.Errorf("failed to destroy EKS resources: %w", err)
 			return

--- a/dagger/network.go
+++ b/dagger/network.go
@@ -144,7 +144,7 @@ fi
 
 func destroyNetwork(ctx context.Context, ctr *dagger.Container) error {
 	workDir := "/cloud-native-ref/terraform/network"
-	_, err := tfRun(ctx, ctr, workDir, "destroy", []string{"-var-file", "variables.tfvars", "-auto-approve"})
+	_, err := tfRun(ctx, ctr, workDir, "destroy", []string{"-var-file", "variables.tfvars"})
 	if err != nil {
 		return fmt.Errorf("failed to destroy the network: %w", err)
 	}

--- a/dagger/vault.go
+++ b/dagger/vault.go
@@ -33,13 +33,13 @@ func createVault(ctx context.Context, ctr *dagger.Container, tfarg string) (map[
 // destroyVault destroys the vault cluster
 func destroyVault(ctx context.Context, ctr *dagger.Container) error {
 	workDir := fmt.Sprintf("/%s/terraform/vault/management", repoName)
-	_, err := tfRun(ctx, ctr, workDir, "destroy", []string{"-var-file", "variables.tfvars", "--auto-approve"})
+	_, err := tfRun(ctx, ctr, workDir, "destroy", []string{"-var-file", "variables.tfvars"})
 	if err != nil {
 		return fmt.Errorf("failed to destroy the vault configuration: %w", err)
 	}
 
 	workDir = fmt.Sprintf("/%s/terraform/vault/cluster", repoName)
-	_, err = tfRun(ctx, ctr, workDir, "destroy", []string{"-var-file", "variables.tfvars", "--auto-approve"})
+	_, err = tfRun(ctx, ctr, workDir, "destroy", []string{"-var-file", "variables.tfvars"})
 	if err != nil {
 		return fmt.Errorf("failed to destroy the vault cluster: %w", err)
 	}

--- a/observability/base/victoria-metrics-k8s-stack/vmscrapeconfigs/ec2.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmscrapeconfigs/ec2.yaml
@@ -15,7 +15,7 @@ spec:
       source_labels: [__meta_ec2_tag_Name]
       target_label: ec2_name
     - action: replace
-      source_labels: [__meta_ec2_tag_app_application]
+      source_labels: [__meta_ec2_tag_app]
       target_label: ec2_application
     - action: replace
       source_labels: [__meta_ec2_availability_zone]

--- a/security/base/cert-manager/vault-clusterissuer.yaml
+++ b/security/base/cert-manager/vault-clusterissuer.yaml
@@ -11,7 +11,7 @@ spec:
     auth:
       appRole:
         path: approle
-        roleId: 749821ba-7480-72ae-24f9-d4c2ac20b24a # !! This value changes each time I recreate the whole platform
+        roleId: 881092f1-bab6-9446-6598-5f1fa2948cad # !! This value changes each time I recreate the whole platform
         secretRef:
           name: cert-manager-vault-approle
           key: secret_id

--- a/security/base/cert-manager/vault-clusterissuer.yaml
+++ b/security/base/cert-manager/vault-clusterissuer.yaml
@@ -11,7 +11,7 @@ spec:
     auth:
       appRole:
         path: approle
-        roleId: 340ef330-41ec-ed7b-48ae-1eb3d7d40bfa # !! This value changes each time I recreate the whole platform
+        roleId: 749821ba-7480-72ae-24f9-d4c2ac20b24a # !! This value changes each time I recreate the whole platform
         secretRef:
           name: cert-manager-vault-approle
           key: secret_id

--- a/terraform/network/README.md
+++ b/terraform/network/README.md
@@ -20,11 +20,12 @@ tailscale = {
   subnet_router_name = "ogenki"
   tailnet            = "smainklh@gmail.com"
   api_key            = "tskey-api-...."
+  prometheus_enabled = "true"
 }
 
 tags = {
-  project = "cloud-native-ref"
-  owner   = "Smana"
+  project =                     = "cloud-native-ref"
+  owner                         = "Smana"
 }
 ```
 

--- a/terraform/network/tailscale.tf
+++ b/terraform/network/tailscale.tf
@@ -65,7 +65,7 @@ resource "tailscale_tailnet_key" "this" {
 
 module "tailscale_subnet_router" {
   source  = "Smana/tailscale-subnet-router/aws"
-  version = "1.0.5"
+  version = "1.1.0"
 
   region = var.region
   env    = var.env
@@ -78,10 +78,14 @@ module "tailscale_subnet_router" {
   advertise_routes      = [module.vpc.vpc_cidr_block]
   tailscale_ssh_enabled = true
 
-  prometheus_node_exporter_enabled = true
-  // No need to enable SSH when Tailscale SSH is working
-  ssm_enabled = true
+  prometheus_node_exporter_enabled = lookup(var.tailscale, "prometheus_enabled", false) ? true : false
+  ssm_enabled                      = lookup(var.tailscale, "ssm_enabled", false) ? true : false
 
-  tags = var.tags
+  tags = merge(var.tags,
+    {
+      app                           = "tailscale"
+      "observability:node-exporter" = lookup(var.tailscale, "prometheus_enabled", "false") ? "true" : "false"
+    }
+  )
 
 }

--- a/terraform/network/variables.tf
+++ b/terraform/network/variables.tf
@@ -23,11 +23,12 @@ variable "private_domain_name" {
 
 
 variable "tailscale" {
-  type = map(string)
+  type = map(any)
   default = {
     subnet_router_name = ""
     api_key            = ""
     tailnet            = ""
+    prometheus_enabled = false
   }
 }
 

--- a/terraform/vault/cluster/variables.tf
+++ b/terraform/vault/cluster/variables.tf
@@ -58,7 +58,6 @@ variable "ami_owner" {
   default = "099720109477" # AWS account ID of Canonical
 }
 
-
 variable "enable_ssm" {
   description = "If true, allow to connect to the instances using AWS Systems Manager"
   type        = bool


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the Tailscale subnet router module to version 1.0.6 and added conditional logic for enabling Prometheus node exporter.
- Introduced a custom bash script for EKS destroy preparation, replacing the previous `kubectl` execution logic.
- Added a new `prometheus_enabled` variable to the Tailscale configuration and updated related documentation.
- Simplified command examples in the Dagger README by removing redundant arguments.
- Updated EC2 application relabeling configuration and Vault approle roleId for authentication.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tailscale.tf</strong><dd><code>Update Tailscale subnet router module and observability tags</code></dd></summary>
<hr>

terraform/network/tailscale.tf

<li>Updated <code>tailscale_subnet_router</code> module version to 1.0.6.<br> <li> Added conditional logic for enabling Prometheus node exporter.<br> <li> Merged additional tags for observability.


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/418/files#diff-9bccc9b98249891cd0a1c37be2f13ddc22b5f88bcbafb74e041c6f762c8eabaa">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>eks.go</strong><dd><code>Replace kubectl execution with custom EKS destroy script</code>&nbsp; </dd></summary>
<hr>

dagger/eks.go

<li>Removed <code>execKubectl</code> function.<br> <li> Added a custom bash script for EKS destroy preparation.<br> <li> Implemented options parsing and resource cleanup in the script.


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/418/files#diff-3a4bdef4e17b6f9f6668d6cf65bcb0d509446c10c5a91d430401f61bd445c6c3">+63/-30</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Add Prometheus enabled variable to Tailscale configuration</code></dd></summary>
<hr>

terraform/network/variables.tf

- Added `prometheus_enabled` variable to the `tailscale` map.


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/418/files#diff-99af7f87ac658171650f9b837a7f372501480bddbbb06ab7c617a8946a62755f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Add default path and ignore patterns for Terraform sources</code></dd></summary>
<hr>

dagger/main.go

<li>Added default path and ignore patterns for Terraform source <br>directories.


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/418/files#diff-f18b612d33c74a552af8f75da09a36af695ef16d51ef7537bd1e7ef2d3d09685">+14/-7</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ec2.yaml</strong><dd><code>Update EC2 application relabeling configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

observability/base/victoria-metrics-k8s-stack/vmscrapeconfigs/ec2.yaml

- Updated source label for EC2 application relabeling.


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/418/files#diff-e319758bbbfb1a6cb0e1db5a5c0e30f5dcbdbb2d32f4ce2b70008ddc1da809e9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>vault-clusterissuer.yaml</strong><dd><code>Update Vault approle roleId for cert-manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

security/base/cert-manager/vault-clusterissuer.yaml

- Updated `roleId` for Vault approle authentication.


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/418/files#diff-ef454d0ddaf31b989827e79a4c946cfe5c38277fbdd2545c54dd6ea97708ac22">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Simplify command examples in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dagger/README.md

<li>Simplified command examples by removing redundant <code>--source</code> argument.


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/418/files#diff-cd04f448c41bdbffc741bde88baed7572c86634a9fcae07b96ee330c1a47f5a4">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update Tailscale configuration example with Prometheus option</code></dd></summary>
<hr>

terraform/network/README.md

<li>Added <code>prometheus_enabled</code> example in Tailscale configuration.<br> <li> Corrected formatting for tags.


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/418/files#diff-3d781762d77ff5b55b788c97b11db751ece54fc4454fe76cd70522ceefe63db0">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

