### PR TITLE
docs(security): describe the OpenBao cluster that is actually deployed

### DIFF
--- a/website/content/docs/decisions/0011-openbao-over-vault.md
+++ b/website/content/docs/decisions/0011-openbao-over-vault.md
@@ -72,8 +72,9 @@ platform's secrets architecture as a whole.
 ### Option 1: OpenBao
 
 The Linux Foundation fork of the last MPL-2.0 Vault codebase. Provisioned
-as two stacks: `opentofu/openbao/cluster/` stands up the Raft-backed EC2
-fleet, and `opentofu/openbao/management/` layers namespaces, the PKI and
+as two stacks: `opentofu/openbao/cluster/` stands up the EC2 fleet — one
+node on `file` storage as committed, or a five-node Raft cluster at
+`mode = "ha"` — and `opentofu/openbao/management/` layers namespaces, the PKI and
 AppRole auth on top through the `hashicorp/vault` OpenTofu provider.
 
 **Pros**:
@@ -235,7 +236,7 @@ demonstrate.
 
 ## Implementation Notes
 
-`opentofu/openbao/cluster/` provisions the Raft-backed EC2 fleet and pins
+`opentofu/openbao/cluster/` provisions the EC2 fleet and pins
 the OpenBao release (`openbao_version` in `variables.tf`, currently on
 the 2.6 line); `opentofu/openbao/management/` layers namespaces, the PKI,
 AppRole auth and policies on top through the `hashicorp/vault` provider,

--- a/website/content/docs/get-started/aws/_index.md
+++ b/website/content/docs/get-started/aws/_index.md
@@ -56,8 +56,14 @@ Terramate continues straight into this stage as part of the same command
 above — `openbao/cluster` depends on `network`, and `openbao/management`
 depends on `openbao/cluster`.
 
-Creates a 5-node HA OpenBao cluster on SPOT instances behind a Network Load
-Balancer, then configures it: the cluster is initialized and auto-unsealed
+Creates the OpenBao cluster behind a Network Load Balancer, then configures
+it. As committed, `opentofu/openbao/cluster/variables.tfvars` sets
+`mode = "dev"`: a single `t3.micro` on `file` storage, which is enough to
+follow everything in these guides and is not highly available. Set
+`mode = "ha"` for the five-node Raft cluster on SPOT instances — the same
+configuration steps apply either way.
+
+Either way, the cluster is initialized and auto-unsealed
 via AWS KMS, its root token and recovery keys are written to two separate
 AWS Secrets Manager entries, and a three-tier PKI (root → intermediate →
 leaf) plus the cert-manager AppRole are provisioned — all driven by

--- a/website/content/docs/platform/foundations/aws.md
+++ b/website/content/docs/platform/foundations/aws.md
@@ -13,7 +13,7 @@ command spans several:
 | Stack | Model stage | Owns |
 |---|---|---|
 | `opentofu/network/` | Network | VPC across three AZs, pod subnets on a secondary CIDR for Cilium ENI prefix delegation, a Route53 private zone, the Tailscale subnet router |
-| `opentofu/openbao/cluster/` | Security | A 5-node HA OpenBao cluster on Raft, mostly-equal-weighted SPOT instance pools, RAID-0 NVMe storage, KMS auto-unseal |
+| `opentofu/openbao/cluster/` | Security | OpenBao on EC2 with KMS auto-unseal. Ships as `mode = "dev"` — a single node on `file` storage; `mode = "ha"` builds the five-node Raft cluster on SPOT with RAID-0 NVMe |
 | `opentofu/openbao/management/` | Security | The three-tier PKI (root → intermediate → leaf), the cert-manager AppRole, backup automation |
 | `opentofu/eks/init/` | Kubernetes (Stage 1) | The EKS cluster, managed node groups, bootstrap addons, IAM, the `flux-system` namespace and secrets |
 | `opentofu/eks/configure/` | Kubernetes (Stage 2) | Cilium, Flux Operator + Instance |
@@ -87,19 +87,36 @@ after the first.
 
 ## The OpenBao cluster stack
 
-`opentofu/openbao/cluster/` runs OpenBao on a 5-node Raft cluster rather than
-a single instance, for HA. Every node is priced as ephemeral SPOT capacity
-across several instance pools — an interrupted node comes from a different
-pool and rejoins automatically — with data on a RAID-0 array of instance-store
-NVMe devices for throughput and KMS auto-unseal so a replaced node rejoins
-without a manual `bao operator unseal`. All five ASG overrides carry equal
-`weighted_capacity`, because the ASG reads `desired_capacity` in capacity
-units — unequal weights would make the quorum size depend on which SPOT pool
-happened to win, rather than always being five.
+`opentofu/openbao/cluster/` has two shapes, chosen by one variable. **The
+committed configuration is the smaller one** — `variables.tfvars` sets
+`mode = "dev"`, and that is what a `terramate script run deploy` gives you
+unless you change it.
 
