### PR TITLE
feat(gcp): pin crossplane-configuration-gcp v0.2.0

### DIFF
--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -185,7 +185,7 @@ spec:
         - clone
         - --depth=1
         - --single-branch
-        - --branch=v0.1.0
+        - --branch=v0.2.0
         - https://github.com/Smana/crossplane-configuration.git
         - /repo/crossplane-configuration
       securityContext:

--- a/infrastructure/base/crossplane/README.md
+++ b/infrastructure/base/crossplane/README.md
@@ -61,9 +61,13 @@ because a `Provider` and a `ManagedResourceActivationPolicy` are cluster-scoped:
 | `providers/` | AWS | 5 provider packages, `aws-config` runtime config, activation policy, extra RBAC. |
 | `configuration/` | AWS | ProviderConfig (`PodIdentity`), `eks-environment`, the Configuration package pin. |
 | `providers-gcp/` | GCP | `provider-gcp-cloudplatform`, `gcp-config` runtime config, activation policy. |
-| `configuration-gcp/` | GCP | ProviderConfig (`InjectedIdentity` + `projectID`), `gke-environment`. No package pin yet. |
+| `configuration-gcp/` | GCP | ProviderConfig (`InjectedIdentity` + `projectID`), `gke-environment`, the Configuration package pin. |
 
-The GCP tree has no Configuration package because `crossplane-configuration-gcp` does not exist
-yet — that is the next piece of slice 5, and adding it is a two-PR cutover with `prune: disabled`
-on the first (packages adopt XRDs, but Flux prune deletes them in between, taking every claim with
-them).
+Both clouds pin their Configuration package by version. Bumping either one is a **two-PR cutover
+with `prune: disabled` on the first** whenever the XRDs it ships already exist on the cluster:
+a package *adopts* existing XRDs and preserves their uids, but Flux prune deletes them in the gap,
+and deleting an XRD destroys every claim it owns (#1774 / #1778).
+
+The GCP pin was introduced without that dance because no `GCPWorkloadIdentity` XRD or claim had ever
+existed on any cluster — nothing to adopt, nothing to destroy. That exemption is specific to a first
+install, and does not carry to the next cluster or the next bump.

--- a/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
@@ -1,0 +1,16 @@
+# The GCP XRDs and Compositions, published from Smana/crossplane-configuration.
+#
+# Only the -gcp package is declared. It pulls -core through its `dependsOn`, and
+# Crossplane creates that dependency itself under a registry-derived name
+# (smana-crossplane-configuration-core). Declaring -core here as well would leave
+# two Configuration objects for one package — the same reasoning as the AWS
+# tree's configuration-packages.yaml.
+#
+# v0.2.0 is the first release containing this package; v0.1.0 shipped only -core
+# and -aws, so there is no earlier tag to roll back to.
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: crossplane-configuration-gcp
+spec:
+  package: ghcr.io/smana/crossplane-configuration-gcp:v0.2.0

--- a/infrastructure/base/crossplane/configuration-gcp/kustomization.yaml
+++ b/infrastructure/base/crossplane/configuration-gcp/kustomization.yaml
@@ -5,13 +5,14 @@ namespace: crossplane-system
 # GCP counterpart to configuration/. What the CLUSTER owns, as opposed to the
 # API contract that ships in a package.
 #
-# NO Configuration package is declared yet, and that is the one real gap in this
-# tree. crossplane-configuration-gcp has to be released from
-# Smana/crossplane-configuration first; pointing at an unpublished OCI tag here
-# would leave the Kustomization failing to pull on every reconcile.
-#
-# Adding it is a two-PR cutover, not a one-line pin — see ../README.md.
+# The two-PR `prune: disabled` cutover described in ../README.md did NOT apply to
+# this pin, and the reason is worth keeping: that procedure exists because a
+# package ADOPTS existing XRDs while Flux prune deletes them in between, taking
+# every claim with them. No GCPWorkloadIdentity XRD or claim has ever existed on
+# any cluster, so there was nothing to adopt and nothing to destroy. It applies
+# again the moment this package reaches a second cluster.
 resources:
   - ../functions
   - cluster-providerconfig-gcp.yaml
+  - configuration-packages.yaml
   - environmentconfig.yaml

--- a/infrastructure/base/crossplane/configuration/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration/configuration-packages.yaml
@@ -12,4 +12,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-aws
 spec:
-  package: ghcr.io/smana/crossplane-configuration-aws:v0.1.0
+  package: ghcr.io/smana/crossplane-configuration-aws:v0.2.0

--- a/website/content/docs/platform/ai-platform/_index.md
+++ b/website/content/docs/platform/ai-platform/_index.md
@@ -29,7 +29,7 @@ plain Flux reconciliation both leave the cluster LLM-free.
 | **Autoscaling** | KEDA, three vLLM saturation triggers OR-combined, `min=1` (always warm) |
 | **Weights** | Amazon S3 Files (POSIX over S3), RWX PVC shared by a preload Job and the serving pod |
 | **GPUs** | Karpenter `gpu-l4` NodePool — single-GPU `g6` spot instances, Bottlerocket NVIDIA AMI, capped at 4 GPUs |
-| **Composition** | `crossplane-inference-service` KCL module `0.9.0`, pinned inside `crossplane-configuration-aws:v0.1.0` |
+| **Composition** | `crossplane-inference-service` KCL module `0.9.0`, pinned inside `crossplane-configuration-aws:v0.2.0` |
 
 ## Why self-host at all
 

--- a/website/content/docs/platform/developer-platform/_index.md
+++ b/website/content/docs/platform/developer-platform/_index.md
@@ -14,7 +14,7 @@ a version:
 ```yaml
 # infrastructure/base/crossplane/configuration/configuration-packages.yaml
 spec:
-  package: ghcr.io/smana/crossplane-configuration-aws:v0.1.0
+  package: ghcr.io/smana/crossplane-configuration-aws:v0.2.0
 ```
 
 What stays here: `functions.yaml` (the KCL function runtime, version-pinned

--- a/website/content/docs/platform/developer-platform/app-field-reference.md
+++ b/website/content/docs/platform/developer-platform/app-field-reference.md
@@ -17,11 +17,11 @@ they live in
 [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration),
 which this repo pins as a `Configuration` package
 (`infrastructure/base/crossplane/configuration/configuration-packages.yaml`,
-currently `ghcr.io/smana/crossplane-configuration-aws:v0.1.0`). This table was
+currently `ghcr.io/smana/crossplane-configuration-aws:v0.2.0`). This table was
 reconciled by hand against that repository's `apis/app/definition.yaml` (the
 CRD schema — types, enums, CEL rules) and `apis/app/kcl/main.k` (composition
 defaults that never appear in the schema, such as resource requests/limits or
-the gateway/route fallback names) at the commit tagged `v0.1.0`.
+the gateway/route fallback names) at the commit tagged `v0.2.0`.
 
 **To regenerate:** check out `Smana/crossplane-configuration` at the tag
 currently pinned above, and read `apis/app/definition.yaml` +

