### PR TITLE
fix(headlamp): do not use persistent volume for plugins

### DIFF
--- a/opentofu/network/versions.tf
+++ b/opentofu/network/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     tailscale = {
       source  = "tailscale/tailscale"
-      version = "~> 0.19"
+      version = "~> 0.20"
     }
   }
 }

--- a/tooling/base/headlamp/helmrelease.yaml
+++ b/tooling/base/headlamp/helmrelease.yaml
@@ -28,17 +28,12 @@ spec:
           - /bin/sh
           - -c
           - mkdir -p /build/plugins && cp -r /plugins/* /build/plugins/
-        image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.1.0-beta-2@sha256:c63dc4e10d7ddb95c966194b5e6fbe2012feb7f932bafa24692daed3cf6c248a
+        image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:latest
         imagePullPolicy: Always
         name: headlamp-plugins
         volumeMounts:
           - mountPath: /build/plugins
             name: headlamp-plugins
-    persistentVolumeClaim:
-      accessModes:
-        - ReadWriteOnce
-      enabled: true
-      size: 1Gi
 
     resources:
       limits:
@@ -52,5 +47,4 @@ spec:
 
     volumes:
       - name: headlamp-plugins
-        persistentVolumeClaim:
-          claimName: headlamp
+        emptyDir: {}


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Remove persistent volume for headlamp plugins

- Switch plugin init image to latest tag

- Use emptyDir volume for plugin storage

- Bump tailscale provider to ~> 0.20


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>versions.tf</strong><dd><code>Bump Tailscale provider version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

opentofu/network/versions.tf

- Updated `tailscale` provider from "~> 0.19" to "~> 0.20"


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/851/files#diff-4482d77795dc5805ee7fde13e800e3de186c8a6f9b680a3c02cd960bded20064">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helmrelease.yaml</strong><dd><code>Remove plugin PVC, use emptyDir and update image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tooling/base/headlamp/helmrelease.yaml

<li>Removed <code>persistentVolumeClaim</code> for headlamp-plugins<br> <li> Switched plugin storage to <code>emptyDir</code><br> <li> Updated initContainer plugin image to <code>latest</code>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/851/files#diff-8dbebd8b1123cf1d4fd1439590ce0cc4a607e523832c037c7299744065174c04">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>