### PR TITLE
chore(eks): upgrade v1.31

### DIFF
--- a/terraform/eks/README.md
+++ b/terraform/eks/README.md
@@ -147,7 +147,7 @@ tofu destroy --var-file variables.tfvars
 |------|-------------|------|---------|:--------:|
 | <a name="input_cilium_version"></a> [cilium\_version](#input\_cilium\_version) | Cilium cluster version | `string` | `"1.16.2"` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the EKS cluster to be created | `string` | n/a | yes |
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | k8s cluster version | `string` | `"1.30"` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | k8s cluster version | `string` | `"1.31"` | no |
 | <a name="input_ebs_csi_driver_chart_version"></a> [ebs\_csi\_driver\_chart\_version](#input\_ebs\_csi\_driver\_chart\_version) | EBS CSI Driver Helm chart version | `string` | `"2.25.0"` | no |
 | <a name="input_env"></a> [env](#input\_env) | The environment of the EKS cluster | `string` | n/a | yes |
 | <a name="input_gateway_api_version"></a> [gateway\_api\_version](#input\_gateway\_api\_version) | Gateway API CRDs version | `string` | `"v1.1.0"` | no |

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -17,7 +17,7 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   description = "k8s cluster version"
-  default     = "1.30"
+  default     = "1.31"
   type        = string
 }
 


### PR DESCRIPTION
### **PR Type**
enhancement, documentation


___

### **Description**
- Updated the default Kubernetes cluster version in the Terraform variables from `1.30` to `1.31`.
- Updated the README documentation to reflect the change in the default Kubernetes cluster version.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Update default Kubernetes cluster version to 1.31</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/variables.tf

<li>Updated the default Kubernetes cluster version from <code>1.30</code> to <code>1.31</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/463/files#diff-03a38e8def3f0b3f9d73cf5d2448da8616011aac36679094c516236136f19afd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README for Kubernetes version 1.31</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/eks/README.md

<li>Updated documentation to reflect the new default Kubernetes cluster <br>version <code>1.31</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/463/files#diff-7ad87ffb2522993ed0b5e545d40352a8eb364f0790ba12dc2e8873816d89520d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information