### PR TITLE
fix: add missing ignore trivy

### DIFF
--- a/opentofu/eks/.trivyignore.yaml
+++ b/opentofu/eks/.trivyignore.yaml
@@ -20,3 +20,4 @@ misconfigurations:
   - id: AVD-KSV-0106
   - id: AVD-KSV-0110
   - id: AVD-KSV-0118
+  - id: AVD-KSV-0125


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add missing Trivy ignore rule


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.trivyignore.yaml</strong><dd><code>Add missing AVD-KSV-0125 ignore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

opentofu/eks/.trivyignore.yaml

- Added `AVD-KSV-0125` ignore under misconfigurations


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/887/files#diff-7fb397dae2fc9738cb824e6cbb516f83d458602028097e5b196d25be60b46c36">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>