### PR TITLE
fix: docs split tm workflows and config

### DIFF
--- a/opentofu/config.tm.hcl
+++ b/opentofu/config.tm.hcl
@@ -1,0 +1,13 @@
+# Global variables that are used in all scripts
+# Use your own values for these variables
+globals {
+  provisioner                      = "tofu"
+  region                           = "eu-west-3"
+  profile                          = ""
+  eks_cluster_name                 = "mycluster-0"
+  openbao_url                      = "https://bao.priv.cloud.ogenki.io:8200"
+  root_token_secret_name           = "openbao/cloud-native-ref/tokens/root"
+  root_ca_secret_name              = "certificates/priv.cloud.ogenki.io/root-ca"
+  cert_manager_approle_secret_name = "openbao/cloud-native-ref/approles/cert-manager"
+  cert_manager_approle             = "cert-manager"
+}

--- a/opentofu/workflows.tm.hcl
+++ b/opentofu/workflows.tm.hcl
@@ -1,17 +1,3 @@
-# Global variables that are used in all scripts
-# Use your own values for these variables
-globals {
-  provisioner                      = "tofu"
-  region                           = "eu-west-3"
-  profile                          = ""
-  eks_cluster_name                 = "mycluster-0"
-  openbao_url                      = "https://bao.priv.cloud.ogenki.io:8200"
-  root_token_secret_name           = "openbao/cloud-native-ref/tokens/root"
-  root_ca_secret_name              = "certificates/priv.cloud.ogenki.io/root-ca"
-  cert_manager_approle_secret_name = "openbao/cloud-native-ref/approles/cert-manager"
-  cert_manager_approle             = "cert-manager"
-}
-
 script "init" {
   name        = "OpenTofu Init"
   description = "Download the required provider plugins and modules and set up the backend"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add new global config file for Terraform variables

- Remove duplicated globals block from workflows file

- Centralize variables in `opentofu/config.tm.hcl`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.tm.hcl</strong><dd><code>Add global variables config file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

opentofu/config.tm.hcl

<li>Introduced new file defining global variables<br> <li> Configured provisioner, region, cluster name, and URLs<br> <li> Added secret names for tokens and certificates


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/823/files#diff-281ae1d2062c244e81b42db7823de8d90941b17c10ce5627c7e470ec86bad035">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workflows.tm.hcl</strong><dd><code>Remove global vars from workflows file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

opentofu/workflows.tm.hcl

<li>Removed globals block from workflows file<br> <li> Retained only workflow script definitions


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/823/files#diff-9cf28f1250e8414e3fb358bf6bdd3f13a2b931753e5cec9ac46a35b1df864a6e">+0/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>