### PR TITLE
ci: authenticate tflint's plugin download instead of racing a rate limit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,13 +25,28 @@ jobs:
           echo 'keep' > opentofu/openbao/cluster/.tls/openbao-key.pem
           echo 'keep' > opentofu/openbao/cluster/.tls/ca-chain.pem
 
+      # Runs pre-commit directly rather than through the pre-commit-tf Dagger
+      # module. That module cannot take a secret — its Run() accepts only
+      # version, dir, tfBinary and a cache_dir wired to TF_PLUGIN_CACHE_DIR —
+      # so `tflint --init` fetched its ruleset from the GitHub releases API
+      # unauthenticated, at 60 requests/hour shared across every Actions runner
+      # on that egress IP. It failed on an unrelated docs PR on 2026-08-22.
+      #
+      # With GITHUB_TOKEN set below, tflint authenticates and gets 5000/hour.
+      # Tool versions come from mise.toml, which pins tofu, pre-commit and
+      # tflint — the same file a contributor runs `mise install` against, so
+      # this keeps the CI/local parity the Dagger image was there to provide.
+      - name: Install tools
+        uses: jdx/mise-action@v4
+
       - name: Validate Opentofu configuration
-        uses: dagger/dagger-for-github@v8.4.1
-        with:
-          version: "latest"
-          verb: call
-          module: github.com/Smana/daggerverse/pre-commit-tf@pre-commit-tf/v0.1.2
-          args: run --dir "." --tf-binary="tofu"
+        run: pre-commit run --all-files --show-diff-on-failure
+        env:
+          # tflint reads this when downloading the ruleset pinned in
+          # .tflint.hcl. Without it the request is anonymous and rate-limited.
+          GITHUB_TOKEN: ${{ github.token }}
+          # What the pre-commit-terraform hooks call instead of `terraform`.
+          PCT_TFPATH: tofu
 
   security-scan:
     name: Security scanning 🔒

--- a/mise.toml
+++ b/mise.toml
@@ -12,6 +12,12 @@ nodejs = "22.23.1"
 opentofu = "1.12.6"
 pre-commit = "4.6.2"
 trivy = "0.74.0"
+
+# Needed by the `terraform_tflint` pre-commit hook. Pinned here rather than
+# left to whatever is on PATH so CI and a local `pre-commit run -a` lint with
+# the same binary. The *plugin* version is separate — `.tflint.hcl` pins
+# ruleset.aws, which tflint downloads from GitHub releases on `--init`.
+tflint = "0.64.0"
 "ubi:terramate-io/terramate" = "0.17.2"
 
 # Manifest validation (SPEC-007). flux 2.9+ is required for `flux plugin`;


### PR DESCRIPTION
## The failure

A documentation-only PR (#1809) failed CI on 2026-08-22:

```
Command 'tflint --init' failed:
Installing "aws" plugin...
Failed to install a plugin; Failed to fetch GitHub releases:
GET .../tflint-ruleset-aws/releases/tags/v0.48.0:
403 API rate limit exceeded for 52.241.147.97   [rate reset in 18m38s]
```

Nothing about the change mattered — it edited one YAML comment and touched no
Terraform. Re-running passed only because the rate-limit window had rolled
over. It will fail again.

## Why it could not be fixed in place

The job ran through `Smana/daggerverse/pre-commit-tf@pre-commit-tf/v0.1.2`,
whose entire interface is:

```go
func (m *PreCommitTf) Run(ctx, version string, dir *dagger.Directory,
                          tfBinary string, cache_dir *dagger.Directory)
```

No parameter carries a secret or an environment variable. `cache_dir` looks
promising but is wired to `TF_PLUGIN_CACHE_DIR` — Terraform *provider*
plugins, not tflint's ruleset directory. So `tflint --init` reached the GitHub
releases API anonymously, at **60 requests/hour shared across every Actions
runner on that egress IP**. v0.1.2 is the latest tag and `main` has the same
signature, so there was nothing to bump to.

## The fix

Run pre-commit directly, with a token tflint can use:

```yaml
- name: Install tools
  uses: jdx/mise-action@v4

- name: Validate Opentofu configuration
  run: pre-commit run --all-files --show-diff-on-failure
  env:
    GITHUB_TOKEN: ${{ github.token }}
    PCT_TFPATH: tofu
```

tflint reads `GITHUB_TOKEN` when downloading plugins. **60/hour anonymous →
5000/hour authenticated.**

## Keeping the parity the Dagger image provided

Dropping the module means losing its pinned toolchain, which is the real cost
and worth answering rather than waving at. The versions move to `mise.toml`,
which already pinned `opentofu` and `pre-commit` and now pins `tflint` as
well:

```toml
tflint = "0.64.0"
```

That is the same file a contributor runs `mise install` against, so CI and a
local `pre-commit run -a` use the same binaries. Arguably better parity than
before, since the image's versions were previously invisible from this
repository.

Note the two version pins are separate and stay separate: `mise.toml` pins the
tflint **binary**, `.tflint.hcl` pins **ruleset.aws** — the thing being
downloaded. The comment in `mise.toml` says so, because conflating them is the
obvious next mistake.

## Verification

Not "should work" — run locally with exactly the tools and env the new step
uses:

```
tflint: TFLint version 0.64.0
tofu:   OpenTofu v1.12.6
pre-commit: pre-commit 4.6.2

trim trailing whitespace ... Passed      Terraform fmt ................. Passed
fix end of files ......... Passed        Terraform validate ............ Passed
check yaml ............... Passed        Terraform validate with tflint  Passed
[...14 hooks...]                         Detect secrets ................ Passed

EXIT=0
```

tflint 0.64.0 was checked against the pinned `ruleset.aws 0.48.0` before being
selected (`tflint --init` resolves it, and the hook reports no new findings),
so this is not a silent lint-behaviour change riding along with a CI fix.

## Alternative considered

Adding a `githubToken *dagger.Secret` parameter to the daggerverse module
would fix it for every consumer, not just this repository. Rejected for now as
a two-repo change; if `pre-commit-tf` gains secret support later, this job can
move back to it.
