### PR TITLE
fix(zitadel): sourcing masterkey from secret

### DIFF
--- a/security/base/cert-manager/vault-clusterissuer.yaml
+++ b/security/base/cert-manager/vault-clusterissuer.yaml
@@ -11,7 +11,7 @@ spec:
     auth:
       appRole:
         path: approle
-        roleId: a8588869-b29e-8190-47cb-23c4cf3c2130 # !! This value changes each time I recreate the whole platform
+        roleId: d346bc9e-91d2-a440-023a-14f32dc03072 # !! This value changes each time I recreate the whole platform
         secretRef:
           name: cert-manager-vault-approle
           key: secret_id

--- a/security/base/zitadel/externalsecret-zitadel-masterkey.yaml
+++ b/security/base/zitadel/externalsecret-zitadel-masterkey.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: zitadel-masterkey
+spec:
+  data:
+    - secretKey: ZITADEL_MASTERKEY
+      remoteRef:
+        key: zitadel/envvars
+        property: ZITADEL_MASTERKEY
+  refreshInterval: 20m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: clustersecretstore
+  target:
+    template:
+      engineVersion: v2
+      data:
+        masterkey: "{{ .ZITADEL_MASTERKEY }}"
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: zitadel-masterkey

--- a/security/base/zitadel/helmrelease.yaml
+++ b/security/base/zitadel/helmrelease.yaml
@@ -20,6 +20,7 @@ spec:
     initJob:
       backoffLimit: 30 # Wait for the CNPG database instance to be ready
     zitadel:
+      masterkeySecretName: "zitadel-masterkey" # Populated from the zitadel-envvars secret
       configmapConfig:
         Log:
           Formatter:

--- a/security/base/zitadel/kustomization.yaml
+++ b/security/base/zitadel/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: security
 resources:
   - externalsecret-zitadel-envvars.yaml
+  - externalsecret-zitadel-masterkey.yaml
   - certificate.yaml
   - gateway.yaml
   - helmrelease.yaml


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added a new `ExternalSecret` for sourcing the Zitadel masterkey from a secret, enhancing security by managing secrets externally.
- Updated the Zitadel HelmRelease configuration to reference the new `zitadel-masterkey` secret.
- Modified the Vault ClusterIssuer configuration by updating the `roleId`.
- Updated the kustomization file to include the new external secret for Zitadel masterkey.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vault-clusterissuer.yaml</strong><dd><code>Update roleId in Vault ClusterIssuer configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

security/base/cert-manager/vault-clusterissuer.yaml

<li>Updated the <code>roleId</code> value in the Vault ClusterIssuer configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/558/files#diff-ef454d0ddaf31b989827e79a4c946cfe5c38277fbdd2545c54dd6ea97708ac22">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>helmrelease.yaml</strong><dd><code>Reference Zitadel masterkey secret in HelmRelease</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

security/base/zitadel/helmrelease.yaml

<li>Added <code>masterkeySecretName</code> to Zitadel HelmRelease values.<br> <li> References the newly created <code>zitadel-masterkey</code> secret.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/558/files#diff-904660c56efd5c0f754439f5e85a232ee91c4e2e9d0123b3c949c178d8ba3a23">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Include Zitadel masterkey external secret in kustomization</code></dd></summary>
<hr>

security/base/zitadel/kustomization.yaml

<li>Included <code>externalsecret-zitadel-masterkey.yaml</code> in the kustomization <br>resources.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/558/files#diff-3108c631d5d667d5f35a410d0bd6e2ebd73eef75162b76c4cb8a07eaa4378cb7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>externalsecret-zitadel-masterkey.yaml</strong><dd><code>Add ExternalSecret configuration for Zitadel masterkey</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

security/base/zitadel/externalsecret-zitadel-masterkey.yaml

<li>Added a new <code>ExternalSecret</code> configuration for Zitadel masterkey.<br> <li> Configures the secret to be sourced from <code>zitadel/envvars</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/558/files#diff-10bef41b17a909da7c891c7220b086ef889dc565797c668bde8d5e6897a36022">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information