### PR TITLE
ci: gate documentation claims against the configuration they describe

### DIFF
--- a/.claude/rules/process.md
+++ b/.claude/rules/process.md
@@ -15,6 +15,7 @@ Before claiming status: identify the command, run it fresh, cite the output inli
 | Manifests valid | `./scripts/validate-manifests.sh` → exit 0, and the report shows `Invalid: 0, Skipped: 0` |
 | KCL composition valid | `task check` in `Smana/crossplane-configuration` → exit 0 (compositions are not in this repo) |
 | Docs links resolve | `./scripts/validate-links.sh` → exit 0 (run after ANY file move — a path grep cannot see relative-link rot) |
+| Docs still true | `./scripts/validate-doc-claims.sh` → exit 0 (run after ANY config change a page describes — links resolving says nothing about whether the sentence is still accurate) |
 | Design ready | Design doc committed under `docs/superpowers/specs/`, no `[NEEDS CLARIFICATION]` markers left |
 | Success criteria met (post-merge) | `/verify-spec <design-doc>` against live cluster |
 | Flux reconciled | `flux get kustomizations` / `helmreleases` → `Ready=True` |

--- a/.doc-claims.yaml
+++ b/.doc-claims.yaml
@@ -1,0 +1,98 @@
+# Documentation claims that must stay true to configuration.
+#
+# Four defects found on 2026-08-21/22 were the same shape: a page asserted
+# something the manifests contradicted, and every automated gate passed. Links
+# resolved, schemas validated, the site built. Nothing checks whether prose is
+# *true*, because nothing can — in general. This file makes it checkable for
+# the specific claims worth pinning.
+#
+# Each entry reads a value from the source of truth and requires the pages that
+# discuss it to agree. The check is bidirectional on purpose: change `mode` in
+# variables.tfvars and this fails until the docs follow; reword the docs away
+# from the committed value and it fails too.
+#
+# Schema
+#   id             stable identifier, used in failure output
+#   why            why this claim is worth pinning — shown when it fails
+#   source.file    the file that decides the answer
+#   source.pattern Python regex; group 1 is captured as {value}
+#                  omit to assert only that the file exists
+#   pages          pages whose prose depends on that value
+#   must_contain   pattern each page must match; {value} interpolates the
+#                  capture, and is regex-escaped before substitution
+#   must_not_contain
+#                  patterns no page may match — for phrasings known to be
+#                  wrong. Prefer must_contain: asserting the correct claim is
+#                  present is stronger than asserting a wrong one is absent,
+#                  and does not break when a fix keeps the words and adds a
+#                  qualifier.
+#
+# Adding an entry is cheap. Do it when a page states something a reader would
+# act on that lives in exactly one place in the repo.
+
+claims:
+  - id: openbao-cluster-mode
+    why: >-
+      `mode` decides node count AND storage backend — dev is one node on the
+      `file` backend, ha is five on Raft. Four pages described the ha shape as
+      though it were deployed while variables.tfvars committed dev, so a reader
+      assessing availability of the secrets store was actively misled.
+    source:
+      file: opentofu/openbao/cluster/variables.tfvars
+      pattern: '^mode\s*=\s*"([a-z]+)"'
+    # Per-page patterns, not a shared one. These pages deliberately document
+    # BOTH modes, so `mode = "{value}"` alone matches whichever value is read
+    # and passes even when the committed mode changes underneath — verified:
+    # flipping variables.tfvars to "ha" did not fail the shared pattern. Each
+    # entry anchors the value to that page's own marker of which mode ships.
+    pages:
+      - path: website/content/docs/platform/foundations/aws.md
+        must_contain: '`variables\.tfvars` sets\s+`mode = "{value}"`'
+        must_not_contain:
+          - '`mode = "(?!{value})[a-z]+"` \(committed\)'
+      - path: website/content/docs/platform/security/openbao.md
+        must_contain: 'as committed \(`mode = "{value}"`\)'
+      - path: website/content/docs/get-started/aws/_index.md
+        must_contain: 'As committed,[^`]*`[^`]*variables\.tfvars` sets\s+`mode = "{value}"`'
+
+  - id: karpenter-max-pods
+    why: >-
+      Pages comparing per-node pod capacity quoted the IP supply prefix
+      delegation provides (~240) as though it were the pod ceiling. maxPods is
+      what actually binds on a Karpenter node, and the distinction is the point
+      of the passage.
+    source:
+      file: infrastructure/base/karpenter-nodepools/default-ec2nc.yaml
+      pattern: 'maxPods:\s*(\d+)'
+    pages:
+      - website/content/docs/platform/networking/cilium.md
+      - website/content/docs/platform/foundations/aws.md
+      - website/content/docs/decisions/0009-cilium-over-vpc-cni.md
+    must_contain: '{value} pods'
+
+  - id: victorialogs-own-vmalert
+    why: >-
+      VictoriaLogs runs its own VMAlert, scoped by ruleSelector, because it
+      needs its own datasource. The overview page claimed a single shared
+      instance evaluated both signals while logs.md said the opposite — the
+      site contradicted itself.
+    source:
+      file: observability/base/victoria-logs/vmalert-vlsingle.yaml
+    pages:
+      - website/content/docs/platform/observability/_index.md
+    must_not_contain:
+      - 'a single `?VMAlert'
+      - 'one shared `?VMAlert'
+
+  - id: kyverno-policies-values
+    why: >-
+      Only the kyverno-policies release ships `values: {}`; the controller sets
+      fullnameOverride and crds.install. Saying "both" made the enforced policy
+      set look chosen rather than inherited from chart defaults.
+    source:
+      file: security/base/kyverno/helmrelease-policies.yaml
+      pattern: '^\s*(values: \{\})\s*$'
+    pages:
+      - website/content/docs/platform/security/policies.md
+    must_not_contain:
+      - 'Both install with'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -218,3 +218,12 @@ jobs:
       - uses: actions/checkout@v7
       - name: Resolve every relative Markdown link
         run: ./scripts/validate-links.sh
