### PR TITLE
chore(kyverno): replace a stale resources TODO with what is actually set

### DIFF
--- a/security/base/kyverno/helmrelease-controller.yaml
+++ b/security/base/kyverno/helmrelease-controller.yaml
@@ -22,4 +22,20 @@ spec:
     fullnameOverride: kyverno
     crds:
       install: false
-# Need to set at least resources limits in a near future
+# No `resources:` override on purpose. The chart already sets requests and a
+# memory limit on every container it renders — admission (init + main),
+# background, cleanup and reports controllers, and the three hook Jobs — so
+# the constitution's requirement is met without pinning numbers here that
+# would then have to be re-tuned by hand on every chart bump.
+#
+# CPU limits are absent on the long-running controllers, and that is the
+# chart's deliberate choice, not an oversight: a CPU limit throttles rather
+# than protects, and throttling an admission webhook adds latency to every
+# matching API call. `.polaris.yaml` scores cpuLimitsMissing as a warning for
+# that reason.
+#
+# Verify after a chart bump by rendering rather than reading values.yaml —
+# several of these live under admissionController.{initContainer,container}
+# rather than a top-level resources key:
+#   helm template kyverno kyverno/kyverno --version <v> \
+#     --set fullnameOverride=kyverno --set crds.install=false


### PR DESCRIPTION
`security/base/kyverno/helmrelease-controller.yaml` carried this since the
first installation in August 2023:

```yaml
# Need to set at least resources limits in a near future
```

It is not true, and has not been for some time. Rendering the chart as this
repository configures it:

```bash
helm template kyverno kyverno/kyverno --version 3.8.2 \
  --set fullnameOverride=kyverno --set crds.install=false
```

| Workload | Container | Limits | Requests |
|---|---|---|---|
| admission-controller | `kyverno-pre` (init) | cpu 100m, mem 256Mi | cpu 10m, mem 64Mi |
| admission-controller | `kyverno` | mem 384Mi | cpu 100m, mem 128Mi |
| background-controller | `controller` | mem 128Mi | cpu 100m, mem 64Mi |
| cleanup-controller | `controller` | mem 128Mi | cpu 100m, mem 64Mi |
| reports-controller | `controller` | mem 128Mi | cpu 100m, mem 64Mi |
| 3 hook Jobs | — | cpu 100m, mem 256Mi | cpu 10m, mem 64Mi |

Containers lacking requests or a memory limit: **0**. The constitution's
requirement is already met.

## Why the comment survived three years

Several of those blocks live under
`admissionController.initContainer.resources` and
`admissionController.container.resources` rather than a top-level `resources:`
key. Skimming `values.yaml` for `^  resources:` finds the background, cleanup
and reports controllers and misses the admission controller entirely — which
reads as "the one in the request path has no limits".

That is exactly how this was misread again last week while auditing the
repository against the constitution. Reading the values file is not the same
as rendering the chart, and the comment invited the former.

## CPU limits

Absent on the long-running controllers, by the chart's design rather than by
omission. A CPU limit throttles rather than protects, and throttling an
admission webhook adds latency to every matching API call. `.polaris.yaml`
scores `cpuLimitsMissing` as `warning`, not `danger`, for that reason.

## What changed

Only the comment. It now states what is set, why there is no override, why CPU
limits are deliberately absent, and the `helm template` command to re-verify
after a chart bump — because the next person to check will otherwise read
`values.yaml` and reach the same wrong conclusion.

**No `values:` override was added.** Pinning these numbers here would mean
re-tuning them by hand on every chart bump, trading a working upstream default
for a maintenance burden and a source of drift.

## Verification

```
./scripts/validate-manifests.sh
Summary: 1183 resources found in 182 files - Valid: 1183, Invalid: 0, Skipped: 0
Polaris score: 87
==> All gates passed
```