--- a/website/content/docs/platform/developer-platform/app-wizard.md
+++ b/website/content/docs/platform/developer-platform/app-wizard.md
@@ -29,7 +29,7 @@ The wizard clones **two** repositories at startup: this one (for the `App`
 schema, stacks, and its own config) and
 [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration)
 at the tag pinned in `apps/platform/app-wizard/app.yaml`'s
-`fetch-crossplane-configuration` init container — currently `v0.1.0`, the
+`fetch-crossplane-configuration` init container — currently `v0.2.0`, the
 same tag pinned in
 `infrastructure/base/crossplane/configuration/configuration-packages.yaml`.
 This is a deliberate coupling, not an accident: if the wizard's clone drifts


### PR DESCRIPTION
Wires the GCP Crossplane API released today as [`crossplane-configuration` v0.2.0](https://github.com/Smana/crossplane-configuration/releases/tag/v0.2.0). #1824 deliberately omitted this because the tag did not exist yet.

Completes workstream 5 of the [GCP support design](../blob/main/docs/superpowers/specs/2026-08-18-gcp-support-design.md).

## The AWS pin bump is not incidental

The schema catalog is derived from **one** pin. `gen-catalog.sh` reads `XPKG_SOURCE` — the *AWS* `configuration-packages.yaml` — and fetches that release's `xrd-crds.yaml` asset.

Left at `v0.1.0`, the catalog carries 5 XRDs and no `GCPWorkloadIdentity`, so the first GCP claim added to this repo would **hard-fail** validation under `skipMissingSchemas: false`. Loud rather than silent, but it makes the new API unusable here — a half-wired pin.

**The alternative was worse.** Teaching `gen-catalog.sh` to merge assets from several pins means handling CRDs that appear in both, and that script carries an explicit warning against growing conditional logic in the fetch, because a second seam is how the catalog drifts from what is actually installed. One version across both clouds keeps it a single seam.

**Safe because the AWS package did not change.** The `package.yaml` inside `crossplane-configuration-aws` `v0.1.0` and `v0.2.0` is byte-identical — 189403 bytes, same 6 kinds — verified by pulling both from ghcr.io rather than assuming it from the diff. The bump deploys the same content under a new revision.

It is also **not** the #1774 adopt-vs-prune case: the AWS XRDs are already package-owned, so there is nothing for Flux to delete in between.

Per CLAUDE.md, the App Wizard's `fetch-crossplane-configuration` clone tag moves in the same change — otherwise the form and render preview describe a different API version than the cluster serves.

## No `prune: disabled` cutover for the GCP pin

That procedure exists because a package *adopts* XRDs that Flux still holds in its inventory, and prune deletes them in the gap, taking every claim with them.

No `GCPWorkloadIdentity` XRD or claim has ever existed on any cluster — nothing to adopt, nothing to destroy. The exemption is specific to a first install and is recorded in the kustomization so it is not mistaken for the general rule. It applies again the moment this package reaches a second cluster.

## Documentation

Five website pages cited `v0.1.0` and **none are covered by `.doc-claims.yaml`**, so they would have gone stale silently. Updated. The crossplane README's per-cloud table now shows both pins and states the cutover rule once.

## Evidence

| Check | Result |
|---|---|
| `./scripts/validate-manifests.sh` | exit 0 — `Valid: 1216, Invalid: 0, Skipped: 0` |
| Schema catalog | now builds **6** XRD schemas incl. `gcpworkloadidentity_v1alpha1.json` (was 5) |
| Published schema matches shipped API | `serviceAccount` carries `name` only, root `required: [spec]`, roles pattern includes the numeric-project form |
| AWS package unchanged across releases | byte-identical `package.yaml`, pulled from ghcr.io |
| `./scripts/validate-links.sh` | exit 0 |
| `./scripts/validate-doc-claims.sh` | exit 0 |

The schema check is the meaningful one: it proves source → release → registry → catalog all line up, including the namespace-confinement fix made during review.

## Still not verified

Nothing here has run against a live GCP project. The provider has never authenticated and the composition has never created an IAM binding — design criteria 18–21 need a rebuild. A healthy `ClusterProviderConfig` proves nothing on its own; the first `ProjectIAMMember` is the real test of the Workload Identity binding.
