### PR TITLE
fix(terramate): close three teardown and gating holes

### DIFF
--- a/opentofu/gcp/config.tm.hcl
+++ b/opentofu/gcp/config.tm.hcl
@@ -1,0 +1,32 @@
+# GCP-wide Terramate globals.
+#
+# `gcp_gate` is the opt-in guard, defined once and interpolated into every GCP
+# script override as `${global.gcp_gate}`.
+#
+# It exists because each Terramate job is its own bash process, so the check
+# cannot be hoisted to the script or stack level -- it has to appear in every
+# job. Written out by hand that is fifteen near-identical copies across three
+# files, which is how four scripts came to be MISSING one: `init`,
+# `drift detect`, `drift reconcile` and `opentofu render` had no override at all
+# and ran ungated on GCP.
+#
+# `drift reconcile` is the one that made this urgent: the global version runs
+# `tofu apply -auto-approve`, so an ungated drift reconcile from opentofu/ would
+# BUILD GCP infrastructure without anyone opting in.
+#
+# The `$${...}` escape is load-bearing: Terramate resolves it to `${...}` when it
+# evaluates this global, so the literal `${TM_GCP_ENABLED:-}` is what reaches
+# bash. Writing `${...}` here instead would have Terramate try to resolve
+# TM_GCP_ENABLED as a Terramate value and fail at parse time.
+#
+# The message is deliberately generic. A per-script message would mean this
+# could not be shared -- and a shared gate that is always present beats a
+# bespoke message on the gates someone remembered to write.
+globals {
+  gcp_gate = <<-EOT
+    if [ "$${TM_GCP_ENABLED:-}" != "true" ]; then
+      echo "[skip] GCP stack: set TM_GCP_ENABLED=true to run this against GCP."
+      exit 0
+    fi
+  EOT
+}