+
+      # Runs in this job rather than its own so the required-check list on
+      # `main` does not have to change. The job name stays "documentation
+      # links" for the same reason; it now gates documentation *claims* too.
+      - name: Install Python dependencies
+        run: python3 -m pip install --quiet --disable-pip-version-check pyyaml
+
+      - name: Check documentation claims against configuration
+        run: ./scripts/validate-doc-claims.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,7 @@ tofu validate
 trivy config --exit-code=1 --ignorefile=./.trivyignore.yaml .
 ./scripts/validate-manifests.sh   # renders the repo, then gates it (see below)
 ./scripts/validate-links.sh       # resolves every relative Markdown link
+./scripts/validate-doc-claims.sh  # docs still agree with config (.doc-claims.yaml)
 kubectl get nodes && kubectl get pods --all-namespaces
 flux get all
 ```

--- a/scripts/validate-doc-claims.sh
+++ b/scripts/validate-doc-claims.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# validate-doc-claims.sh — check that documentation still agrees with configuration.
+#
+# The other gates in this repository check structure: links resolve, schemas
+# validate, the site builds. None of them can tell whether a sentence is true.
+# On 2026-08-21/22 four pages were found asserting things the manifests
+# contradicted — a five-node OpenBao cluster that variables.tfvars sets to one
+# node, a single VMAlert where two exist, an IP count presented as a pod
+# ceiling, a `values: {}` attributed to both Kyverno releases when only one has
+# it. Every gate was green throughout.
+#
+# This closes that class for claims worth pinning. `.doc-claims.yaml` names a
+# source of truth, a value to read from it, and the pages whose prose depends
+# on that value. The check is bidirectional: it fails when config moves away
+# from the docs, and when docs move away from config.
+#
+# It is deliberately not clever. It cannot verify prose in general and does not
+# try; it verifies the specific claims someone chose to pin. Adding one is a
+# few lines of YAML.
+#
+# Usage:
+#   ./scripts/validate-doc-claims.sh          # fail on any violated claim
+#   ./scripts/validate-doc-claims.sh --list   # print every claim and its current value
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CLAIMS_FILE=".doc-claims.yaml"
+MODE="${1:-check}"
+
+if [ ! -f "$CLAIMS_FILE" ]; then
+  echo "error: $CLAIMS_FILE not found" >&2
+  exit 2
+fi
+
+if ! python3 -c "import yaml" 2>/dev/null; then
+  echo "error: PyYAML not installed." >&2
+  echo "       Fix: python3 -m pip install pyyaml" >&2
+  exit 2
+fi
+
+python3 - "$CLAIMS_FILE" "$MODE" <<'PY'
+import os
+import re
+import sys
+
+import yaml
+
+claims_file, mode = sys.argv[1], sys.argv[2]
+listing = mode == "--list"
+
+with open(claims_file, encoding="utf-8") as fh:
+    claims = (yaml.safe_load(fh) or {}).get("claims") or []
+
+if not claims:
+    print("error: no claims defined in %s" % claims_file, file=sys.stderr)
+    sys.exit(2)
+
+
+def wrap(text, width=72, indent="    "):
+    """Reflow `why` text so failure output stays readable in a CI log."""
+    words = " ".join((text or "").split())
+    if not words:
+        return ""
+    lines, cur = [], ""
+    for w in words.split(" "):
+        if len(cur) + len(w) + 1 > width:
+            lines.append(indent + cur)
+            cur = w
+        else:
+            cur = w if not cur else cur + " " + w
+    if cur:
+        lines.append(indent + cur)
+    return "\n".join(lines)
+
+
+failures = []
+checked = 0
+
+for claim in claims:
+    cid = claim.get("id", "<unnamed>")
+    source = claim.get("source") or {}
+    src_file = source.get("file")
+    pattern = source.get("pattern")
+
+    if not src_file:
+        failures.append((cid, claim, "claim has no source.file"))
+        continue
+
+    if not os.path.exists(src_file):
+        # The source of truth moved or was deleted. That is exactly when docs
+        # rot, so this is a failure rather than a skip.
+        failures.append(
+            (cid, claim, "source of truth is missing: %s" % src_file)
+        )
+        continue
+
+    value = None
+    if pattern:
+        text = open(src_file, encoding="utf-8", errors="replace").read()
+        m = re.search(pattern, text, re.M)
+        if not m:
+            failures.append(
+                (
+                    cid,
+                    claim,
+                    "pattern %r matched nothing in %s — the file changed shape, "
+                    "so the claim can no longer be verified" % (pattern, src_file),
+                )
+            )
+            continue
+        value = m.group(1)
+
+    if listing:
+        print("%-28s %-52s %s" % (cid, src_file, value if value else "(exists)"))
+        continue
+
+    for entry in claim.get("pages") or []:
+        # A page is either a bare path (uses the claim's must_contain) or a
+        # mapping that overrides it. The override exists because a shared
+        # pattern is often too loose: pages that deliberately document BOTH a
+        # committed and an alternative value match `mode = "{value}"` whichever
+        # value is read, so the check silently passes on real drift. Anchoring
+        # on each page's own phrasing is what makes it bite.
+        if isinstance(entry, dict):
+            page = entry.get("path")
+            must = entry.get("must_contain", claim.get("must_contain"))
+            banned_extra = entry.get("must_not_contain") or []
+        else:
+            page, must, banned_extra = entry, claim.get("must_contain"), []
+
+        checked += 1
+        if not page:
+            failures.append((cid, claim, "page entry has no path"))
+            continue
+        if not os.path.exists(page):
+            failures.append((cid, claim, "page is missing: %s" % page))
+            continue
+        prose = open(page, encoding="utf-8", errors="replace").read()
+
+        if must:
+            needle = must.replace("{value}", re.escape(value or ""))
+            if not re.search(needle, prose):
+                failures.append(
+                    (
+                        cid,
+                        claim,
+                        "%s does not state the current value.\n"
+                        "    %s says %s\n"
+                        "    the page must match: %s"
+                        % (page, src_file, value, needle),
+                    )
+                )
+
+        for banned in list(claim.get("must_not_contain") or []) + list(banned_extra):
+            needle = banned.replace("{value}", re.escape(value or ""))
+            if re.search(needle, prose):
+                failures.append(
+                    (cid, claim, "%s still matches %r" % (page, needle))
+                )
+
+if listing:
+    sys.exit(0)
+
+if failures:
+    print()
+    for cid, claim, detail in failures:
+        print("BROKEN CLAIM  %s" % cid)
+        print("    %s" % detail)
+        why = wrap(claim.get("why"))
+        if why:
+            print("  why this is pinned:")
+            print(why)
+        print()
+    print(
+        "%d documentation claim(s) no longer match the repository.\n"
+        "Fix the page, or — if the configuration deliberately changed — update\n"
+        "the page and the claim together in %s." % (len(failures), claims_file)
+    )
+    sys.exit(1)
+
+print(
+    "==> All %d documentation claims match the repository (%d page checks)."
+    % (len(claims), checked)
+)
+PY


### PR DESCRIPTION
## The gap

Four defects found on 2026-08-21/22 were the same shape — a page asserting
something the manifests contradicted — and **every gate stayed green through
all of them**. Links resolved, schemas validated, Polaris passed, the site
built.

| Page said | Repository said |
|---|---|
| a 5-node HA OpenBao cluster on Raft | `variables.tfvars` sets `mode = "dev"` — one node, `file` backend |
| "a single `VMAlert`" evaluates both signals | two instances; `logs.md` said so on another page |
| a Karpenter node "gets ~240" | ~240 *IPs*; `maxPods: 100` is the pod ceiling |
| "Both install with `values: {}`" | only `kyverno-policies` does |

Structure was never the problem. Nothing checks whether a sentence is *true*,
because in general nothing can.

## What this adds

`.doc-claims.yaml` makes it checkable for the claims worth pinning. Each entry
names a source of truth, a value to read from it, and the pages whose prose
depends on that value:

```yaml
- id: karpenter-max-pods
  why: >-
    Pages comparing per-node pod capacity quoted the IP supply prefix
    delegation provides (~240) as though it were the pod ceiling.
  source:
    file: infrastructure/base/karpenter-nodepools/default-ec2nc.yaml
    pattern: 'maxPods:\s*(\d+)'
  pages:
    - website/content/docs/platform/networking/cilium.md
    - website/content/docs/platform/foundations/aws.md
    - website/content/docs/decisions/0009-cilium-over-vpc-cni.md
  must_contain: '{value} pods'
