### PR TITLE
docs(observability): correct the VMAlert topology and the per-node pod-IP comparison

### DIFF
--- a/website/content/docs/decisions/0009-cilium-over-vpc-cni.md
+++ b/website/content/docs/decisions/0009-cilium-over-vpc-cni.md
@@ -192,8 +192,10 @@ one most tempting to write up as a pure win.
   during bootstrap.** Those nodes exist from Stage 1, before Cilium is
   running in Stage 2, so Cilium hands them individually-allocated
   secondary IPs instead of prefixes and never converts them afterward —
-  a permanent ceiling of roughly 42 pod IPs per node instead of the
-  ~240 a Karpenter-provisioned node gets with prefix delegation. The
+  a permanent ceiling of roughly 42 pod IPs per node. A Karpenter node
+  with prefix delegation has several hundred, more than the 100 pods its
+  `EC2NodeClass` permits — so there scheduling binds first, while a
+  bootstrap node exhausts addresses well below that limit. The
   failure surfaces far from the cause: a DaemonSet pod stuck unable to
   get an IP keeps its rollout in progress, which times out an unrelated
   `HelmRelease`'s `--wait` and reports that HelmRelease `InstallFailed`.

--- a/website/content/docs/platform/foundations/aws.md
+++ b/website/content/docs/platform/foundations/aws.md
@@ -76,9 +76,11 @@ script — the second job `cd`s into `../configure` and applies it directly —
 plus a third job that recycles any node-group node whose ENIs predate
 Cilium. Those nodes exist from Stage 1, before Cilium is running, so Cilium
 hands them individually-allocated secondary IPs instead of `/28` prefixes
-and never converts them: a permanent ceiling of roughly 42 pod IPs per node
-instead of the ~240 a Karpenter-provisioned node gets with prefix
-delegation. The failure surfaces far from the cause — a DaemonSet pod that
+and never converts them: a permanent ceiling of roughly 42 pod IPs per node.
+With prefix delegation a Karpenter-provisioned node has several hundred — more
+than the 100 pods its `EC2NodeClass` sets as `maxPods`, so scheduling binds
+before addressing does. A bootstrap node runs out of IPs long before it
+reaches that limit. The failure surfaces far from the cause — a DaemonSet pod that
 can't get an IP keeps its rollout `InProgress`, which times out an unrelated
 HelmRelease's `--wait` and reports that HelmRelease `InstallFailed`. The
 recycle script is idempotent: it inspects each node's `CiliumNode` and only

--- a/website/content/docs/platform/networking/cilium.md
+++ b/website/content/docs/platform/networking/cilium.md
@@ -86,7 +86,10 @@ is the only tag these subnets should carry.
 Prefix delegation only benefits nodes **created after** Cilium is running.
 Stage 1 bootstrap nodes predate it, so their ENIs get individually-allocated
 secondary IPs and never convert — a permanent ceiling of roughly 42 pod IPs
-per node instead of the ~240 a Karpenter-provisioned node gets. See
+per node. Prefix delegation gives a Karpenter-provisioned node several hundred
+instead, comfortably more than the 100 pods its `EC2NodeClass` allows, so
+there the `maxPods` limit binds first and IP supply never does. On a bootstrap
+node the IPs run out well below that. See
 [AWS Foundations]({{< relref "/docs/platform/foundations/aws.md#why-eks-bootstrap-is-two-opentofu-stacks" >}})
 for the recycle step that works around it.
 

--- a/website/content/docs/platform/observability/_index.md
+++ b/website/content/docs/platform/observability/_index.md
@@ -13,7 +13,7 @@ not run on the cluster today. Every other component below does. See
 [Dashboards & Alerts]({{< relref "/docs/platform/observability/dashboards-and-alerts.md#grafana-oncall-built-but-not-deployed" >}})
 for what that means in practice.
 
-![Where a metric, a log and a span go: vmagent scrapes Pods, Services and OpenBao into single-node VictoriaMetrics, Vector ships container stdout and Kubernetes Events into VictoriaLogs, and applications push OTLP spans straight to VictoriaTraces; one Grafana reads all three, while VMAlert evaluates PromQL and LogsQL rules from the same VMRule mechanism and Alertmanager fans every surviving alert to both RunLore and Slack](/images/diagrams/observability-flow.svg)
+![Where a metric, a log and a span go: vmagent scrapes Pods, Services and OpenBao into single-node VictoriaMetrics, Vector ships container stdout and Kubernetes Events into VictoriaLogs, and applications push OTLP spans straight to VictoriaTraces; one Grafana reads all three, while a VMAlert instance per signal evaluates PromQL and LogsQL rules authored through the same VMRule mechanism and Alertmanager fans every surviving alert to both RunLore and Slack](/images/diagrams/observability-flow.svg)
 
 | Component | Deployed via | Documented in |
 |---|---|---|