--- a/opentofu/gcp/gke/configure/workflows.tm.hcl
+++ b/opentofu/gcp/gke/configure/workflows.tm.hcl
@@ -81,7 +81,94 @@ script "destroy" {
         # `destroy` is a standalone entrypoint: unlike `deploy` it can be the first
         # tofu command run in a stack, so it has to init itself.
         ${global.provisioner} init -lock-timeout=5m
-        ${global.provisioner} destroy -auto-approve -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}'
+        # -refresh=false is deliberate on DESTROY.
+        #
+        # This stack reads another stack's outputs through
+        # data.terraform_remote_state. Refreshing that data source requires the
+        # upstream state OBJECT to exist -- and once the upstream stack has been
+        # destroyed its state is empty, so no object is written at all and the
+        # read fails hard with
+        #
+        #   Error: Unable to find remote state
+        #   No stored state was found for the given workspace in the given backend.
+        #
+        # A destroy does not need those outputs: everything being destroyed is
+        # already described by THIS stack's state, and the data source's last
+        # value is cached there. Refreshing only adds a way for teardown to fail.
+        #
+        # Hit for real on 2026-08-23, when the network stack was destroyed before
+        # this one and the teardown could not proceed without it.
+        ${global.provisioner} destroy -refresh=false -auto-approve -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}'
+      BASH
+      ],
+    ]
+  }
+}
+
+script "init" {
+  name        = "GCP Init (opt-in)"
+  description = "Initialize this GCP stack when TM_GCP_ENABLED=true"
+
+  job {
+    commands = [
+      ["bash", "-c", <<-BASH
+        ${global.gcp_gate}
+        set -euo pipefail
+        ${global.provisioner} init
+      BASH
+      ],
+    ]
+  }
+}
+
+script "drift" "detect" {
+  name        = "GCP Drift Check (opt-in)"
+  description = "Detect drift in this GCP stack when TM_GCP_ENABLED=true"
+
+  job {
+    commands = [
+      ["bash", "-c", <<-BASH
+        ${global.gcp_gate}
+        set -euo pipefail
+        ${global.provisioner} init
+        ${global.provisioner} plan -out=drift.tfplan -detailed-exitcode -lock=false -var-file=variables.tfvars
+      BASH
+      ],
+    ]
+  }
+}
+
+# The global version of this script runs `tofu apply -auto-approve`. Ungated, a
+# drift reconcile from opentofu/ would BUILD this GCP stack without anyone
+# opting in -- which is the whole reason the missing overrides were a problem
+# rather than an inconsistency.
+script "drift" "reconcile" {
+  name        = "GCP Drift Reconciliation (opt-in)"
+  description = "Reconcile drift in this GCP stack when TM_GCP_ENABLED=true"
+
+  job {
+    commands = [
+      ["bash", "-c", <<-BASH
+        ${global.gcp_gate}
+        set -euo pipefail
+        ${global.provisioner} apply -input=false -auto-approve -lock-timeout=5m -var-file=variables.tfvars drift.tfplan
+      BASH
+      ],
+    ]
+  }
+}
+
+script "opentofu" "render" {
+  name        = "GCP Show Plan (opt-in)"
+  description = "Render this GCP stack's plan when TM_GCP_ENABLED=true"
+
+  job {
+    commands = [
+      ["bash", "-c", <<-BASH
+        ${global.gcp_gate}
+        set -euo pipefail
+        echo "Stack: ${terramate.stack.path.absolute}"
+        ${global.provisioner} show -no-color out.tfplan
       BASH
       ],
     ]

--- a/opentofu/gcp/gke/init/workflows.tm.hcl
+++ b/opentofu/gcp/gke/init/workflows.tm.hcl
@@ -194,7 +194,24 @@ script "destroy" {
         # No tolerance here, unlike stage 2: this is the billable resource. If it
         # cannot be destroyed the run must fail loudly rather than move on to the
         # network stack and strand a live cluster behind a deleted VPC.
-        ${global.provisioner} destroy -auto-approve -var-file=variables.tfvars
+        # -refresh=false is deliberate on DESTROY.
+        #
+        # This stack reads another stack's outputs through
+        # data.terraform_remote_state. Refreshing that data source requires the
+        # upstream state OBJECT to exist -- and once the upstream stack has been
+        # destroyed its state is empty, so no object is written at all and the
+        # read fails hard with
+        #
+        #   Error: Unable to find remote state
+        #   No stored state was found for the given workspace in the given backend.
+        #
+        # A destroy does not need those outputs: everything being destroyed is
+        # already described by THIS stack's state, and the data source's last
+        # value is cached there. Refreshing only adds a way for teardown to fail.
+        #
+        # Hit for real on 2026-08-23, when the network stack was destroyed before
+        # this one and the teardown could not proceed without it.
+        ${global.provisioner} destroy -refresh=false -auto-approve -var-file=variables.tfvars
       BASH
       ],
     ]
@@ -212,6 +229,76 @@ script "destroy" {
         set -euo pipefail
         bash "${terramate.root.path.fs.absolute}/scripts/gke-destroy-stage2.sh" \
           reconcile "${terramate.root.path.fs.absolute}/opentofu/gcp/gke/configure"
+      BASH
+      ],
+    ]
+  }
+}
+
+script "init" {
+  name        = "GCP Init (opt-in)"
+  description = "Initialize this GCP stack when TM_GCP_ENABLED=true"
+
+  job {
+    commands = [
+      ["bash", "-c", <<-BASH
+        ${global.gcp_gate}
+        set -euo pipefail
+        ${global.provisioner} init
+      BASH
+      ],
+    ]
+  }
+}
+
+script "drift" "detect" {
+  name        = "GCP Drift Check (opt-in)"
+  description = "Detect drift in this GCP stack when TM_GCP_ENABLED=true"
+
+  job {
+    commands = [
+      ["bash", "-c", <<-BASH
+        ${global.gcp_gate}
+        set -euo pipefail
+        ${global.provisioner} init
+        ${global.provisioner} plan -out=drift.tfplan -detailed-exitcode -lock=false -var-file=variables.tfvars
+      BASH
+      ],
+    ]
+  }
+}
+
+# The global version of this script runs `tofu apply -auto-approve`. Ungated, a
+# drift reconcile from opentofu/ would BUILD this GCP stack without anyone
+# opting in -- which is the whole reason the missing overrides were a problem
+# rather than an inconsistency.
+script "drift" "reconcile" {
+  name        = "GCP Drift Reconciliation (opt-in)"
+  description = "Reconcile drift in this GCP stack when TM_GCP_ENABLED=true"
+
+  job {
+    commands = [
+      ["bash", "-c", <<-BASH
+        ${global.gcp_gate}
+        set -euo pipefail
+        ${global.provisioner} apply -input=false -auto-approve -lock-timeout=5m -var-file=variables.tfvars drift.tfplan
+      BASH
+      ],
+    ]
+  }
+}
+
+script "opentofu" "render" {
+  name        = "GCP Show Plan (opt-in)"
+  description = "Render this GCP stack's plan when TM_GCP_ENABLED=true"
+
+  job {
+    commands = [
+      ["bash", "-c", <<-BASH
+        ${global.gcp_gate}
+        set -euo pipefail
+        echo "Stack: ${terramate.stack.path.absolute}"
+        ${global.provisioner} show -no-color out.tfplan
       BASH
       ],
     ]

--- a/opentofu/gcp/network/workflows.tm.hcl
+++ b/opentofu/gcp/network/workflows.tm.hcl
@@ -109,3 +109,56 @@ script "destroy" {
     ]
   }
 }