-This is a demo posture, not a production one: the cluster is torn down and
-reprovisioned on every platform test, which is what the SPOT-everywhere,
-RAID-0-with-no-redundancy choices are priced for. `opentofu/openbao/management/`
+| | `mode = "dev"` (committed) | `mode = "ha"` |
+|---|---|---|
+| Nodes | 1 | 5 |
+| Storage backend | `file`, on the root volume | Raft, with `retry_join` auto-discovery by tag |
+| Instances | `t3.micro`, on-demand | SPOT across several pools, mixed-instances policy |
+| Data volume | gp3 root volume | RAID-0 over instance-store NVMe |
+| Unseal | KMS auto-unseal | KMS auto-unseal |
+
+So the default posture is a single node whose OpenBao data *and* server TLS
+private key both sit on one encrypted gp3 root volume. It is enough to
+exercise every path this documentation describes, and it is not highly
+available — a Raft-only command like `bao operator raft list-peers` has
+nothing to talk to.
+
+In `ha` mode, an interrupted SPOT node comes back from a different pool and
+rejoins automatically, and KMS auto-unseal means it does so without a manual
+`bao operator unseal`. All five ASG overrides carry equal `weighted_capacity`,
+because the ASG reads `desired_capacity` in capacity units — unequal weights
+would make the quorum size depend on which SPOT pool happened to win, rather
+than always being five.
+
+Neither shape is a production posture. The cluster is torn down and
+reprovisioned on every platform test, which is what `dev` mode is priced for
+and what the SPOT-everywhere, RAID-0-with-no-redundancy choices in `ha` mode
+are priced for. `opentofu/openbao/management/`
 then layers the three-tier PKI, the cert-manager AppRole, and policies on
 top of the running cluster — see `opentofu/openbao/cluster/README.md` and
 `opentofu/openbao/management/README.md` for the operational detail (unseal

--- a/website/content/docs/platform/security/openbao.md
+++ b/website/content/docs/platform/security/openbao.md
@@ -6,8 +6,10 @@ lastVerified: 2026-08-20
 ---
 
 [Foundations]({{< relref "/docs/platform/foundations/aws.md#the-openbao-cluster-stack" >}})
-covers how the OpenBao cluster is provisioned — five SPOT nodes on Raft, KMS
-auto-unseal, RAID-0 NVMe. This page covers what runs on top of that cluster:
+covers how the OpenBao cluster is provisioned — a single node on `file`
+storage as committed (`mode = "dev"`), or five SPOT nodes on Raft with RAID-0
+NVMe at `mode = "ha"`, with KMS auto-unseal either way. This page covers what
+runs on top of that cluster:
 `opentofu/openbao/management/` layers namespaces, auth methods, the PKI, and
 policies onto it, and this is the operational surface every other security
 page and the [Access]({{< relref "/docs/get-started/aws/access.md" >}}) guide


### PR DESCRIPTION
Four pages described the OpenBao cluster as "a 5-node HA cluster on Raft,
mostly-equal-weighted SPOT instance pools, RAID-0 NVMe storage, KMS
auto-unseal". `opentofu/openbao/cluster/variables.tfvars` commits
`mode = "dev"`.

That one variable decides considerably more than node count:

```hcl
# autoscaling_group.tf:123
desired_capacity = var.mode == "dev" ? 1 : 5
```
```bash
# scripts/startup_script.sh:119
%{ if dev_mode }
storage "file" { path = "${openbao_data_path}" }
%{ else }
storage "raft" { ... }
```

| Claimed | With the committed `mode = "dev"` |
|---|---|
| 5 nodes | **1** |
| HA on Raft | **`file` backend**, on the root volume |
| SPOT instance pools | none — `mixed_instances_policy` is `ha`-only; `t3.micro` on-demand |
| RAID-0 NVMe | `t3.micro` has no instance store; `setup-local-disks.sh` logs "No ephemeral disks found, skipping disk setup" |
| KMS auto-unseal | ✅ the one that held |

The dev launch template's own comment says it plainly — *"in dev mode the
`file` storage backend and the server TLS private key both live on the root
volume"* — so the deployed posture is a single node holding both the secrets
data and the server key on one gp3 volume.

## What changed

The `ha` design is accurate *for `ha` mode* and worth keeping, so it stays —
reframed as what `mode = "ha"` builds rather than as what you get.

- **Foundations → AWS**: the stack table row, and a table comparing the two
  modes across nodes, storage backend, instance type, data volume and unseal.
- **Get Started → AWS**: says which cluster the command is about to create.
  This page is read *before* deploying, which made it the worst place to
  overstate.
- **Platform → Security → OpenBao**: the summary line.
- **ADR-0011**: called it a "Raft-backed EC2 fleet" twice. Mine, from #1804.

Parts of the OpenBao page already knew — `bao operator raft list-peers` is
annotated "ha mode only", and the snapshot section notes that Raft-only
endpoints do not exist in `dev` mode. It was the summaries at the top of each
page that had drifted from the tfvars.

## Not changed

`dashboards-and-alerts.md` describes `openbao.yaml` as covering "lost/at-risk
Raft voter". That is an accurate description of the rules in that file. They
simply never fire in `dev` mode, which is a property of the alerts, not a
false claim about them.

No infrastructure changed. If a single node is not the posture you want, the
fix is `mode = "ha"` in `variables.tfvars`, not an edit here.

## Verification

```
./scripts/validate-links.sh     ==> All relative Markdown links resolve (0 allowlisted).
./scripts/verify-doc-paths.sh   ==> Every repository path named in the docs site exists.
hugo --source website --minify  BUILD OK

grep -rn "5-node HA|5-node Raft" website/content --include=*.md   → none
```

Found while sourcing ADR-0011 during the ADR backfill (#1804).
