### PR TITLE
docs(site): lead with what the platform is, name the workflow, rewrite the security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,52 +2,90 @@
 
 ## Reporting Security Issues
 
-If you find a security vulnerability in this demo repository, please report it by:
+If you find a security vulnerability in this repository, please report it by:
 
 1. Opening a [GitHub Security Advisory](https://github.com/Smana/cloud-native-ref/security/advisories/new)
 2. Or emailing the maintainer directly
 
 Please do not create public issues for security vulnerabilities.
 
-## Security Considerations
+## What this repository is
 
-This is a **demonstration repository** for learning cloud-native technologies. Before using in production:
+A **reference implementation** of a cloud-native platform. Everything in it
+runs — it is not a slideware repo — but it is built to be read and forked, not
+to be adopted unexamined. The posture below is what it actually enforces, and
+the limitations further down are the ones it genuinely has rather than the
+generic caveats a template would list.
 
-### Infrastructure Security
+## Enforced posture
 
-- Change all default passwords and secrets
-- Review IAM permissions and apply least privilege
-- Enable AWS CloudTrail and monitoring
-- Configure proper backup and disaster recovery
+| Property | How | Where |
+|---|---|---|
+| No static cloud credentials | EKS Pod Identity, never IRSA, never long-lived keys | [ADR-0002](website/content/docs/decisions/0002-eks-pod-identity-over-irsa.md), `security/base/epis/` |
+| IAM scoped to `xplane-*` | Crossplane provider policies restricted by resource prefix | [Platform constitution](docs/platform-constitution.md) |
+| No delete permission on stateful services | S3, IAM and Route 53 grants exclude deletion | [Platform constitution](docs/platform-constitution.md) |
+| Default-deny pod networking | A `CiliumNetworkPolicy` per pod-running workload, both directions | `security/base/*/network-policy.yaml` |
+| Private cluster API | The EKS endpoint is private; reachable only over Tailscale | [ADR-0013](website/content/docs/decisions/0013-tailscale-over-bastion.md), `opentofu/eks/init/` |
+| Admin services unreachable, not merely unlisted | Two Tailscale gateways split by ACL tag (`tag:k8s`, `tag:admin`) | `infrastructure/base/gapi/` |
+| TLS on internal traffic | A private PKI issues every certificate through cert-manager | [ADR-0011](website/content/docs/decisions/0011-openbao-over-vault.md), `security/base/cert-manager/` |
+| No secrets in Git | External Secrets Operator pulls from AWS Secrets Manager and OpenBao at runtime | `security/base/external-secrets/` |
+| Restricted pod security context | Kyverno at admission, Polaris on the rendered bundle before merge | [ADR-0016](website/content/docs/decisions/0016-kyverno-over-gatekeeper.md), `scripts/validate-manifests.sh` |
 
-### Kubernetes Security
+## Supply chain
 
-- Review network policies and RBAC configurations
-- Enable Pod Security Standards
-- Scan container images for vulnerabilities
-- Keep all components updated
+Narrower than the phrase usually implies, so it is worth being exact about
+which of these block a merge and which only report:
 
-### OpenBao/Secrets Management
+| Tool | Scope | Blocks a merge? |
+|---|---|---|
+| `flux schema validate` | Every rendered manifest, with `skipMissingSchemas: false` — an unknown Kind fails the build rather than being skipped | **Yes** |
+| Polaris | The rendered bundle (~69 controllers), not the source tree | **Yes** |
+| Trivy | Filesystem scan of the repository, `CRITICAL,HIGH`, `ignore-unfixed` | Reports to GitHub Security |
+| Checkov | `terraform,secrets` frameworks, `soft_fail: true` | No — advisory only |
+| TruffleHog | CI, `--only-verified` | Reports |
+| `detect-secrets` | pre-commit, before the push | **Yes**, locally |
 
-- Generate new certificates and keys
-- Implement proper secret rotation
-- Review access policies
-- Enable audit logging
+**No container image is scanned anywhere in CI.** Trivy runs `scan-type: fs`
+against the repository, not against images. Harbor carries no explicit Trivy
+configuration, so whatever its chart defaults to is what you get.
 
-## Known Demo Limitations
+## Known limitations
 
-- Uses development-grade certificates
-- Contains example configurations with placeholder values
-- May use elevated permissions for demonstration purposes
-- Not hardened for production workloads
+These are real and specific to this repository. They are documented rather than
+hidden because a reader evaluating the platform needs to know which properties
+are enforced and which are accepted exceptions.
 
-## Security Tools Included
+- **The root CA private key is present in the live OpenBao mount.** The
+  intermediate is signed inside OpenBao so the deploy stays unattended.
+  Accepted for a reference platform; explicitly not to be carried into a
+  deployment where the root CA matters.
+- **CiliumNetworkPolicy coverage is uneven.** The constitution requires one on
+  every pod-running workload; the observability stack does not yet meet that
+  bar.
+- **Some enforcement is inherited, not chosen.** `kyverno-policies` installs
+  with `values: {}`, so which Pod Security Standard policies run — and whether
+  they audit or enforce — comes from the upstream chart's defaults rather than
+  a decision recorded here.
+- **The demo cluster is single-tenant and single-operator.** RBAC binds one
+  `admin` OIDC group to `cluster-admin`. A multi-tenant deployment needs a
+  finer split than this repository demonstrates.
 
-- Trivy vulnerability scanning
-- Checkov infrastructure analysis
-- Pre-commit hooks for secret detection
-- Kubernetes manifest validation
+## Before running any of this yourself
+
+- Review IAM permissions against your own account's blast radius.
+- Enable CloudTrail and audit logging; this repository configures neither for you.
+- Generate your own PKI material — do not reuse anything committed here.
+- Decide your own secret rotation policy; External Secrets syncs, it does not rotate.
+
+## How the platform implements this
+
+The security model is documented in full at
+[cnref.ogenki.io](https://cnref.ogenki.io):
+[Zero trust](https://cnref.ogenki.io/docs/concepts/zero-trust/) for the model,
+and [Security](https://cnref.ogenki.io/docs/platform/security/) for the PKI
+chain, the secret flow and the policies enforced on a running workload.
 
 ## Supported Versions
 
-Only the latest version of this demo is maintained. For production use, implement proper versioning and security update processes.
+Only the tip of `main` is maintained. Renovate tracks upstream releases and CI
+renders the whole repository against each one before it can merge.

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -9,15 +9,14 @@ description: "An opinionated, production-ready Kubernetes platform reference. Gi
 {{< /hextra/hero-badge >}}
 
 {{< hextra/hero-headline >}}
-  A production-ready platform you can actually deploy
+  An opinionated, production-ready Kubernetes platform, built on GitOps
 {{< /hextra/hero-headline >}}
 
 {{< hextra/hero-subtitle >}}
-  Not a slide deck and not a toy cluster. Every component here runs, is
-  reconciled by Flux, and is gated in CI — a private PKI, zero-trust networking,
-  a developer-facing abstraction over managed infrastructure, and a full
-  observability stack. Deploy it into your own account in about thirty minutes,
-  or read how each piece was chosen.
+  Infrastructure as code with OpenTofu and Crossplane, continuous delivery with
+  Flux, a private PKI and zero-trust networking, and a developer abstraction
+  that turns one small YAML claim into a whole application. Deploy it into your
+  own AWS account in about thirty minutes.
 {{< /hextra/hero-subtitle >}}
 
 {{< hextra/hero-button text="Deploy in 30 minutes" link="docs/get-started/" >}}
@@ -27,28 +26,21 @@ description: "An opinionated, production-ready Kubernetes platform reference. Gi
 
 ![Platform architecture: AWS managed services, the EKS cluster in four tiers, and the applications and data stores on top](/images/diagrams/platform-overview.svg)
 
-<h2 class="cnref-section-title">What this repository is for</h2>
-
-{{< hextra/feature-grid cols="2" >}}
-  {{< hextra/feature-card link="docs/get-started/" icon="lightning-bolt" title="Bootstrap a platform"
-    subtitle="Three sequential stages — network, secrets, Kubernetes — driven by OpenTofu and Terramate. One command per stage, and the cluster comes up with Cilium, Flux and Karpenter already running." >}}
-  {{< hextra/feature-card link="docs/concepts/" icon="academic-cap" title="Learn the concepts"
-    subtitle="GitOps as a dependency hierarchy rather than a slogan. Progressive complexity in a platform API. Zero trust that is enforced by policy, not asserted in a README." >}}
-  {{< hextra/feature-card link="docs/platform/" icon="cube-transparent" title="Evaluate the tools"
-    subtitle="Cilium, Flux, Crossplane, OpenBao, VictoriaMetrics, Gateway API, Karpenter, KEDA — each with what it actually buys you here, and what it cost to adopt." >}}
-  {{< hextra/feature-card link="docs/guides/fork-and-adapt/" icon="template" title="Make it yours"
-    subtitle="Which values are environment-specific, what to strip out, what the minimum viable subset is, and roughly what it costs to run." >}}
-{{< /hextra/feature-grid >}}
-
-<h2 class="cnref-section-title">Browse the docs</h2>
+<h2 class="cnref-section-title">What's here</h2>
 
 {{< hextra/feature-grid cols="3" >}}
-  {{< hextra/feature-card link="docs/get-started/" icon="play" title="Get Started" subtitle="Prerequisites, the deploy path, first application, teardown." >}}
-  {{< hextra/feature-card link="docs/platform/" icon="server" title="Platform" subtitle="Every domain: foundations, GitOps, networking, security, developer platform, observability, AI." >}}
-  {{< hextra/feature-card link="docs/concepts/" icon="light-bulb" title="Concepts" subtitle="The ideas the platform demonstrates, and how it is built." >}}
-  {{< hextra/feature-card link="docs/guides/" icon="map" title="Guides" subtitle="Fork and adapt, add an application, add a cloud provider, troubleshoot." >}}
-  {{< hextra/feature-card link="docs/reference/" icon="book-open" title="Reference" subtitle="Repository layout, technology stack, commands, CI, the platform constitution." >}}
-  {{< hextra/feature-card link="docs/decisions/" icon="scale" title="Decisions" subtitle="Architecture decision records — what was chosen, and what it was chosen over." >}}
+  {{< hextra/feature-card link="docs/get-started/" icon="play" title="Get Started"
+    subtitle="Three sequential stages — network, secrets, Kubernetes — driven by OpenTofu and Terramate. One command per stage, and the cluster comes up with Cilium, Flux and Karpenter already running." >}}
+  {{< hextra/feature-card link="docs/platform/" icon="server" title="Platform"
+    subtitle="Cilium, Flux, Crossplane, OpenBao, VictoriaMetrics, Gateway API, Karpenter, KEDA — each with what it actually buys you here, and what it cost to adopt." >}}
+  {{< hextra/feature-card link="docs/concepts/" icon="light-bulb" title="Concepts"
+    subtitle="GitOps as a dependency hierarchy rather than a slogan. Progressive complexity in a platform API. Zero trust that is enforced by policy, not asserted in a README." >}}
+  {{< hextra/feature-card link="docs/guides/" icon="map" title="Guides"
+    subtitle="Fork and adapt, add an application, add a cloud provider, troubleshoot — including what to strip out and roughly what it costs to run." >}}
+  {{< hextra/feature-card link="docs/reference/" icon="book-open" title="Reference"
+    subtitle="Repository layout, the technology stack and what each piece is responsible for, commands, CI, the platform constitution." >}}
+  {{< hextra/feature-card link="docs/decisions/" icon="scale" title="Decisions"
+    subtitle="Sixteen architecture decision records — what was chosen, what it was chosen over, and the cost that came with it." >}}
 {{< /hextra/feature-grid >}}
 
 {{< stack-strip >}}

--- a/website/content/docs/concepts/how-this-is-built.md
+++ b/website/content/docs/concepts/how-this-is-built.md
@@ -11,6 +11,13 @@ transferable than the YAML.
 
 ## Design before implementation
 
+The sequence below is not homegrown. It comes from
+[Superpowers](https://github.com/obra/superpowers), a plugin declared in this
+repository's `.claude/settings.json`, whose skills trigger on the shape of the
+work rather than on a command someone has to remember to type. That last
+property is what makes it stick: a workflow you have to invoke is a workflow
+you skip when you are in a hurry.
+
 Non-trivial changes go through a fixed sequence:
 
 1. **Brainstorm** — explore the problem and the options before committing to
@@ -29,7 +36,14 @@ part that normally evaporates.
 
 Cross-cutting technology decisions graduate into
 [decision records]({{< relref "/docs/decisions/_index.md" >}}), so a choice
-made once is not relitigated per feature.
+made once is not relitigated per feature. A technology chosen over a named
+alternative needs one before it merges — if you can say what it was picked
+over, that reasoning is worth keeping.
+
+The wider practice this sits inside — how an AI coding agent is actually wired
+into a platform-engineering workflow, and where it earns its keep — is covered
+at length in [Agentic Coding: concepts and hands-on Platform Engineering use
+cases](https://blog.ogenki.io/post/series/agentic_ai/ai-coding-agent/).
 
 ## The constitution
 

--- a/website/content/docs/decisions/0001-use-kcl-for-crossplane-compositions.md
+++ b/website/content/docs/decisions/0001-use-kcl-for-crossplane-compositions.md
@@ -7,8 +7,8 @@ lastVerified: 2026-08-20
 ---
 
 **Status**: Accepted
-**Date**: 2024-01-15
-**Deciders**: Platform Team
+**Date**: 2024-09-29 (recorded retrospectively on 2026-01-06)
+**Deciders**: Smana (Platform Owner)
 **Related Spec**: N/A (foundational decision)
 
 ---

--- a/website/content/docs/decisions/0002-eks-pod-identity-over-irsa.md
+++ b/website/content/docs/decisions/0002-eks-pod-identity-over-irsa.md
@@ -7,8 +7,8 @@ lastVerified: 2026-08-20
 ---
 
 **Status**: Accepted
-**Date**: 2024-01-15
-**Deciders**: Platform Team
+**Date**: 2024-04-15 (recorded retrospectively on 2026-01-06)
+**Deciders**: Smana (Platform Owner)
 **Related Spec**: [SPEC-0000: EKS Pod Identity](https://github.com/Smana/cloud-native-ref/blob/main/docs/specs/done/2024-Q1/0000-eks-pod-identity/spec.md)
 **Scope**: AWS only — narrowed 2026-08-18, see [ADR-0007](0007-cloud-abstraction-boundaries.md)
 

--- a/website/content/docs/decisions/0005-gke-standard-self-managed-cilium.md
+++ b/website/content/docs/decisions/0005-gke-standard-self-managed-cilium.md
@@ -8,7 +8,7 @@ lastVerified: 2026-08-20
 
 **Status**: Accepted
 **Date**: 2026-08-18
-**Deciders**: Platform Team
+**Deciders**: Smana (Platform Owner)
 **Related Design**: [GCP Support — Dual-Cloud Platform Design](https://github.com/Smana/cloud-native-ref/blob/main/docs/superpowers/specs/2026-08-18-gcp-support-design.md)
 
 ---

--- a/website/content/docs/decisions/0006-nap-computeclass-over-karpenter.md
+++ b/website/content/docs/decisions/0006-nap-computeclass-over-karpenter.md
@@ -8,7 +8,7 @@ lastVerified: 2026-08-20
 
 **Status**: Accepted
 **Date**: 2026-08-18
-**Deciders**: Platform Team
+**Deciders**: Smana (Platform Owner)
 **Related Design**: [GCP Support — Dual-Cloud Platform Design](https://github.com/Smana/cloud-native-ref/blob/main/docs/superpowers/specs/2026-08-18-gcp-support-design.md)
 
 ---

--- a/website/content/docs/decisions/0007-cloud-abstraction-boundaries.md
+++ b/website/content/docs/decisions/0007-cloud-abstraction-boundaries.md
@@ -8,7 +8,7 @@ lastVerified: 2026-08-20
 
 **Status**: Accepted
 **Date**: 2026-08-18
-**Deciders**: Platform Team
+**Deciders**: Smana (Platform Owner)
 **Related Design**: [GCP Support — Dual-Cloud Platform Design](https://github.com/Smana/cloud-native-ref/blob/main/docs/superpowers/specs/2026-08-18-gcp-support-design.md)
 
 ---

--- a/website/content/docs/decisions/_index.md
+++ b/website/content/docs/decisions/_index.md
@@ -2,7 +2,7 @@
 title: Decisions
 weight: 60
 description: Architecture decision records — what was chosen, and what it was chosen over.
-lastVerified: 2026-08-21
+lastVerified: 2026-08-22
 ---
 
 Architecture decision records for the choices that would otherwise need
@@ -11,6 +11,9 @@ what it was chosen over, and the trade-off that made the difference.
 
 An ADR records the "why" behind a decision, not just the "what": the context
 that forced a choice, the options considered, and the consequences accepted.
+Specs MUST comply with the [platform constitution]({{< relref "/docs/reference/platform-constitution.md" >}})
+and MAY reference an ADR for context on a technology choice; a constitution
+amendment requires an ADR to document the change.
 
 ## The principles behind the picks
 
@@ -37,14 +40,11 @@ rather than leaving it unsaid. Version bumps, chart-value changes and
 single-file fixes never need one.
 
 ## The records
-Specs MUST comply with the [platform constitution]({{< relref "/docs/reference/platform-constitution.md" >}})
-and MAY reference an ADR for context on a technology choice; a constitution
-amendment requires an ADR to document the change.
 
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
-| [0001]({{< relref "/docs/decisions/0001-use-kcl-for-crossplane-compositions.md" >}}) | Use KCL for Crossplane Compositions | Accepted | 2024-01-15 |
-| [0002]({{< relref "/docs/decisions/0002-eks-pod-identity-over-irsa.md" >}}) | Use EKS Pod Identity over IRSA | Accepted | 2024-01-15 |
+| [0001]({{< relref "/docs/decisions/0001-use-kcl-for-crossplane-compositions.md" >}}) | Use KCL for Crossplane Compositions | Accepted | 2024-09-29 |
+| [0002]({{< relref "/docs/decisions/0002-eks-pod-identity-over-irsa.md" >}}) | Use EKS Pod Identity over IRSA | Accepted | 2024-04-15 |
 | [0003]({{< relref "/docs/decisions/0003-vllm-production-stack-over-kserve.md" >}}) | Use vLLM Production Stack over KServe + llm-d for v1 LLM Platform | Accepted | 2026-04-30 |
 | [0004]({{< relref "/docs/decisions/0004-amazon-s3-files-for-model-weights-storage.md" >}}) | Use Amazon S3 Files for LLM Model Weights Storage | Accepted | 2026-05-01 |
 | [0005]({{< relref "/docs/decisions/0005-gke-standard-self-managed-cilium.md" >}}) | GKE Standard with self-managed Cilium (not Dataplane V2, not Autopilot) | Accepted | 2026-08-18 |

--- a/website/content/docs/platform/security/_index.md
+++ b/website/content/docs/platform/security/_index.md
@@ -12,6 +12,12 @@ credentials out of it into the cluster; [Policies]({{< relref "/docs/platform/se
 covers what's enforced once a workload is running — Kyverno admission,
 CiliumNetworkPolicy default-deny, and pod security context.
 
+The repository's
+[security policy](https://github.com/Smana/cloud-native-ref/blob/main/SECURITY.md)
+covers reporting, the enforced posture in summary, and the limitations this
+platform accepts as a reference implementation — including the ones it would be
+more comfortable not to mention.
+
 These pages describe how the platform *implements* security. The rules
 themselves — required security-context fields, RBAC conventions, IAM
 scoping — are the [Platform Constitution]({{< relref "/docs/reference/platform-constitution.md" >}});

--- a/website/content/docs/platform/security/policies.md
+++ b/website/content/docs/platform/security/policies.md
@@ -17,9 +17,11 @@ this page is how the platform implements them.
 Two `HelmRelease`s in `security/base/kyverno/`: the `kyverno` controller
 (3.8.2) and `kyverno-policies` (also 3.8.2, same chart family) — the
 upstream policy pack that implements the Kubernetes Pod Security Standards
-as `ClusterPolicy` resources. Both install with `values: {}` / no policy
-overrides, so the enforced set and its failure action (audit vs. enforce)
-come from the chart's own defaults rather than being hand-picked here.
+as `ClusterPolicy` resources. `kyverno-policies` installs with `values: {}` —
+no policy overrides at all — so the enforced set and its failure action (audit
+vs. enforce) come from the chart's own defaults rather than being hand-picked
+here. The controller release is not empty: it sets `fullnameOverride` and
+`crds.install: false`, and nothing else.
 `crds.install: false` on the controller — the CRDs are managed separately,
 under `crds/base/`, alongside every other CRD this repository installs
 ahead of the controllers that consume them.
@@ -111,6 +113,36 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 ```
+
+## Supply chain
+
+What runs here is narrower than the phrase usually implies, so it is worth
+being precise about which of these block a merge and which only report. A gate
+that reports is still useful; a gate that reports while everyone believes it
+blocks is worse than none.
+
+| Tool | What it looks at | Blocks a merge? |
+|---|---|---|
+| `flux schema validate` | Every rendered manifest, with `skipMissingSchemas: false` in `.fluxschema.yml` — an unknown Kind **fails** the build rather than being skipped | **Yes** |
+| Polaris | The *rendered* bundle rather than the source tree — the repository holds a handful of raw workloads, the render holds dozens | **Yes** |
+| `detect-secrets` | Staged changes, pre-commit, before the push | **Yes**, locally |
+| Trivy | Filesystem scan of the repository (`scan-type: fs`), `CRITICAL,HIGH`, `ignore-unfixed: true` | No — uploads SARIF to GitHub Security |
+| Checkov | `terraform,secrets` frameworks, `soft_fail: true` | No — advisory |
+| TruffleHog | The push range in CI, `--only-verified` | No — reports verified findings |
+
+Two gaps are worth stating plainly rather than leaving a reader to infer them
+from the table:
+
+**No container image is scanned anywhere in CI.** Trivy is pointed at the
+filesystem, not at images. Harbor is the registry, and it carries no explicit
+Trivy configuration in
+`tooling/base/harbor/helmrelease-harbor.yaml` — whatever the chart defaults to
+is what runs, and nothing here asserts it.
+
+**Checkov never blocks.** `soft_fail: true` means a finding lands in the
+GitHub Security tab and the build stays green. It is a reporting tool in this
+repository, not a gate, and reading the CI job list without reading its
+arguments would give the opposite impression.
 
 ## RBAC
 


### PR DESCRIPTION
PR 3 of 3 in the documentation rework. Follows #1804 (the nine ADRs) and
#1805 (roles, `technology-choices` retirement, the ADR rule).

## Homepage

The hero defined the project by what it isn't — *"Not a slide deck and not a
toy cluster"* — and spent forty words before reaching a concrete noun. It now
opens with the README's own line, so GitHub and the site say the same thing to
someone arriving from either.

The two feature grids ("What this repository is for", 4 cards; "Browse the
docs", 6 cards) covered the same six sections twice. They collapse into one,
keeping the stronger subtitles from the first — *"Zero trust that is enforced
by policy, not asserted in a README"* is better copy than *"The ideas the
platform demonstrates."*

## How this is built

The page described a five-step workflow and attributed it to nothing, so a
reader could admire the method but not reproduce it. It now names
[Superpowers](https://github.com/obra/superpowers) — verified declared in
`.claude/settings.json` — and explains the property that makes it stick: skills
trigger on the shape of the work rather than on a command someone has to
remember to type.

It also links [Agentic Coding: concepts and hands-on Platform Engineering use
cases](https://blog.ogenki.io/post/series/agentic_ai/ai-coding-agent/) at the
point the method is described, rather than only from Further Reading.

## SECURITY.md

It was a template, and it was wrong about this repository:

| It said | Reality |
|---|---|
| "Uses development-grade certificates" | A three-tier private PKI with automatic rotation |
| "Change all default passwords and secrets" | There are none — they are generated into AWS Secrets Manager |
| "Enable Pod Security Standards" | Kyverno already enforces them at admission |

Replaced with the posture the repository actually enforces — nine properties,
each pointing at the manifest or ADR that implements it — and with limitations
that are real rather than generic: the root CA private key living in the live
OpenBao mount, uneven `CiliumNetworkPolicy` coverage, a Kyverno policy set
inherited from chart defaults rather than chosen, and single-operator RBAC.

## Supply chain

New section on Platform → Security → Policies, and a matching table in
`SECURITY.md`. The point of it is the `Blocks a merge?` column:

- **No container image is scanned anywhere in CI.** Trivy runs
  `scan-type: fs` against the repository, not against images. Harbor carries no
  explicit Trivy configuration, so whatever its chart defaults to is what runs.
- **Checkov never blocks.** `soft_fail: true` — findings land in the GitHub
  Security tab and the build stays green.

Reading the CI job list without reading its arguments gives the opposite
impression of both. Writing this section as though image scanning or Checkov
gating existed would have repeated exactly the failure the rework set out to
fix.

## Provenance on the oldest records

Five ADRs credited `Deciders: Platform Team`, which does not exist — this is a
solo-maintained repository. ADR-0001 and ADR-0002 also carried
`Date: 2024-01-15`, which predates the work they describe.

Corrected from `git log`: the KCL conversion landed `2024-09-29`, the IRSA →
EKS Pod Identity migration `2024-04-15`, and both records were written
`2026-01-06`. Each now shows the decision's date with the retrospective
recording noted, rather than a single date that was wrong either way.

## Also fixed

`platform/security/policies.md` claimed both Kyverno releases install with
`values: {}`. Only `kyverno-policies` does; the controller sets
`fullnameOverride` and `crds.install: false`. Found while sourcing ADR-0016.

## Verification

```
./scripts/validate-links.sh     ==> All relative Markdown links resolve (0 allowlisted).
./scripts/verify-doc-paths.sh   ==> Every repository path named in the docs site exists.
hugo --source website --minify  BUILD OK

rendered homepage: new hero present, "Not a slide deck" absent, 1 feature grid
no "Platform Team" remains in website/content/docs/decisions/
```
