### PR TITLE
fix(zitadel): should be started after cloud-native-pg operator

### DIFF
--- a/clusters/mycluster-0/security.yaml
+++ b/clusters/mycluster-0/security.yaml
@@ -83,3 +83,29 @@ spec:
       kind: HelmRelease
       name: external-secrets
       namespace: security
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: zitadel
+  namespace: flux-system
+spec:
+  prune: true
+  interval: 1m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./security/mycluster-0/zitadel
+  postBuild:
+    substitute:
+      domain_name: "cloud.ogenki.io"
+    substituteFrom:
+      - kind: ConfigMap
+        name: eks-mycluster-0-vars
+  dependsOn:
+    - name: infrastructure
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: zitadel
+      namespace: security

--- a/opentofu/eks/README.md
+++ b/opentofu/eks/README.md
@@ -130,8 +130,8 @@ tofu destroy --var-file variables.tfvars
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 20 |
-| <a name="module_irsa_crossplane"></a> [irsa\_crossplane](#module\_irsa\_crossplane) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.54.1 |
-| <a name="module_irsa_ebs_csi_driver"></a> [irsa\_ebs\_csi\_driver](#module\_irsa\_ebs\_csi\_driver) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.54.1 |
+| <a name="module_irsa_crossplane"></a> [irsa\_crossplane](#module\_irsa\_crossplane) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.55.0 |
+| <a name="module_irsa_ebs_csi_driver"></a> [irsa\_ebs\_csi\_driver](#module\_irsa\_ebs\_csi\_driver) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.55.0 |
 | <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | terraform-aws-modules/eks/aws//modules/karpenter | ~> 20.0 |
 
 ## Resources

--- a/opentofu/eks/iam.tf
+++ b/opentofu/eks/iam.tf
@@ -1,7 +1,7 @@
 # AWS permissions for the EBS-CSI-DRIVER
 module "irsa_ebs_csi_driver" {
   source    = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version   = "5.54.1"
+  version   = "5.55.0"
   role_name = "${var.cluster_name}-ebs_csi_driver"
 
   assume_role_condition_test = "StringLike"
@@ -22,7 +22,7 @@ module "irsa_ebs_csi_driver" {
 # AWS permissions for Crossplane
 module "irsa_crossplane" {
   source    = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version   = "5.54.1"
+  version   = "5.55.0"
   role_name = "${var.cluster_name}-crossplane"
 
   assume_role_condition_test = "StringLike"

--- a/security/mycluster-0/kustomization.yaml
+++ b/security/mycluster-0/kustomization.yaml
@@ -6,5 +6,4 @@ resources:
   - ../base/cert-manager
   - ../base/openbao-snapshot
   - ../base/rbac
-  - ../base/zitadel
   - external-secrets

--- a/security/mycluster-0/zitadel/kustomization.yaml
+++ b/security/mycluster-0/zitadel/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/zitadel


### PR DESCRIPTION
### **PR Type**
- Bug fix
- Enhancement



___

### **Description**
- Updated IAM module versions to 5.55.0

- Added Flux Kustomization for zitadel deployment

- Updated documentation for module version updates

- Removed duplicate zitadel reference in base kustomization


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>iam.tf</strong><dd><code>Update IAM modules version numbers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

opentofu/eks/iam.tf

<li>Bumped IAM module versions from 5.54.1 to 5.55.0 for both <br>irsa_ebs_csi_driver and irsa_crossplane


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/821/files#diff-eb3cc1e1333b9c49197576fb37db026822f8013c546a2d2d93d213fbb441e8f9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>security.yaml</strong><dd><code>Add Flux Kustomization for zitadel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

clusters/mycluster-0/security.yaml

<li>Added new Kustomization manifest for zitadel<br> <li> Set dependency on infrastructure and postBuild substitutions<br> <li> Defined health check reference for helm release


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/821/files#diff-833df5b6e8be10b27783e6e3bab226ceaab442d21463859ec1a50ef5919448ee">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Remove outdated zitadel reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

security/mycluster-0/kustomization.yaml

- Removed reference to ../base/zitadel from resource list


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/821/files#diff-c4dd19f094e3c821e83329f7aff3bb114e5fc4849ff72e17b02b1edc67954045">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Add zitadel specific kustomization file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

security/mycluster-0/zitadel/kustomization.yaml

- Created new kustomization file for zitadel referencing base/zitadel


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/821/files#diff-f867c85ee2177ef87dd0f0baefb7c6a56a9418a90ea3fda440fdb4771ee4c4aa">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README with new IAM versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

opentofu/eks/README.md

<li>Updated module versions in documentation table to 5.55.0<br> <li> Align README with IAM module version bump


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/821/files#diff-a92136ec9c6319e9aea919099848926d8fde1e24ee8908ddaccb6b2ef7591b31">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>