### PR TITLE
fix(gcp): two review-introduced bugs that blocked the GCP rebuild

### DIFF
--- a/opentofu/gcp/gke/init/outputs.tf
+++ b/opentofu/gcp/gke/init/outputs.tf
@@ -4,13 +4,24 @@ output "cluster_name" {
 }
 
 output "cluster_endpoint" {
-  # NOT sensitive. It is an RFC1918 address that gke/configure publishes into a
-  # ConfigMap anyway, and marking it here taints everything downstream: the taint
-  # propagates through yamlencode into the whole Flux vars ConfigMap, hiding that
-  # entire resource's diff from every plan. Hiding a plan diff to protect a
-  # private IP is a bad trade. The CA certificate below stays sensitive.
+  # Deliberately NOT sensitive. It is an RFC1918 address that gke/configure
+  # publishes into a ConfigMap anyway, and marking it taints everything
+  # downstream: the taint propagates through yamlencode into the whole Flux vars
+  # ConfigMap, hiding that entire resource's diff from every plan. Hiding a plan
+  # diff to protect a private IP is a bad trade. The CA certificate stays
+  # sensitive.
+  #
+  # nonsensitive() is REQUIRED, not decoration. The CFT module marks its
+  # `endpoint` output sensitive, and OpenTofu refuses a root output that derives
+  # from a sensitive value unless the intent is explicit:
+  #
+  #   Error: Output refers to sensitive values
+  #
+  # Simply dropping `sensitive = true` is therefore not enough -- which is how
+  # this shipped broken: the review that unmarked it ran after the only GCP
+  # deploy, so the change was never applied until the 2026-08-24 rebuild.
   description = "Private control-plane endpoint, consumed by gke/configure"
-  value       = module.gke.endpoint
+  value       = nonsensitive(module.gke.endpoint)
 }
 
 output "cluster_ca_certificate" {

--- a/opentofu/gcp/network/tailscale.tf
+++ b/opentofu/gcp/network/tailscale.tf
@@ -69,12 +69,25 @@ resource "tailscale_tailnet_key" "this" {
   ephemeral     = false
   preauthorized = true
 
-  # Explicit, long expiry. The provider defaults to 7776000s (90 days) and
-  # recreates a reusable key once it becomes invalid -- so at day 90 OpenTofu
-  # would mint a fresh key into state while the running instance keeps the old
-  # one. The instance would stay up but fail to rejoin on its next reboot, and it
-  # is the ONLY administrative path into this VPC.
-  expiry = 31536000 # 365 days
+  # 90 days is the CEILING, not a choice: Tailscale's key API rejects anything
+  # longer with
+  #   Error creating tailnet key: expirySeconds must be less than or equal to
+  #   7776000 (400)
+  #
+  # This was previously set to 31536000 (365 days) to stop OpenTofu re-minting
+  # the key at day 90. That reasoning was sound but the remedy is not available,
+  # and the value was never exercised: it was added by review AFTER the only GCP
+  # deploy, so the first apply that reached the API was the rebuild on
+  # 2026-08-24, which failed on it.
+  #
+  # Re-minting at day 90 is now benign anyway, for a reason that landed in the
+  # same review. The key reaches the instance through `metadata.startup-script`,
+  # which updates IN PLACE and no longer carries `ignore_changes` -- so a rotated
+  # key does propagate. The running node keeps its existing node key and stays
+  # connected; the next boot registers with the new auth key. The failure the old
+  # comment feared -- a fresh key in state that the instance never receives --
+  # was a property of ignore_changes, not of the expiry.
+  expiry = 7776000 # 90 days — the API maximum
 
   # Alphanumerics, spaces and dashes only. Tailscale's key API rejects other
   # characters with a bare `keys: description had invalid characters (400)` that


### PR DESCRIPTION
Two one-line bugs that made the GCP stacks unappliable. Both were found by
rebuilding GCP from nothing on 2026-08-24, and both come from the same place.

## The bugs

**1. `opentofu/gcp/network` — tailnet key expiry above the API maximum**

```
Error creating tailnet key: expirySeconds must be less than or equal to 7776000 (400)
```

`expiry` was `31536000` (365 days). Tailscale caps tailnet keys at `7776000`
(90 days), so the value was not a tuning question — it was rejected outright and
the network stack could not be created at all.

**2. `opentofu/gcp/gke/init` — output derived from a sensitive value**

```
Error: Output refers to sensitive values
  on outputs.tf line 6, in output "cluster_endpoint"
```

The CFT GKE module marks its `endpoint` output sensitive. OpenTofu refuses a
root output derived from a sensitive value unless the intent is explicit, so
dropping `sensitive = true` was not enough — it needs `nonsensitive()`.

## Why both shipped broken

Both lines were introduced by the OpenTofu review in #1818, which ran **after
the only GCP deploy of that session**. Everything following it was teardown. So
both were written, reviewed, merged, and never once executed until this
rebuild — where they failed immediately, in sequence.

`tofu validate` passes on both. It cannot know an API's numeric limits, and it
cannot know a module's sensitivity marks. Neither could any gate we currently
run: the only thing that catches this class is applying it.

Worth stating plainly because the review was reported as verified: it found real
problems and introduced two worse ones, and the branch carried no evidence
either way.

## The reasoning behind each change still holds

**Expiry.** The 365-day value existed to stop OpenTofu re-minting the key at day
90 and stranding the running instance with a key it no longer matches — on the
only administrative path into the VPC. That remedy is unavailable, but the
concern is now moot: the same review removed `ignore_changes` from the startup
script, and the key reaches the instance through `metadata.startup-script`,
which updates **in place**. A rotated key therefore propagates. The running node
keeps its node key and stays connected; the next boot registers with the new
auth key. The failure the old comment feared was a property of `ignore_changes`,
not of the expiry.

**Endpoint.** Still deliberately declassified. It is an RFC1918 address that
`gke/configure` publishes into a ConfigMap anyway, and marking it taints
everything downstream — the taint propagates through `yamlencode` into the whole
Flux vars ConfigMap and hides that resource's diff from every plan. Hiding a
plan diff to protect a private IP is a bad trade. The CA certificate stays
sensitive.

## Verification

Not `tofu validate` this time — an actual rebuild, which is the only thing that
would have caught either bug:

- `opentofu/gcp/network` applies: VPC, Cloud NAT, Cloud DNS, subnet router, and
  a 90-day tailnet key.
- `opentofu/gcp/gke/init` applies both stages: **21 resources added**.
- Cluster: 2 nodes `Ready` on k8s 1.35.6-gke.
- Cilium: 2 agents `Running`, `cilium-dbg status --brief` → **OK**.
- Flux: source Ready on `refs/heads/main`, **5/5 Kustomizations Ready**.