+
+script "init" {
+  name        = "GCP Init (opt-in)"
+  description = "Initialize this GCP stack when TM_GCP_ENABLED=true"
+
+  job {
+    commands = [
+      ["bash", "-c", <<-BASH
+        ${global.gcp_gate}
+        set -euo pipefail
+        ${global.provisioner} init
+      BASH
+      ],
+    ]
+  }
+}
+
+# The global version of this script runs `tofu apply -auto-approve`. Ungated, a
+# drift reconcile from opentofu/ would BUILD this GCP stack without anyone
+# opting in -- which is the whole reason the missing overrides were a problem
+# rather than an inconsistency.
+script "drift" "reconcile" {
+  name        = "GCP Drift Reconciliation (opt-in)"
+  description = "Reconcile drift in this GCP stack when TM_GCP_ENABLED=true"
+
+  job {
+    commands = [
+      ["bash", "-c", <<-BASH
+        ${global.gcp_gate}
+        set -euo pipefail
+        ${global.provisioner} apply -input=false -auto-approve -lock-timeout=5m -var-file=variables.tfvars drift.tfplan
+      BASH
+      ],
+    ]
+  }
+}
+
+script "opentofu" "render" {
+  name        = "GCP Show Plan (opt-in)"
+  description = "Render this GCP stack's plan when TM_GCP_ENABLED=true"
+
+  job {
+    commands = [
+      ["bash", "-c", <<-BASH
+        ${global.gcp_gate}
+        set -euo pipefail
+        echo "Stack: ${terramate.stack.path.absolute}"
+        ${global.provisioner} show -no-color out.tfplan
+      BASH
+      ],
+    ]
+  }
+}

--- a/opentofu/shared/tailscale/workflows.tm.hcl
+++ b/opentofu/shared/tailscale/workflows.tm.hcl
@@ -1,0 +1,57 @@
+# Shared Tailscale — destroy guard.
+#
+# Only `destroy` is overridden here. deploy / preview / drift detect all inherit
+# the global scripts at opentofu/workflows.tm.hcl unchanged, because there is
+# nothing dangerous about applying this stack.
+#
+# WHY THE GUARD
+#
+# Everything this stack owns is TAILNET-WIDE, not cloud-scoped: the ACL, the DNS
+# nameservers and the DNS search paths are one object per tailnet, shared by both
+# clouds. Destroying it therefore removes tailnet access control for AWS *and*
+# GCP at once -- including the autoApprovers that authorise every subnet router's
+# routes, and the search paths that make priv.aws / priv.gcp resolve at all.
+#
+# The stack is deliberately NOT tagged `opt-in`. That tag means "skipped unless
+# asked for", which is wrong here -- both network stacks declare `after` on this
+# one and it must always deploy. The hazard is asymmetric: harmless to apply,
+# tailnet-wide to destroy. So the guard sits on destroy alone.
+#
+# Without it, `terramate script run --reverse destroy` from opentofu/ tears this
+# down as just another stack in the sweep. Someone tearing down ONE cloud loses
+# tailnet access for the other, and the failure looks like a routing problem
+# rather than a policy one -- routes stay advertised but unapproved.
+#
+# Usage:
+#   terramate script run --reverse destroy                       # skipped here
+#   TM_TAILNET_DESTROY=true terramate script run destroy         # actually runs
+#
+# The double-`$$` escape keeps Terramate from interpolating `${VAR:-default}`;
+# the literal `${...}` must reach bash. `${global.provisioner}` and
+# `${terramate.root...}` are intentional (Terramate-evaluated).
+
+script "destroy" {
+  name        = "Shared Tailscale Destroy (guarded)"
+  description = "Destroy the tailnet-wide singletons. Requires TM_TAILNET_DESTROY=true: this affects BOTH clouds"
+
+  job {
+    commands = [
+      ["bash", "-c", <<-BASH
+        if [ "$${TM_TAILNET_DESTROY:-}" != "true" ]; then
+          echo "[skip] shared/tailscale destroy: this stack owns the tailnet-wide ACL,"
+          echo "       DNS nameservers and search paths, shared by BOTH clouds."
+          echo "       Destroying it removes tailnet access control for AWS and GCP."
+          echo "       Set TM_TAILNET_DESTROY=true if that is genuinely what you want."
+          exit 0
+        fi
+        set -euo pipefail
+        bash "${terramate.root.path.fs.absolute}/scripts/terramate-destroy-confirm.sh"
+        # `destroy` is a standalone entrypoint: unlike `deploy` it can be the first
+        # tofu command run in a stack, so it has to init itself.
+        ${global.provisioner} init -lock-timeout=5m
+        ${global.provisioner} destroy -auto-approve -var-file=variables.tfvars
+      BASH
+      ],
+    ]
+  }
+}