@@ -40,10 +40,16 @@ Prometheus and Loki — existing dashboards and alerting rules written against
 either wire protocol work unchanged, so adopting them cost nothing on that
 front. The two products share one operator
 (`operator.victoriametrics.com/v1beta1` — `VMRule`, `VMServiceScrape`,
-`VMScrapeConfig`, `VMAlert`) and one Grafana, which is what lets a single
-`VMAlert` evaluate both PromQL rules against VictoriaMetrics and LogsQL rules
-(`type: vlogs`) against VictoriaLogs from the same `ruleSelector` mechanism —
-see [`loggen`'s alert]({{< relref "/docs/platform/observability/logs.md#alerting-on-logs" >}})
+`VMScrapeConfig`, `VMAlert`) and one Grafana, so a rule is a `VMRule` whether
+it is PromQL against VictoriaMetrics or LogsQL (`type: vlogs`) against
+VictoriaLogs — one authoring surface for both signals.
+
+Each signal still runs its **own** `VMAlert` instance, because each needs its
+own datasource: the one bundled with `victoria-metrics-k8s-stack` evaluates
+the PromQL rules, and `vmalert-vlsingle.yaml` defines a second, scoped by
+`ruleSelector.matchLabels.vmlog: "true"`, that evaluates the LogsQL ones. A
+rule missing that label is invisible to it. See
+[`loggen`'s alert]({{< relref "/docs/platform/observability/logs.md#alerting-on-logs" >}})
 for a concrete `type: vlogs` example. No ADR in this repository records the
 comparison against Prometheus/Loki directly; treat this section as the
 current rationale, not a linked decision record.


### PR DESCRIPTION
Two claims that the manifests contradict. Both found while sourcing ADRs
during the backfill (#1804), both out of scope there.

## One `VMAlert`, or two

`observability/_index.md` said the shared operator is *"what lets a **single**
`VMAlert` evaluate both PromQL rules against VictoriaMetrics and LogsQL rules
(`type: vlogs`) against VictoriaLogs from the same `ruleSelector` mechanism"*.

There are two instances, and they must be two, because each needs its own
datasource:

| Instance | Source | Evaluates |
|---|---|---|
| bundled | `victoria-metrics-k8s-stack` chart | PromQL rules against `vmsingle` |
| `victoria-logs` | `observability/base/victoria-logs/vmalert-vlsingle.yaml` | LogsQL rules, `ruleSelector.matchLabels.vmlog: "true"`, against the VictoriaLogs datasource |

The site already contradicted itself — `logs.md` says plainly that the
`vmlog: "true"` label is what makes a rule visible to VictoriaLogs' own
`VMAlert`, and that *"VictoriaMetrics' default `VMAlert` … never sees it"*.

What is genuinely shared is the **authoring surface**: a rule is a `VMRule`
either way, and that is the claim worth making. The section now says so, names
both instances, and notes that a rule missing the label is invisible to the
logs one — the failure mode a reader would actually hit.

The flow diagram draws one `VMAlert` box. That is a reasonable simplification
for a flow diagram and I have not redrawn it, but its alt text no longer
asserts a single instance, since alt text is the whole picture for a
screen-reader user.

## `~240` is a count of IPs, not of pods

Three pages compared a bootstrap node's ~42 pod IPs against *"the ~240 a
Karpenter-provisioned node gets"*. In a sentence about pod capacity that reads
as a pod count. It is not:

```yaml
# infrastructure/base/karpenter-nodepools/default-ec2nc.yaml:10
  kubelet:
    maxPods: 100
```

A Karpenter-provisioned node schedules **100** pods however many addresses
prefix delegation hands it. The ~240 is IP supply, and IP supply is not what
limits it.

That distinction is the entire point of the passage, so losing it costs the
explanation: on a Karpenter node `maxPods` binds first and addressing never
does; on a bootstrap node whose ENIs predate Cilium, the ~42 IPs bind well
below that limit — which is why the recycle step exists.

Fixed in `platform/networking/cilium.md`, `platform/foundations/aws.md`, and
ADR-0009 (mine, from #1804).

## Verification

```
./scripts/validate-links.sh     ==> All relative Markdown links resolve (0 allowlisted).
./scripts/verify-doc-paths.sh   ==> Every repository path named in the docs site exists.
hugo --source website --minify  BUILD OK

grep -rn "~240|a single .VMAlert" website/content --include=*.md   → none
```

No manifests changed — both are documentation corrections.
