### PR TITLE
chore(alb-controller): upgrade v1.10.0

### DIFF
--- a/infrastructure/base/aws-load-balancer-controller/helmrelease.yaml
+++ b/infrastructure/base/aws-load-balancer-controller/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
         kind: HelmRepository
         name: eks
         namespace: kube-system
-      version: "1.9.2"
+      version: "1.10.0"
   interval: 3m0s
   install:
     remediation:

--- a/security/base/epis/load-balancer-controller.yaml
+++ b/security/base/epis/load-balancer-controller.yaml
@@ -43,6 +43,7 @@ spec:
                             "ec2:DescribeTags",
                             "ec2:GetCoipPoolUsage",
                             "ec2:DescribeCoipPools",
+                            "ec2:GetSecurityGroupsForVpc",
                             "elasticloadbalancing:DescribeLoadBalancers",
                             "elasticloadbalancing:DescribeLoadBalancerAttributes",
                             "elasticloadbalancing:DescribeListeners",


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Upgraded the AWS Load Balancer Controller Helm chart version from 1.9.2 to 1.10.0 to ensure compatibility with the latest features and improvements.
- Added a new permission `ec2:GetSecurityGroupsForVpc` to the load balancer controller to enhance security group management capabilities.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helmrelease.yaml</strong><dd><code>Upgrade AWS Load Balancer Controller Helm chart version</code>&nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/base/aws-load-balancer-controller/helmrelease.yaml

<li>Upgraded the AWS Load Balancer Controller Helm chart version from <br>1.9.2 to 1.10.0.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/526/files#diff-98a8b6383ea785e63dce6be61980815dab03763822183dec4543f7b7ba9966dc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>load-balancer-controller.yaml</strong><dd><code>Add new EC2 permission to load balancer controller</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

security/base/epis/load-balancer-controller.yaml

<li>Added permission for <code>ec2:GetSecurityGroupsForVpc</code> to the load balancer <br>controller.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/526/files#diff-363e74830ff32797a72d6e00d07ac435978c62762e788f3d8e6e2fe1a60ad7c3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information