--- a/scripts/gke-destroy-stage2.sh
+++ b/scripts/gke-destroy-stage2.sh
@@ -53,7 +53,12 @@ case "${mode}" in
 attempt)
   tofu init -lock-timeout=5m
 
-  if tofu destroy -auto-approve -var-file=variables.tfvars "$@"; then
+  # -refresh=false: this stack reads gke/init through terraform_remote_state,
+  # and refreshing that requires the upstream state object to exist. Once
+  # gke/init is destroyed its state is empty and no object is written, so the
+  # read fails hard. A destroy needs only this stack's own state, where the
+  # data source's last value is already cached.
+  if tofu destroy -refresh=false -auto-approve -var-file=variables.tfvars "$@"; then
     echo "[ok] stage 2 destroyed gracefully"
     exit 0
   fi


### PR DESCRIPTION
Three gaps in the Terramate gating and teardown paths, found by review and by
rebuilding both clouds from nothing on 2026-08-23. All three are fixable without
touching infrastructure, and all three are verified by running the guards rather
than by reading them.

## 1. The GCP opt-in gate was incomplete — and one gap could *build* things

Seven scripts are defined globally in `opentofu/workflows.tm.hcl`. The GCP
stacks overrode only three or four each:

| Stack | Overrode | Ran ungated |
|---|---|---|
| `gcp/network` | deploy, preview, drift detect, destroy | **init, drift reconcile, render** |
| `gke/init` | deploy, deploy-stage1, preview, destroy | **init, drift detect, drift reconcile, render** |
| `gke/configure` | deploy, preview, destroy | **init, drift detect, drift reconcile, render** |

`drift reconcile` is the one that made this urgent rather than untidy: the
global version runs `tofu apply -auto-approve`. A drift reconcile from
`opentofu/` would have **built GCP infrastructure with nobody opting in** —
precisely what `TM_GCP_ENABLED` exists to prevent.

All seven are now overridden in all three stacks. The guard is defined **once**
as `global.gcp_gate` in a new `opentofu/gcp/config.tm.hcl` rather than written
out fifteen times. That is not only DRY: writing it by hand is exactly how four
came to be missed. Each Terramate job is its own bash process, so the check
cannot be hoisted any further than a shared global.

## 2. `shared/tailscale` could be destroyed by a routine sweep, taking both clouds

Everything that stack owns is **tailnet-wide** — the ACL, the DNS nameservers,
the DNS search paths — one object per tailnet, shared by both clouds. It had no
workflow override, so `terramate script run --reverse destroy` from `opentofu/`
tore it down as just another stack in the sweep. Someone tearing down *one*
cloud would lose tailnet access control for the other, including the
autoApprovers that authorise every subnet router's routes — and it presents as a
routing failure rather than a policy one.

Now guarded on `TM_TAILNET_DESTROY`.

Deliberately **not** solved with the `opt-in` tag. That tag means "skipped
unless asked for", which is wrong for a stack both network stacks declare
`after` on and which must always deploy. The hazard is asymmetric — harmless to
apply, tailnet-wide to destroy — so only `destroy` is overridden and everything
else still inherits the global scripts.

## 3. `terraform_remote_state` made teardown fail once the upstream stack was gone

`gke/init` reads `network`, and `gke/configure` reads `gke/init`. Refreshing a
`terraform_remote_state` data source requires the upstream state **object** to
exist — and a destroyed stack has empty state, for which no object is written at
all. The read then fails hard:

```
Error: Unable to find remote state
No stored state was found for the given workspace in the given backend.
```

Yesterday's teardown could not proceed without `-refresh=false`. That flag is
now the default on those destroy paths, with the reasoning recorded inline: a
destroy needs only *this* stack's own state, where the data source's last value
is already cached. Refreshing adds a failure mode and buys nothing.

## Verification

Guards were exercised, not just inspected:

- `terramate script run init` in `gcp/network` (previously ungated) → stops at
  the gate, `[skip]`, no tofu executed.
- `terramate script run drift reconcile` in `gke/init` (the one that applies) →
  stops at the gate, no tofu executed.
- `terramate script run destroy` in `shared/tailscale` → stops at the gate, and
  `tofu state list` afterwards still shows all three tailnet singletons.
- `terramate list` parses all ten stacks; `tofu fmt` clean; `bash -n` and
  `shellcheck -x -S warning` clean on the modified script.

## Not included

The CNPG live-WAL-prefix collision — a recovering database fails if its live
prefix is non-empty, which took out both zitadel and harbor on the last rebuild
— is still unfixed. It is the same class as the load-balancer security groups
swept in #1818, one level down, and wants its own change.