```

**Bidirectional on purpose.** Change `maxPods` and it fails until the docs
follow; reword the docs away from the committed value and it fails too.

## The bug worth reading about

The first version of the OpenBao claim used one shared pattern,
`mode = "{value}"`, and **it passed while `variables.tfvars` was flipped from
`dev` to `ha`**. Those pages deliberately document *both* modes — that was the
point of the fix in #1807 — so the pattern matched whichever value was read.

A check that cannot fail is worse than no check, because it is believed.

Fixed by supporting per-page patterns anchored on each page's own marker of
which mode ships:

```yaml
- path: website/content/docs/platform/foundations/aws.md
  must_contain: '`variables\.tfvars` sets\s+`mode = "{value}"`'
  must_not_contain:
    - '`mode = "(?!{value})[a-z]+"` \(committed\)'
```

The `.doc-claims.yaml` comment records why, next to the entry, because the
obvious simplification is the broken one.

## Verified by reintroducing the defects

A clean run proves nothing. Each defect was put back and the check had to fail:

```
caught      config drifts: openbao mode dev -> ha
caught      config drifts: maxPods 100 -> 200
caught      docs drift: openbao page drops the mode
caught      docs drift: 'a single VMAlert' returns
caught      docs drift: 'Both install with' returns
caught      source of truth deleted

== the clean tree must PASS ==
clean tree passes

passed=7 failed=0
```

A deleted source of truth fails rather than skips — that is precisely when
docs rot.

## Scope and deliberate limits

- **No new required check.** It runs inside the existing documentation-links
  job, so branch protection on `main` is untouched. The job keeps its name; a
  comment explains why it now gates claims too.
- **It is not clever, and should not become clever.** It cannot verify prose
  in general and does not try. It verifies four claims someone chose to pin.
  Adding a fifth is a few lines of YAML.
- **`why:` is required in spirit.** It prints on failure, so whoever trips the
  gate in six months learns what the claim protects rather than deleting the
  entry.

Also adds the command to `CLAUDE.md`'s validation list and to the evidence
table in `.claude/rules/process.md`.
