### PR TITLE
feat(gcp): private ingress and external-dns on gcp-0

### DIFF
--- a/.doc-claims.yaml
+++ b/.doc-claims.yaml
@@ -84,6 +84,33 @@ claims:
       - 'a single `?VMAlert'
       - 'one shared `?VMAlert'
 
+  - id: tailscale-gateway-general-hostname
+    why: >-
+      `gateway-general-priv` carries a `-${cluster_name}` suffix because the
+      tailnet is shared between aws-0 and gcp-0 and a Tailscale hostname is
+      tailnet-unique — see the comment in
+      platform-tailscale-general-gateway.yaml. private-access.md quotes this
+      annotation verbatim as the pattern to copy when adding a new Gateway;
+      a stale copy without the suffix reintroduces the exact hostname
+      collision the suffix exists to prevent.
+    source:
+      file: infrastructure/base/gapi/platform-tailscale-general-gateway.yaml
+      pattern: 'tailscale\.com/hostname:\s*"(gateway-general-priv-\$\{cluster_name\})"'
+    pages:
+      - website/content/docs/platform/networking/private-access.md
+    must_contain: '{value}'
+
+  - id: tailscale-gateway-admin-hostname
+    why: >-
+      Same claim as tailscale-gateway-general-hostname, for the admin
+      Gateway's hostname.
+    source:
+      file: infrastructure/base/gapi/platform-tailscale-admin-gateway.yaml
+      pattern: 'tailscale\.com/hostname:\s*"(gateway-admin-priv-\$\{cluster_name\})"'
+    pages:
+      - website/content/docs/platform/networking/private-access.md
+    must_contain: '{value}'
+
   - id: kyverno-policies-values
     why: >-
       Only the kyverno-policies release ships `values: {}`; the controller sets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,7 @@ via its own AppRole. Cluster-wide endpoints such as `sys/storage/raft/*` are cal
 - AWS CLI configured with appropriate permissions
 - Helm CLI (v3.12+), kubectl, bao CLI, jq
 - Tailscale account and API key
+- **GCP only:** three hand-created prerequisites — state bucket, Cloud KMS key ring, Tailscale OAuth client. See [`docs/gcp-bootstrap.md`](docs/gcp-bootstrap.md).
 
 **Tool versions managed via `mise.toml`**. Run `mise install` to install all required tools.
 

--- a/clusters/gcp-0/infrastructure/gapi.yaml
+++ b/clusters/gcp-0/infrastructure/gapi.yaml
@@ -12,9 +12,13 @@
 #   - security-tailscale, because without the operator both Gateways' Services
 #     sit Pending forever and nothing in their status names the reason.
 #
-# healthChecks on the Gateways rather than the Certificate: a Gateway going
-# Programmed proves the whole chain -- the operator serviced the LoadBalancer,
-# Cilium accepted the GatewayClass, and the TLS secret resolved.
+# healthChecks on the Gateways rather than the Certificate, but the literal
+# `healthChecks` form only asserts the objects EXIST -- Gateway API v1 has no
+# `Ready` condition and no top-level `observedGeneration`, so kstatus reports
+# Current the instant the Gateway is created, before the operator has serviced
+# the LoadBalancer, before Cilium has accepted the GatewayClass, before the TLS
+# secret resolves. healthCheckExprs below is what actually waits: it reads the
+# `Programmed` condition Cilium sets once the Gateway is genuinely serving.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -45,3 +49,8 @@ spec:
       kind: Gateway
       name: platform-tailscale-admin
       namespace: infrastructure
+  healthCheckExprs:
+    - apiVersion: gateway.networking.k8s.io/v1
+      kind: Gateway
+      failed: status.conditions.filter(c, c.type == 'Programmed').all(c, c.status == 'False')
+      current: status.conditions.filter(c, c.type == 'Programmed').all(c, c.status == 'True')

--- a/clusters/gcp-0/infrastructure/gapi.yaml
+++ b/clusters/gcp-0/infrastructure/gapi.yaml
@@ -1,0 +1,47 @@
+# Gateway API layer: the GatewayClass, both Tailscale Gateways, the wildcard
+# certificate and the L7-proxy network policy.
+#
+# TWO dependsOn edges, both load-bearing, and both learned the hard way in
+# workstream 11:
+#
+#   - security-openbao, because the wildcard Certificate cannot be issued before
+#     the `openbao` ClusterIssuer exists. It is also cert-manager's webhook that
+#     admits the Certificate, and applying a resource in the same reconcile as
+#     the chart that admits it fails with `no endpoints available` and then backs
+#     off exponentially -- while Flux reports Ready.
+#   - security-tailscale, because without the operator both Gateways' Services
+#     sit Pending forever and nothing in their status names the reason.
+#
+# healthChecks on the Gateways rather than the Certificate: a Gateway going
+# Programmed proves the whole chain -- the operator serviced the LoadBalancer,
+# Cilium accepted the GatewayClass, and the TLS secret resolved.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infrastructure-gapi
+  namespace: flux-system
+spec:
+  prune: true
+  interval: 4m0s
+  retryInterval: 30s
+  timeout: 10m0s
+  sourceRef:
+    kind: ExternalArtifact
+    name: infra-artifact
+  path: ./infrastructure/gcp-0/gapi
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: gke-gcp-0-vars
+  dependsOn:
+    - name: security-openbao
+    - name: security-tailscale
+  healthChecks:
+    - apiVersion: gateway.networking.k8s.io/v1
+      kind: Gateway
+      name: platform-tailscale-general
+      namespace: infrastructure
+    - apiVersion: gateway.networking.k8s.io/v1
+      kind: Gateway
+      name: platform-tailscale-admin
+      namespace: infrastructure

--- a/clusters/gcp-0/infrastructure/infrastructure.yaml
+++ b/clusters/gcp-0/infrastructure/infrastructure.yaml
@@ -26,6 +26,13 @@ spec:
   sourceRef:
     kind: ExternalArtifact
     name: infra-artifact
+  # external-dns's claim and HelmRelease are the first manifests under this path
+  # to reference ${var} (computeclass/* has none) -- without this, kustomize-
+  # controller applies the literal `${project_id}` text instead of substituting it.
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: gke-gcp-0-vars
   dependsOn:
     # Currently inert -- a ComputeClass is cluster-scoped and this path holds
     # nothing namespaced. Kept as future-proofing: this is the GCP cluster's only

--- a/clusters/gcp-0/infrastructure/infrastructure.yaml
+++ b/clusters/gcp-0/infrastructure/infrastructure.yaml
@@ -10,10 +10,12 @@
 # already builds from `@repo/infrastructure/**` — so the new directory needs no
 # generator change, only this Kustomization.
 #
-# No dependsOn: crds. The only resource here is a ComputeClass, whose CRD is
-# installed by GKE itself (`cloud.google.com/v1`, present on a fresh cluster)
-# rather than by crds/base. Adding that edge would couple this to a Kustomization
-# it does not need and delay it behind the whole upstream CRD set.
+# No dependsOn: crds. This path's ComputeClass CRD is installed by GKE itself
+# (`cloud.google.com/v1`, present on a fresh cluster) rather than by crds/base;
+# the one CRD this path does need from Crossplane (GCPWorkloadIdentity, below)
+# comes from the crossplane-configuration edge instead, so a second edge on
+# `crds` would only delay this Kustomization behind the whole upstream CRD set
+# for no ordering benefit.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -34,9 +36,17 @@ spec:
       - kind: ConfigMap
         name: gke-gcp-0-vars
   dependsOn:
-    # Currently inert -- a ComputeClass is cluster-scoped and this path holds
-    # nothing namespaced. Kept as future-proofing: this is the GCP cluster's only
-    # infrastructure Kustomization, so the first namespaced resource added here
-    # would otherwise race its namespace, which is a failure that presents as a
-    # dependency cascade rather than as a missing namespace.
+    # namespaces: this path now holds a namespaced HelmRelease (external-dns,
+    # in kube-system) alongside the cluster-scoped ComputeClass, so this edge is
+    # no longer future-proofing -- it is load-bearing for the HelmRelease's
+    # namespace to exist first.
     - name: namespaces
+    # crossplane-configuration: external-dns's GCPWorkloadIdentity claim needs
+    # both the `GCPWorkloadIdentity` CRD and the `gke-environment`
+    # EnvironmentConfig (for the projectID the claim omits), and both come from
+    # the crossplane-configuration-gcp package that Kustomization installs.
+    # Without this edge the claim applies before the package lands and fails
+    # with `no matches for kind "GCPWorkloadIdentity"` until the 1m retry
+    # converges -- self-healing, but a red Kustomization on every fresh deploy
+    # pointing at the wrong layer.
+    - name: crossplane-configuration

--- a/clusters/gcp-0/security/security-tailscale.yaml
+++ b/clusters/gcp-0/security/security-tailscale.yaml
@@ -1,0 +1,36 @@
+# The Tailscale Kubernetes Operator.
+#
+# Its own Kustomization rather than part of `security`, because the Gateway API
+# layer (infrastructure-gapi) must wait for it: without a running operator both
+# Gateways' Services sit Pending forever with no error naming the cause, since
+# nothing services loadBalancerClass: tailscale.
+#
+# dependsOn security-openbao rather than security: this needs External Secrets
+# RUNNING (to sync the OAuth client), and security-openbao is already gated on
+# that via security's HelmRelease health checks. Depending on the deepest edge
+# that implies the others keeps this graph honest instead of listing all three.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: security-tailscale
+  namespace: flux-system
+spec:
+  prune: true
+  interval: 4m0s
+  retryInterval: 30s
+  timeout: 8m0s
+  sourceRef:
+    kind: ExternalArtifact
+    name: security-artifact
+  path: ./security/gcp-0/tailscale-operator
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: gke-gcp-0-vars
+  dependsOn:
+    - name: security-openbao
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: tailscale-operator
+      namespace: tailscale

--- a/docs/gcp-bootstrap.md
+++ b/docs/gcp-bootstrap.md
@@ -1,0 +1,75 @@
+# GCP bootstrap prerequisites
+
+Three things must exist before `terramate script run deploy` can build GCP, and
+none of them is managed by OpenTofu. Each is deliberate — they are all
+chicken-and-egg or destructive-to-recreate — but three of them scattered across
+three files is how a repository quietly stops being reproducible. They are
+collected here.
+
+Run these once per GCP project.
+
+## 1. OpenTofu state bucket (ADR-0018)
+
+These steps set up the GCS backend introduced by ADR-0018
+(`website/content/docs/decisions/0018-per-cloud-opentofu-state.md`, PR
+#1831); until that merges, the GCP stacks read the shared S3 bucket named in
+each stack's `backend.tf` instead. Once it lands: state lives in GCS, in a
+project that holds nothing else, so that deleting or suspending the workload
+project cannot take the state describing it too.
+
+```bash
+gcloud projects create ogenki-tfstate --organization=<org-id>
+gcloud billing projects link ogenki-tfstate --billing-account=<account-id>
+gcloud services enable storage.googleapis.com --project=ogenki-tfstate
+gcloud storage buckets create gs://ogenki-cloud-native-ref-tfstate \
+  --project=ogenki-tfstate --location=europe-west4 \
+  --uniform-bucket-level-access --public-access-prevention
+gcloud storage buckets update gs://ogenki-cloud-native-ref-tfstate --versioning
+```
+
+Versioning is the recovery path for a truncated state file and is painful to add
+after the fact.
+
+## 2. Cloud KMS key ring for OpenBao auto-unseal
+
+Read as a data source by `opentofu/gcp/openbao/cluster/kms.tf`, never managed,
+because **GCP cannot delete either a key ring or a crypto key.** A `tofu destroy`
+of a managed one returns success while destroying only key VERSIONS, and a
+rebuild then fails with `ALREADY_EXISTS`.
+
+```bash
+gcloud services enable cloudkms.googleapis.com --project=ogenki-435905
+gcloud kms keyrings create openbao-dev --location=europe-west4 --project=ogenki-435905
+gcloud kms keys create openbao-unseal --location=europe-west4 \
+  --keyring=openbao-dev --purpose=encryption --project=ogenki-435905
+```
+
+It survives teardown by design and costs nothing idle. Do not treat it as a leak.
+
+## 3. Tailscale OAuth client for the Kubernetes operator
+
+Separate from the AWS cluster's client, so compromising one cluster's operator
+does not force rotating the other's.
+
+Create an OAuth client in the Tailscale admin console (Settings → OAuth clients)
+with scopes `devices:core` and `auth_keys` (write), tagged `tag:k8s-operator`,
+then:
+
+```bash
+printf '{"client_id":"%s","client_secret":"%s"}' "$CLIENT_ID" "$CLIENT_SECRET" \
+  | gcloud secrets create tailscale-k8s-operator-oauth \
+      --project=ogenki-435905 --replication-policy=automatic --data-file=-
+```
+
+The JSON keys are consumed verbatim by `dataFrom.extract` into the chart's
+required `operator-oauth` Secret — do not rename them.
+
+**Revoke this client on teardown** if the project is being decommissioned; it is
+the one prerequisite that is a live credential rather than an empty container.
+
+## What is NOT a prerequisite
+
+The offline root CA and the GCP intermediate. Those come from the signing
+ceremony in the [OpenBao design](superpowers/specs/2026-08-24-gcp-openbao-design.md)
+and already live in Secret Manager (`openbao-priv-gcp-ca-chain`,
+`openbao-priv-gcp-intermediate-ca`). The root's private key must never be in GCP.

--- a/docs/superpowers/plans/2026-08-25-gcp-private-ingress.md
+++ b/docs/superpowers/plans/2026-08-25-gcp-private-ingress.md
@@ -723,7 +723,7 @@ kustomize build infrastructure/gcp-0 --load-restrictor=LoadRestrictionsNone \
   | grep -A 3 "provider:"
 ```
 
-Expected: `Invalid: 0, Skipped: 0`, and the rendered values show `provider: {name: google}` with **no** `aws:` block and no `zoneType`.
+Expected: `Invalid: 0, Skipped: 0`, and the rendered values show `provider: {name: google}`. The base's `aws:` block (with its `zoneType`) and `global.imageRegistry` are still present -- the patch replaces only the fields it names (`provider`, `domainFilters`, `extraArgs`), and both are inert on chart 1.21.1 per ruling 2, so leaving them in the render is correct, not a regression to fix.
 
 Confirm the claim validates against the real XRD (this is what `skipMissingSchemas: false` buys):
 

--- a/docs/superpowers/plans/2026-08-25-gcp-private-ingress.md
+++ b/docs/superpowers/plans/2026-08-25-gcp-private-ingress.md
@@ -508,9 +508,13 @@ resources:
 #   - security-tailscale, because without the operator both Gateways' Services
 #     sit Pending forever and nothing in their status names the reason.
 #
-# healthChecks on the Gateways rather than the Certificate: a Gateway going
-# Programmed proves the whole chain -- the operator serviced the LoadBalancer,
-# Cilium accepted the GatewayClass, and the TLS secret resolved.
+# healthChecks on the Gateways rather than the Certificate, but the literal
+# `healthChecks` form only asserts the objects EXIST -- Gateway API v1 has no
+# `Ready` condition and no top-level `observedGeneration`, so kstatus reports
+# Current the instant the Gateway is created, before the operator has serviced
+# the LoadBalancer, before Cilium has accepted the GatewayClass, before the TLS
+# secret resolves. healthCheckExprs below is what actually waits: it reads the
+# `Programmed` condition Cilium sets once the Gateway is genuinely serving.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -541,6 +545,11 @@ spec:
       kind: Gateway
       name: platform-tailscale-admin
       namespace: infrastructure
+  healthCheckExprs:
+    - apiVersion: gateway.networking.k8s.io/v1
+      kind: Gateway
+      failed: status.conditions.filter(c, c.type == 'Programmed').all(c, c.status == 'False')
+      current: status.conditions.filter(c, c.type == 'Programmed').all(c, c.status == 'True')
 ```
 
 - [ ] **Step 3: Validate, and prove the public Gateway is absent**

--- a/docs/superpowers/plans/2026-08-25-gcp-private-ingress.md
+++ b/docs/superpowers/plans/2026-08-25-gcp-private-ingress.md
@@ -713,7 +713,7 @@ resources:
   - external-dns
 ```
 
-external-dns joins the existing `infrastructure` Kustomization rather than getting its own: it degrades gracefully when there is nothing to watch, so it needs no ordering edge. Its claim does need Crossplane, which `infrastructure` already sequences behind.
+external-dns joins the existing `infrastructure` Kustomization rather than getting its own: it degrades gracefully when there is nothing to watch, so it needs no ordering edge of its own. Its `GCPWorkloadIdentity` claim does need Crossplane, though — add `- name: crossplane-configuration` to `infrastructure`'s `dependsOn` (it is not there by default; this is the edge that closes finding 2 of the final review).
 
 - [ ] **Step 5: Validate, including that the AWS provider is gone**
 

--- a/docs/superpowers/plans/2026-08-25-gcp-private-ingress.md
+++ b/docs/superpowers/plans/2026-08-25-gcp-private-ingress.md
@@ -638,12 +638,19 @@ spec:
 # business in. domainFilters is a CLIENT-side filter and not a security
 # boundary; the IAM role is.
 #
-# imageRegistry is reset to the chart default: the base pins public.ecr.aws,
-# which works from GCP but makes every image pull on this cluster depend on an
-# AWS registry.
+# The base's `global.imageRegistry: public.ecr.aws` and its top-level `aws:`
+# block are deliberately NOT touched. Verified against
+# `helm show values external-dns/external-dns --version 1.21.1`: neither is a
+# chart value -- `global` supports only `imagePullSecrets`, and there is no
+# top-level `aws` key. Both are inert on both clouds. Overriding a setting that
+# does nothing, and writing a comment explaining why, would be two lies for the
+# price of one.
 #
-# txtOwnerId is ${cluster_name} on both clouds and they are now distinct (aws-0 /
-# gcp-0), so two clusters sharing a zone could not corrupt each other's registry.
+# GCP settings therefore go through extraArgs, because chart 1.21.1 has no
+# `google:` values block either.
+#
+# txtOwnerId stays at the base's ${cluster_name}. The two clusters are now
+# distinct (aws-0 / gcp-0), so their TXT registries cannot collide.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -651,8 +658,6 @@ metadata:
   namespace: kube-system
 spec:
   values:
-    global:
-      imageRegistry: ""
     provider:
       name: google
     domainFilters:
@@ -847,12 +852,44 @@ Expected: empty. Creating records is the easy half; a registry that never prunes
 
 - [ ] **Step 5: Criterion 7 — the ACL split is real**
 
-The two Gateways differ only by Tailscale tag, and the enforcement is outside Kubernetes. From a tailnet device that is **not** in `group:admin`:
+The two Gateways differ only by Tailscale tag, and the enforcement is outside Kubernetes.
+
+Deploy a second probe on the ADMIN Gateway. It goes in `kube-system` because that
+namespace is in the admin Gateway's `allowedRoutes` while `apps` is not — putting it in
+`apps` gets the route rejected `NotAllowedByListeners`, which reads as a broken app rather
+than a gateway ACL:
+
+```bash
+kubectl create deployment probe-admin --image=nginx:alpine -n kube-system
+kubectl expose deployment probe-admin --port=80 -n kube-system
+kubectl apply -f - <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: probe-admin
+  namespace: kube-system
+spec:
+  parentRefs:
+    - name: platform-tailscale-admin
+      namespace: infrastructure
+  hostnames:
+    - probe-admin.priv.gcp.ogenki.io
+  rules:
+    - backendRefs:
+        - name: probe-admin
+          port: 80
+EOF
+kubectl wait --for=condition=Accepted httproute/probe-admin -n kube-system --timeout=120s
+```
+
+Then, from a tailnet device that is **not** in `group:admin`:
 
 ```bash
 curl -sS -m 10 -o /dev/null -w 'general:%{http_code}\n' https://probe.priv.gcp.ogenki.io/ ; \
-curl -sS -m 10 -o /dev/null -w 'admin:%{http_code}\n' https://hubble-gcp-0.priv.gcp.ogenki.io/ || echo "admin: unreachable (expected)"
+curl -sS -m 10 -o /dev/null -w 'admin:%{http_code}\n' https://probe-admin.priv.gcp.ogenki.io/ || echo "admin: unreachable (expected)"
 ```
+
+Clean up both probes afterwards (`kubectl delete deployment,service,httproute probe-admin -n kube-system`).
 
 Expected: the general hostname answers; the admin one times out or refuses. If both answer, `tagOwners` or the ACL is not doing what the design claims and that is a finding, not a nuisance.
 

--- a/docs/superpowers/plans/2026-08-25-gcp-private-ingress.md
+++ b/docs/superpowers/plans/2026-08-25-gcp-private-ingress.md
@@ -1,0 +1,909 @@
+# GCP Private Ingress and external-dns Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `gcp-0` private ingress — two Tailscale-backed Gateways serving `*.priv.gcp.ogenki.io` with TLS from the OpenBao PKI, and DNS records maintained automatically in the private Cloud DNS zone.
+
+**Architecture:** Three cluster-side components. The tailscale-operator services `loadBalancerClass: tailscale`; the Gateway API layer is consumed **by file** from the existing cloud-neutral `infrastructure/base/gapi/`; external-dns runs the `google` provider with identity from a `GCPWorkloadIdentity` claim. Two new Flux Kustomizations enforce ordering with `dependsOn` plus health checks, because the components admit each other's resources through validating webhooks.
+
+**Tech Stack:** Flux (Kustomize + Helm), Cilium Gateway API, Tailscale Kubernetes Operator 1.90.6, external-dns 1.21.1, Crossplane (`GCPWorkloadIdentity` from `crossplane-configuration-gcp:v0.2.0`), OpenTofu, GCP Cloud DNS + Secret Manager.
+
+**Spec:** [`docs/superpowers/specs/2026-08-25-gcp-private-ingress-design.md`](../specs/2026-08-25-gcp-private-ingress-design.md)
+
+## Global Constraints
+
+- **Cluster names**: `aws-0` and `gcp-0`. Renamed in #1832; never write `mycluster-0`.
+- **GCP project**: `ogenki-435905`. Project number `323586397743`. Region `europe-west4`, zone `europe-west4-a`.
+- **Private domain**: `priv.gcp.ogenki.io` on GCP, `priv.aws.ogenki.io` on AWS. Always reach it through `${private_domain_name}`, never a literal.
+- **DNS role**: `projects/ogenki-435905/roles/xplane_dns_editor` — already created and allowlisted in `crossplane_grantable_roles` (`opentofu/gcp/gke/init/iam.tf`). Do not create it.
+- **No public certificates, no public Gateway.** Excluded by the spec. Never add `platform-public-gateway.yaml` to a GCP kustomization.
+- **No `ProxyGroup`.** AWS runs egress proxies; GCP has no consumer. YAGNI.
+- **By-file references across directories are correct here** — Flux and `scripts/flux-schema/render-bundle.py` both build with `--load-restrictor=LoadRestrictionsNone`. Do not "fix" them into directory references.
+- **Namespaces**: tailscale-operator → `tailscale`; external-dns → `kube-system`; Gateways → `infrastructure`; External Secrets controller SA → `security/external-secrets`.
+- **Evidence rule** (`.claude/rules/process.md`): no "done" without a fresh command run cited inline. `./scripts/validate-manifests.sh` must report `Invalid: 0, Skipped: 0`.
+- **Standing user rule: never leave test infrastructure running.** Task 6 ends with a verified teardown.
+
+---
+
+### Task 1: Parameterise the Gateway Tailscale hostnames
+
+Both Gateways hardcode a Tailscale hostname. Two clusters cannot claim the same one — Tailscale silently suffixes the loser, making its MagicDNS name unpredictable. This is the one task that touches AWS-consumed manifests.
+
+**Files:**
+- Modify: `infrastructure/base/gapi/platform-tailscale-general-gateway.yaml`
+- Modify: `infrastructure/base/gapi/platform-tailscale-admin-gateway.yaml`
+
+**Interfaces:**
+- Consumes: `${cluster_name}` from both clusters' vars ConfigMaps (`eks-aws-0-vars`, `gke-gcp-0-vars`) — already present, no new variable.
+- Produces: device hostnames `gateway-general-priv-aws-0`, `gateway-admin-priv-aws-0`, `gateway-general-priv-gcp-0`, `gateway-admin-priv-gcp-0`.
+
+- [ ] **Step 1: Change the general Gateway's hostname**
+
+In `infrastructure/base/gapi/platform-tailscale-general-gateway.yaml`, replace the `tailscale.com/hostname` line inside `spec.infrastructure.annotations`:
+
+```yaml
+  infrastructure:
+    annotations:
+      # Per-cluster, because the tailnet is SHARED between aws-0 and gcp-0 and a
+      # Tailscale hostname is tailnet-unique. Two clusters claiming
+      # "gateway-general-priv" does not error -- Tailscale suffixes the second
+      # device, so its MagicDNS name silently stops being the one anything
+      # expects.
+      #
+      # <role>-<visibility>-<cluster> rather than a suffix that is empty on AWS:
+      # a scheme where one cloud is the unlabelled default is exactly what
+      # ADR-0017 rejects for DNS names, and cluster names were renamed to aws-0 /
+      # gcp-0 in #1832 for the same reason.
+      tailscale.com/hostname: "gateway-general-priv-${cluster_name}"
+      tailscale.com/tags: "tag:k8s"
+      tailscale.com/funnel: "false"
+```
+
+- [ ] **Step 2: Change the admin Gateway's hostname**
+
+In `infrastructure/base/gapi/platform-tailscale-admin-gateway.yaml`, apply the same change with the admin values (keep its existing `tailscale.com/tags: "tag:admin"` line unchanged):
+
+```yaml
+      tailscale.com/hostname: "gateway-admin-priv-${cluster_name}"
+```
+
+Add a one-line comment pointing at the general Gateway rather than repeating the paragraph:
+
+```yaml
+      # Per-cluster hostname -- see platform-tailscale-general-gateway.yaml for why.
+```
+
+- [ ] **Step 3: Verify both hostnames render per cluster**
+
+Run:
+
+```bash
+kustomize build infrastructure/aws-0 --load-restrictor=LoadRestrictionsNone \
+  | grep 'tailscale.com/hostname'
+```
+
+Expected: two lines, both still containing the literal `${cluster_name}` — kustomize does not substitute; Flux does. This step only proves the annotation survives the build.
+
+Then prove substitution end-to-end through the repo's own renderer:
+
+```bash
+./scripts/validate-manifests.sh 2>&1 | grep -E "RENDER:|Invalid:"
+grep -rn "gateway-general-priv" .bundle/ | head -4
+```
+
+Expected: `Invalid: 0, Skipped: 0`, and the rendered bundle shows `gateway-general-priv-foobar` (the fixture value of `cluster_name` in `scripts/flux-schema/render-bundle.py`), **not** a bare `${cluster_name}`. A literal `${...}` surviving into the bundle means the variable is not in the ConfigMap and Flux would render it unsubstituted while reporting success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infrastructure/base/gapi/
+git commit -m "refactor(gapi): per-cluster Tailscale hostnames on the private Gateways"
+```
+
+---
+
+### Task 2: Bootstrap prerequisites — Tailscale OAuth client, IAM, and one documented procedure
+
+The tailscale-operator authenticates with a Tailscale OAuth client. AWS reads one from AWS Secrets Manager; GCP gets **its own**, so compromising one cluster's operator does not force rotating the other's.
+
+This task also pays down debt the spec flags: GCP now has three hand-created prerequisites (Cloud KMS key ring, the OpenTofu state bucket and its project, this OAuth client) documented in three unrelated files. Three undocumented steps is how a repository stops being reproducible.
+
+**Files:**
+- Create: `docs/gcp-bootstrap.md`
+- Modify: `opentofu/gcp/gke/init/iam.tf`
+- Modify: `opentofu/gcp/gke/init/variables.tf`
+
+**Interfaces:**
+- Consumes: `data.google_project.this.number` (already in `iam.tf`), `var.project_id`.
+- Produces: GCP Secret Manager entry `tailscale-k8s-operator-oauth`, readable by the External Secrets controller principal.
+
+- [ ] **Step 1: Create the OAuth client and store it**
+
+In the Tailscale admin console (Settings → OAuth clients), create a client with scopes `devices:core` and `auth_keys` (write), tagged `tag:k8s-operator`. Then:
+
+```bash
+CLIENT_ID='<paste>'
+CLIENT_SECRET='<paste>'
+printf '{"client_id":"%s","client_secret":"%s"}' "$CLIENT_ID" "$CLIENT_SECRET" \
+  | gcloud secrets create tailscale-k8s-operator-oauth \
+      --project=ogenki-435905 --replication-policy=automatic --data-file=-
+```
+
+The JSON keys `client_id` and `client_secret` are what the chart's `operator-oauth` Secret requires; `dataFrom.extract` in Task 3 copies them verbatim, so do not rename them.
+
+Verify:
+
+```bash
+gcloud secrets versions access latest --secret=tailscale-k8s-operator-oauth \
+  --project=ogenki-435905 | jq -r 'keys | join(",")'
+```
+
+Expected: `client_id,client_secret`
+
+- [ ] **Step 2: Add the External Secrets identity variables**
+
+Append to `opentofu/gcp/gke/init/variables.tf`:
+
+```hcl
+variable "external_secrets_namespace" {
+  description = "Namespace of the External Secrets controller's ServiceAccount. Part of the Workload Identity subject, so it must match the cluster exactly."
+  type        = string
+  default     = "security"
+}
+
+variable "external_secrets_service_account" {
+  description = "Name of the External Secrets controller's ServiceAccount. Part of the Workload Identity subject; a mismatch produces a binding the API accepts and that never matches."
+  type        = string
+  default     = "external-secrets"
+}
+
+variable "tailscale_oauth_secret_name" {
+  description = "GCP Secret Manager entry holding the Tailscale OAuth client for the Kubernetes operator. Created by hand -- see docs/gcp-bootstrap.md."
+  type        = string
+  default     = "tailscale-k8s-operator-oauth"
+}
+```
+
+- [ ] **Step 3: Bind External Secrets to that one secret**
+
+Append to `opentofu/gcp/gke/init/iam.tf`:
+
+```hcl
+# External Secrets' access to the Tailscale OAuth client.
+#
+# PER-SECRET, not through GCPWorkloadIdentity, for the same reason
+# opentofu/gcp/openbao/management/iam.tf binds per secret: that composition
+# renders ProjectIAMMember, which is PROJECT-scoped, so any secret-reading role
+# granted through it can read every secret in the project by name -- including
+# OpenBao's root token and the intermediate CA's private key.
+#
+# The subject duplicates the one in openbao/management deliberately rather than
+# being shared: the two stacks have no dependency edge, and a remote-state read
+# purely to avoid restating two strings would create one.
+locals {
+  # TRAP: `projects/` takes the project NUMBER while `workloadIdentityPools/`
+  # takes the project ID. Reversed, the API ACCEPTS the binding and it silently
+  # never matches.
+  external_secrets_principal = join("", [
+    "principal://iam.googleapis.com/projects/${data.google_project.this.number}",
+    "/locations/global/workloadIdentityPools/${var.project_id}.svc.id.goog",
+    "/subject/ns/${var.external_secrets_namespace}/sa/${var.external_secrets_service_account}",
+  ])
+}
+
+resource "google_secret_manager_secret_iam_member" "external_secrets_tailscale_oauth" {
+  project   = var.project_id
+  secret_id = var.tailscale_oauth_secret_name
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.external_secrets_principal
+}
+```
+
+- [ ] **Step 4: Validate the stack**
+
+```bash
+cd opentofu/gcp/gke/init
+tofu fmt && tofu init -backend=false -input=false >/dev/null && tofu validate
+```
+
+Expected: `Success! The configuration is valid` (warnings about a deprecated `kubernetes_config_map` are pre-existing and fine).
+
+If `tofu init` fails with `invalid ref: "<sha>"`, that is transient GitHub throttling on module downloads — re-run it. It is not caused by this change.
+
+- [ ] **Step 5: Write the consolidated bootstrap document**
+
+Create `docs/gcp-bootstrap.md`:
+
+```markdown
+# GCP bootstrap prerequisites
+
+Three things must exist before `terramate script run deploy` can build GCP, and
+none of them is managed by OpenTofu. Each is deliberate — they are all
+chicken-and-egg or destructive-to-recreate — but three of them scattered across
+three files is how a repository quietly stops being reproducible. They are
+collected here.
+
+Run these once per GCP project.
+
+## 1. OpenTofu state bucket (ADR-0018)
+
+State lives in GCS, in a project that holds nothing else, so that deleting or
+suspending the workload project cannot take the state describing it too.
+
+```bash
+gcloud projects create ogenki-tfstate --organization=<org-id>
+gcloud billing projects link ogenki-tfstate --billing-account=<account-id>
+gcloud services enable storage.googleapis.com --project=ogenki-tfstate
+gcloud storage buckets create gs://ogenki-cloud-native-ref-tfstate \
+  --project=ogenki-tfstate --location=europe-west4 \
+  --uniform-bucket-level-access --public-access-prevention
+gcloud storage buckets update gs://ogenki-cloud-native-ref-tfstate --versioning
+```
+
+Versioning is the recovery path for a truncated state file and is painful to add
+after the fact.
+
+## 2. Cloud KMS key ring for OpenBao auto-unseal
+
+Read as a data source by `opentofu/gcp/openbao/cluster/kms.tf`, never managed,
+because **GCP cannot delete either a key ring or a crypto key.** A `tofu destroy`
+of a managed one returns success while destroying only key VERSIONS, and a
+rebuild then fails with `ALREADY_EXISTS`.
+
+```bash
+gcloud services enable cloudkms.googleapis.com --project=ogenki-435905
+gcloud kms keyrings create openbao-dev --location=europe-west4 --project=ogenki-435905
+gcloud kms keys create openbao-unseal --location=europe-west4 \
+  --keyring=openbao-dev --purpose=encryption --project=ogenki-435905
+```
+
+It survives teardown by design and costs nothing idle. Do not treat it as a leak.
+
+## 3. Tailscale OAuth client for the Kubernetes operator
+
+Separate from the AWS cluster's client, so compromising one cluster's operator
+does not force rotating the other's.
+
+Create an OAuth client in the Tailscale admin console (Settings → OAuth clients)
+with scopes `devices:core` and `auth_keys` (write), tagged `tag:k8s-operator`,
+then:
+
+```bash
+printf '{"client_id":"%s","client_secret":"%s"}' "$CLIENT_ID" "$CLIENT_SECRET" \
+  | gcloud secrets create tailscale-k8s-operator-oauth \
+      --project=ogenki-435905 --replication-policy=automatic --data-file=-
+```
+
+The JSON keys are consumed verbatim by `dataFrom.extract` into the chart's
+required `operator-oauth` Secret — do not rename them.
+
+**Revoke this client on teardown** if the project is being decommissioned; it is
+the one prerequisite that is a live credential rather than an empty container.
+
+## What is NOT a prerequisite
+
+The offline root CA and the GCP intermediate. Those come from the signing
+ceremony in the [OpenBao design](superpowers/specs/2026-08-24-gcp-openbao-design.md)
+and already live in Secret Manager (`openbao-priv-gcp-ca-chain`,
+`openbao-priv-gcp-intermediate-ca`). The root's private key must never be in GCP.
+```
+
+- [ ] **Step 6: Link the document from CLAUDE.md**
+
+In `CLAUDE.md`, under the `### Prerequisites` bullet list, add:
+
+```markdown
+- **GCP only:** three hand-created prerequisites — state bucket, Cloud KMS key ring, Tailscale OAuth client. See [`docs/gcp-bootstrap.md`](docs/gcp-bootstrap.md).
+```
+
+- [ ] **Step 7: Verify links and commit**
+
+```bash
+./scripts/validate-links.sh
+git add docs/gcp-bootstrap.md CLAUDE.md opentofu/gcp/gke/init/
+git commit -m "feat(gcp): Tailscale OAuth bootstrap secret, and one bootstrap doc"
+```
+
+Expected: `validate-links.sh` exit 0.
+
+---
+
+### Task 3: tailscale-operator on gcp-0
+
+**Files:**
+- Create: `security/gcp-0/tailscale-operator/kustomization.yaml`
+- Create: `security/gcp-0/tailscale-operator/oauth-client-externalsecret.yaml`
+- Create: `clusters/gcp-0/security/security-tailscale.yaml`
+
+**Interfaces:**
+- Consumes: `clustersecretstore` (ClusterSecretStore, from workstream 11); Secret Manager entry `tailscale-k8s-operator-oauth` (Task 2).
+- Produces: a running operator that services `loadBalancerClass: tailscale`; Flux Kustomization named `security-tailscale`, which Task 4 depends on.
+
+- [ ] **Step 1: Create the OAuth ExternalSecret**
+
+`security/gcp-0/tailscale-operator/oauth-client-externalsecret.yaml`:
+
+```yaml
+# The Tailscale OAuth client the operator authenticates with.
+#
+# GCP has its OWN client, not a copy of the AWS one: compromising this cluster's
+# operator should not force rotating the other cluster's. Created by hand --
+# docs/gcp-bootstrap.md -- because it is issued by the Tailscale admin console.
+#
+# `dataFrom.extract` copies the JSON's keys verbatim, so the Secret ends up with
+# client_id / client_secret, which is what the chart requires. The target NAME is
+# also fixed by the chart and must stay `operator-oauth`.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tailscale-operator-oauth-client
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        key: tailscale-k8s-operator-oauth
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: clustersecretstore
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: operator-oauth
+```
+
+Note there is no `namespace:` in `metadata` — the kustomization sets it, matching the AWS tree.
+
+- [ ] **Step 2: Create the kustomization**
+
+`security/gcp-0/tailscale-operator/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tailscale
+
+# The chart and both ProxyClasses come from security/base BY FILE, not by
+# directory. The base directory also carries oauth-client-externalsecret.yaml,
+# whose `key: tailscale/k8s-operator/oauth-client` is an AWS Secrets Manager
+# path -- pulling the directory would bring a store reference that cannot
+# resolve here, and its target Secret name would collide with ours.
+#
+# Referencing the chart by file keeps a version bump landing on both clouds at
+# once. Flux builds with LoadRestrictionsNone, as does
+# scripts/flux-schema/render-bundle.py, so a cross-directory file reference is
+# supported rather than tolerated.
+#
+# NO proxygroup.yaml. AWS runs `ts-proxies`, two EGRESS replicas; nothing on
+# this cluster egresses through the tailnet. Add it when something does.
+resources:
+  - ../../base/tailscale-operator/helmrelease.yaml
+  - ../../base/tailscale-operator/proxyclass-general.yaml
+  - ../../base/tailscale-operator/proxyclass-admin.yaml
+  - oauth-client-externalsecret.yaml
+```
+
+- [ ] **Step 3: Create the Flux Kustomization**
+
+`clusters/gcp-0/security/security-tailscale.yaml`:
+
+```yaml
+# The Tailscale Kubernetes Operator.
+#
+# Its own Kustomization rather than part of `security`, because the Gateway API
+# layer (infrastructure-gapi) must wait for it: without a running operator both
+# Gateways' Services sit Pending forever with no error naming the cause, since
+# nothing services loadBalancerClass: tailscale.
+#
+# dependsOn security-openbao rather than security: this needs External Secrets
+# RUNNING (to sync the OAuth client), and security-openbao is already gated on
+# that via security's HelmRelease health checks. Depending on the deepest edge
+# that implies the others keeps this graph honest instead of listing all three.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: security-tailscale
+  namespace: flux-system
+spec:
+  prune: true
+  interval: 4m0s
+  retryInterval: 30s
+  timeout: 8m0s
+  sourceRef:
+    kind: ExternalArtifact
+    name: security-artifact
+  path: ./security/gcp-0/tailscale-operator
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: gke-gcp-0-vars
+  dependsOn:
+    - name: security-openbao
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: tailscale-operator
+      namespace: tailscale
+```
+
+- [ ] **Step 4: Validate**
+
+```bash
+./scripts/validate-manifests.sh 2>&1 | grep -E "RENDER:|Invalid:"
+kustomize build security/gcp-0/tailscale-operator --load-restrictor=LoadRestrictionsNone \
+  | grep -E "^kind:|  name:|  namespace:"
+```
+
+Expected: `Invalid: 0, Skipped: 0`; and the build shows a HelmRelease `tailscale-operator`, two ProxyClasses (`general`, `admin`), and one ExternalSecret `tailscale-operator-oauth-client` — **all in namespace `tailscale`**, with no ProxyGroup and no second ExternalSecret.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add security/gcp-0/tailscale-operator/ clusters/gcp-0/security/security-tailscale.yaml
+git commit -m "feat(gcp): tailscale-operator on gcp-0"
+```
+
+---
+
+### Task 4: Gateway API layer on gcp-0
+
+**Files:**
+- Create: `infrastructure/gcp-0/gapi/kustomization.yaml`
+- Create: `clusters/gcp-0/infrastructure/gapi.yaml`
+
+**Interfaces:**
+- Consumes: `security-tailscale` (Task 3); the `openbao` ClusterIssuer from workstream 11; `${private_domain_name}` and `${cluster_name}` from `gke-gcp-0-vars`.
+- Produces: Gateways `platform-tailscale-general` and `platform-tailscale-admin` in namespace `infrastructure`, both labelled `external-dns: enabled`, which Task 5's external-dns watches.
+
+- [ ] **Step 1: Create the kustomization**
+
+`infrastructure/gcp-0/gapi/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: infrastructure
+
+# Six of the seven manifests in infrastructure/base/gapi are cloud-neutral and
+# are used verbatim. Referenced BY FILE because the seventh is not:
+#
+#   platform-public-gateway.yaml carries
+#   service.beta.kubernetes.io/aws-load-balancer-* annotations and
+#   cert-manager.io/cluster-issuer: letsencrypt-prod. It is the PUBLIC path,
+#   which this cluster deliberately does not build -- see the design's "What this
+#   deliberately does NOT build". Adding it here would also require solving
+#   DNS-01 against a public zone GCP does not have.
+#
+# platform-private-gateway-certificate.yaml needs no GCP variant at all: it asks
+# the `openbao` ClusterIssuer for *.${private_domain_name}, and workstream 11
+# verified that issuer end to end on this cluster.
+#
+# Using loadBalancerClass: tailscale rather than a GCP forwarding rule means the
+# private gateways incur no cloud load-balancer charges.
+resources:
+  - ../../base/gapi/tailscale-gatewayclass.yaml
+  - ../../base/gapi/tailscale-gatewayclass-config.yaml
+  - ../../base/gapi/platform-tailscale-general-gateway.yaml
+  - ../../base/gapi/platform-tailscale-admin-gateway.yaml
+  - ../../base/gapi/platform-private-gateway-certificate.yaml
+  - ../../base/gapi/allow-gateway-l7-proxy.yaml
+```
+
+- [ ] **Step 2: Create the Flux Kustomization**
+
+`clusters/gcp-0/infrastructure/gapi.yaml`:
+
+```yaml
+# Gateway API layer: the GatewayClass, both Tailscale Gateways, the wildcard
+# certificate and the L7-proxy network policy.
+#
+# TWO dependsOn edges, both load-bearing, and both learned the hard way in
+# workstream 11:
+#
+#   - security-openbao, because the wildcard Certificate cannot be issued before
+#     the `openbao` ClusterIssuer exists. It is also cert-manager's webhook that
+#     admits the Certificate, and applying a resource in the same reconcile as
+#     the chart that admits it fails with `no endpoints available` and then backs
+#     off exponentially -- while Flux reports Ready.
+#   - security-tailscale, because without the operator both Gateways' Services
+#     sit Pending forever and nothing in their status names the reason.
+#
+# healthChecks on the Gateways rather than the Certificate: a Gateway going
+# Programmed proves the whole chain -- the operator serviced the LoadBalancer,
+# Cilium accepted the GatewayClass, and the TLS secret resolved.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infrastructure-gapi
+  namespace: flux-system
+spec:
+  prune: true
+  interval: 4m0s
+  retryInterval: 30s
+  timeout: 10m0s
+  sourceRef:
+    kind: ExternalArtifact
+    name: infra-artifact
+  path: ./infrastructure/gcp-0/gapi
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: gke-gcp-0-vars
+  dependsOn:
+    - name: security-openbao
+    - name: security-tailscale
+  healthChecks:
+    - apiVersion: gateway.networking.k8s.io/v1
+      kind: Gateway
+      name: platform-tailscale-general
+      namespace: infrastructure
+    - apiVersion: gateway.networking.k8s.io/v1
+      kind: Gateway
+      name: platform-tailscale-admin
+      namespace: infrastructure
+```
+
+- [ ] **Step 3: Validate, and prove the public Gateway is absent**
+
+```bash
+./scripts/validate-manifests.sh 2>&1 | grep -E "RENDER:|Invalid:"
+kustomize build infrastructure/gcp-0/gapi --load-restrictor=LoadRestrictionsNone \
+  | grep -E "^kind:|^  name:"
+```
+
+Expected: `Invalid: 0, Skipped: 0`; exactly one `GatewayClass`, one `CiliumGatewayClassConfig`, two `Gateway`s, one `Certificate`, one `CiliumClusterwideNetworkPolicy` — and **no `platform-public` Gateway**.
+
+Confirm no AWS-only annotation leaked in:
+
+```bash
+kustomize build infrastructure/gcp-0/gapi --load-restrictor=LoadRestrictionsNone \
+  | grep -c "aws-load-balancer"
+```
+
+Expected: `0`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infrastructure/gcp-0/gapi/ clusters/gcp-0/infrastructure/gapi.yaml
+git commit -m "feat(gcp): Tailscale Gateways and the private wildcard certificate"
+```
+
+---
+
+### Task 5: external-dns with the google provider
+
+**Files:**
+- Create: `infrastructure/gcp-0/external-dns/kustomization.yaml`
+- Create: `infrastructure/gcp-0/external-dns/helmrelease.yaml`
+- Create: `infrastructure/gcp-0/external-dns/workloadidentity.yaml`
+- Modify: `infrastructure/gcp-0/kustomization.yaml`
+
+**Interfaces:**
+- Consumes: `${private_domain_name}`, `${project_id}`, `${cluster_name}` from `gke-gcp-0-vars`; the custom role `projects/ogenki-435905/roles/xplane_dns_editor`; the Gateways from Task 4 (as watch targets).
+- Produces: DNS records under `priv.gcp.ogenki.io` with a TXT registry owned by `gcp-0`.
+
+- [ ] **Step 1: Create the GCPWorkloadIdentity claim**
+
+`infrastructure/gcp-0/external-dns/workloadidentity.yaml`:
+
+```yaml
+# external-dns's Google identity.
+#
+# This is the GCPWorkloadIdentity composition's FIRST consumer, and the call is
+# deliberately the opposite of workstream 11's. There, External Secrets needed
+# exactly two named secrets, and this composition renders ProjectIAMMember --
+# project-scoped -- which would have granted read of every secret in the project
+# including the intermediate CA's private key. So it was bound per secret and
+# this API was left without a consumer.
+#
+# external-dns's access genuinely IS project-shaped: it must discover which zone
+# owns a name, which needs dns.managedZones.list ACROSS the project. A per-zone
+# google_dns_managed_zone_iam_member cannot express that.
+#
+# xplane_dns_editor (opentofu/gcp/gke/init/iam.tf) holds record and change
+# permissions plus read-only on zones -- no zone create or delete. It is
+# allowlisted in crossplane_grantable_roles; a role outside that list fails at
+# the provider with a message naming it.
+#
+# The claim lives in kube-system because the composition derives the
+# ServiceAccount's namespace from the claim's own, and that is where external-dns
+# runs. No annotation is added to the ServiceAccount: GKE Workload Identity binds
+# by SUBJECT.
+apiVersion: cloud.ogenki.io/v1alpha1
+kind: GCPWorkloadIdentity
+metadata:
+  name: xplane-external-dns
+  namespace: kube-system
+spec:
+  serviceAccount:
+    name: external-dns
+  roles:
+    - "projects/${project_id}/roles/xplane_dns_editor"
+```
+
+- [ ] **Step 2: Create the HelmRelease patch**
+
+`infrastructure/gcp-0/external-dns/helmrelease.yaml`:
+
+```yaml
+# GCP overrides for the shared external-dns release.
+#
+# provider: google, and ONE domain filter. AWS filters two zones because it owns
+# a public one; this cluster has only the private Cloud DNS zone --
+# cloud.ogenki.io is a Route53 zone this repository does not manage, and public
+# certificates are out of scope by design.
+#
+# --google-zone-visibility=private stops it enumerating public zones it has no
+# business in. domainFilters is a CLIENT-side filter and not a security
+# boundary; the IAM role is.
+#
+# imageRegistry is reset to the chart default: the base pins public.ecr.aws,
+# which works from GCP but makes every image pull on this cluster depend on an
+# AWS registry.
+#
+# txtOwnerId is ${cluster_name} on both clouds and they are now distinct (aws-0 /
+# gcp-0), so two clusters sharing a zone could not corrupt each other's registry.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns
+  namespace: kube-system
+spec:
+  values:
+    global:
+      imageRegistry: ""
+    provider:
+      name: google
+    domainFilters:
+      - ${private_domain_name}
+    extraArgs:
+      - --google-project=${project_id}
+      - --google-zone-visibility=private
+      - --gateway-namespace=infrastructure
+      - --gateway-label-filter=external-dns=enabled
+      - --min-event-sync-interval=30s
+```
+
+- [ ] **Step 3: Create the kustomization**
+
+`infrastructure/gcp-0/external-dns/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+
+# The chart release by file -- the base DIRECTORY is AWS-shaped in its values
+# (provider aws, two domain filters, an ECR registry), which the patch below
+# replaces rather than augments for the fields it names.
+resources:
+  - ../../base/external-dns/helmrelease.yaml
+  - workloadidentity.yaml
+
+patches:
+  - path: helmrelease.yaml
+    target:
+      group: helm.toolkit.fluxcd.io
+      kind: HelmRelease
+      name: external-dns
+```
+
+- [ ] **Step 4: Wire it into the cluster's infrastructure tree**
+
+In `infrastructure/gcp-0/kustomization.yaml`, add `external-dns` to `resources`:
+
+```yaml
+resources:
+  - computeclass
+  - external-dns
+```
+
+external-dns joins the existing `infrastructure` Kustomization rather than getting its own: it degrades gracefully when there is nothing to watch, so it needs no ordering edge. Its claim does need Crossplane, which `infrastructure` already sequences behind.
+
+- [ ] **Step 5: Validate, including that the AWS provider is gone**
+
+```bash
+./scripts/validate-manifests.sh 2>&1 | grep -E "RENDER:|Invalid:"
+kustomize build infrastructure/gcp-0 --load-restrictor=LoadRestrictionsNone \
+  | grep -A 3 "provider:"
+```
+
+Expected: `Invalid: 0, Skipped: 0`, and the rendered values show `provider: {name: google}` with **no** `aws:` block and no `zoneType`.
+
+Confirm the claim validates against the real XRD (this is what `skipMissingSchemas: false` buys):
+
+```bash
+grep -rn "GCPWorkloadIdentity" .bundle/ | head -2
+```
+
+Expected: a match — the claim is in the bundle, which means it passed gate 1 against the schema fetched from `crossplane-configuration-gcp:v0.2.0`, not skipped.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add infrastructure/gcp-0/
+git commit -m "feat(gcp): external-dns on the google provider via GCPWorkloadIdentity"
+```
+
+---
+
+### Task 6: Live verification, then teardown
+
+Everything above is unverified configuration. This task is where it becomes true or false. **The standing rule is that no test infrastructure survives this task.**
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-08-25-gcp-private-ingress-verification.md`
+
+**Interfaces:**
+- Consumes: every prior task.
+- Produces: a verification document recording each success criterion with its command output.
+
+- [ ] **Step 1: Deploy**
+
+```bash
+git push -u origin "$(git branch --show-current)"
+cd opentofu/gcp/network && TM_GCP_ENABLED=true terramate script run \
+  --disable-check-git-remote --disable-check-git-untracked --disable-check-git-uncommitted deploy
+cd ../gke && TM_GCP_ENABLED=true TF_VAR_flux_git_ref="refs/heads/$(git branch --show-current)" \
+  terramate script run --disable-check-git-remote --disable-check-git-untracked \
+  --disable-check-git-uncommitted deploy
+cd ../openbao/cluster && TM_GCP_ENABLED=true terramate script run \
+  --disable-check-git-remote --disable-check-git-untracked --disable-check-git-uncommitted deploy
+```
+
+Then initialise OpenBao and deploy the management stack (the CA file is needed because OpenBao's certificate comes from the offline root):
+
+```bash
+cd ../management
+export VAULT_CACERT="$PWD/.tls/ca.pem"
+bash ../../../../scripts/openbao-config.sh ca --cloud gcp --project ogenki-435905 \
+  --root-ca-secret-name openbao-priv-gcp-ca-chain --ca-output-file .tls/ca.pem
+bash ../../../../scripts/openbao-config.sh init --cloud gcp --project ogenki-435905 \
+  --url https://bao.priv.gcp.ogenki.io:8200 \
+  --root-token-secret-name openbao-priv-gcp-root-token \
+  --recovery-keys-secret-name openbao-priv-gcp-recovery-keys
+TM_GCP_ENABLED=true terramate script run --disable-check-git-remote \
+  --disable-check-git-untracked --disable-check-git-uncommitted deploy
+```
+
+**Read the logs, not the exit codes.** Background and wrapped commands in this repository have reported success over real failures repeatedly.
+
+- [ ] **Step 2: Wait for Flux and record criteria 1–3**
+
+```bash
+gcloud container clusters get-credentials gcp-0 --zone europe-west4-a --project ogenki-435905
+kubectl wait --for=condition=Ready kustomization/infrastructure-gapi -n flux-system --timeout=900s
+kubectl get gateway -n infrastructure
+tailscale status | grep -E "gateway-(general|admin)-priv-gcp-0"
+kubectl get certificate -n infrastructure private-gateway-certificate
+```
+
+Expected: both Gateways `PROGRAMMED=True` with a `100.x.y.z` address; both devices in `tailscale status`; the Certificate `READY=True`.
+
+Then prove the certificate came from the right issuer:
+
+```bash
+kubectl get secret private-gateway-tls -n infrastructure \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -issuer -subject
+```
+
+Expected: `issuer=CN=Ogenki GCP Intermediate CA`, subject CN `*.priv.gcp.ogenki.io`.
+
+- [ ] **Step 3: Criterion 4 — a real route, served over the tailnet**
+
+```bash
+kubectl create deployment probe --image=nginx:alpine -n apps
+kubectl expose deployment probe --port=80 -n apps
+kubectl apply -f - <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: probe
+  namespace: apps
+spec:
+  parentRefs:
+    - name: platform-tailscale-general
+      namespace: infrastructure
+  hostnames:
+    - probe.priv.gcp.ogenki.io
+  rules:
+    - backendRefs:
+        - name: probe
+          port: 80
+EOF
+kubectl wait --for=condition=Accepted httproute/probe -n apps --timeout=120s
+```
+
+From a tailnet device:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code} %{ssl_verify_result}\n' \
+  --cacert opentofu/gcp/openbao/management/.tls/ca.pem \
+  https://probe.priv.gcp.ogenki.io/
+```
+
+Expected: `200 0` — HTTP 200 **and** `ssl_verify_result` 0, meaning the chain validated against the offline root. A 200 with a non-zero verify result means TLS was not actually trusted.
+
+- [ ] **Step 4: Criteria 5–6 — the DNS record and its pruning**
+
+```bash
+gcloud dns record-sets list --zone=priv-gcp-ogenki-io --project=ogenki-435905 \
+  --filter="name~probe" --format="value(name,type,rrdatas)"
+```
+
+Expected: an `A` record for `probe.priv.gcp.ogenki.io.` plus a `TXT` registry entry containing `external-dns/owner=gcp-0`.
+
+Then delete the route and confirm `policy: sync` actually prunes:
+
+```bash
+kubectl delete httproute probe -n apps
+sleep 120
+gcloud dns record-sets list --zone=priv-gcp-ogenki-io --project=ogenki-435905 \
+  --filter="name~probe" --format="value(name)"
+```
+
+Expected: empty. Creating records is the easy half; a registry that never prunes leaves a zone that slowly fills with dead names.
+
+- [ ] **Step 5: Criterion 7 — the ACL split is real**
+
+The two Gateways differ only by Tailscale tag, and the enforcement is outside Kubernetes. From a tailnet device that is **not** in `group:admin`:
+
+```bash
+curl -sS -m 10 -o /dev/null -w 'general:%{http_code}\n' https://probe.priv.gcp.ogenki.io/ ; \
+curl -sS -m 10 -o /dev/null -w 'admin:%{http_code}\n' https://hubble-gcp-0.priv.gcp.ogenki.io/ || echo "admin: unreachable (expected)"
+```
+
+Expected: the general hostname answers; the admin one times out or refuses. If both answer, `tagOwners` or the ACL is not doing what the design claims and that is a finding, not a nuisance.
+
+If no non-admin device is available, record the criterion as **unverified** with that reason. Do not mark it passed by inspection.
+
+- [ ] **Step 6: Write the verification document**
+
+Create `docs/superpowers/specs/2026-08-25-gcp-private-ingress-verification.md` with one section per criterion, each quoting the command and its **actual** output. Record any criterion that could not be tested as unverified, with the reason. A verification document that reports only successes is not evidence.
+
+- [ ] **Step 7: Tear down, and verify the teardown**
+
+```bash
+cd opentofu/gcp
+TM_GCP_ENABLED=true TM_DESTROY_CONFIRMED=true terramate script run --reverse \
+  --disable-check-git-remote --disable-check-git-untracked --disable-check-git-uncommitted destroy
+```
+
+Then confirm against the API rather than the exit code — a teardown in this repository has already reported success while destroying nothing:
+
+```bash
+gcloud compute instances list --project=ogenki-435905
+gcloud container clusters list --project=ogenki-435905
+gcloud compute forwarding-rules list --project=ogenki-435905
+gcloud compute addresses list --project=ogenki-435905
+gcloud compute disks list --project=ogenki-435905
+gcloud dns record-sets list --zone=priv-gcp-ogenki-io --project=ogenki-435905 \
+  --format="value(name,type)"
+tailscale status | grep -c "gcp-0"
+```
+
+Expected: every list empty except the zone's own `NS` and `SOA` records, and 0 tailnet devices matching `gcp-0`.
+
+Two known non-leaks: the **Cloud KMS key ring** survives by design (GCP cannot delete one), and **Secret Manager entries** for the ceremony material and the OAuth client persist deliberately. Two known real leaks to sweep by hand: unattached `pvc-*` **disks** from `flux-system/source-controller` (`gcloud compute disks delete <name> --zone=europe-west4-a`), and **stale Tailscale devices** — the operator's devices should deregister on teardown, but subnet routers from previous rebuilds have accumulated.
+
+- [ ] **Step 8: Commit and open the PR**
+
+```bash
+git add docs/superpowers/specs/2026-08-25-gcp-private-ingress-verification.md
+git commit -m "docs(gcp): verification of private ingress on gcp-0"
+git push
+gh pr create --title "feat(gcp): private ingress and external-dns on gcp-0" --base main
+```
+
+---
+
+## Self-review
+
+**Spec coverage.** Every section of the design maps to a task: tailscale-operator → 3; Gateway API layer → 4; external-dns + `GCPWorkloadIdentity` → 5; the hostname rename → 1; the Flux ordering → 3 and 4; the manual OAuth client and the accumulating-prerequisites risk → 2; all eight success criteria → 6. The design's excluded scope (public certificates, `ProxyGroup`) is restated as a Global Constraint so a task cannot quietly re-add it.
+
+**Placeholders.** None. Every YAML and command is complete and runnable; no step says "configure appropriately".
+
+**Consistency.** Names used across tasks match what defines them: Kustomizations `security-tailscale` (3) → depended on by `infrastructure-gapi` (4); `operator-oauth` is the chart's required Secret name in 2 and 3; `xplane-external-dns` in `kube-system` matches external-dns's chart ServiceAccount; `${cluster_name}` in 1 is the same variable `txtOwnerId` uses in 5; `tailscale-k8s-operator-oauth` is identical in Task 2's `gcloud`, its OpenTofu variable default, and Task 3's `remoteRef`.
+
+**One gap accepted deliberately.** Task 2 restates the External Secrets Workload Identity subject that `opentofu/gcp/openbao/management/iam.tf` also builds. Factoring it out would mean a `terraform_remote_state` edge between two stacks that otherwise have none — a worse coupling than two duplicated strings. The comment in Task 2 Step 3 says so.

--- a/docs/superpowers/specs/2026-08-25-gcp-private-ingress-design.md
+++ b/docs/superpowers/specs/2026-08-25-gcp-private-ingress-design.md
@@ -266,7 +266,7 @@ Falsifiable, verified against a live cluster, then torn down.
 
 - Parent design: [GCP Support — Dual-Cloud Platform Design](2026-08-18-gcp-support-design.md)
 - Sibling: [GCP OpenBao — private PKI](2026-08-24-gcp-openbao-design.md), merged #1830
-- [ADR-0005 · Cilium on GKE Standard](../../../website/content/docs/decisions/0005-gke-standard-with-cilium.md)
+- [ADR-0005 · Cilium on GKE Standard](../../../website/content/docs/decisions/0005-gke-standard-self-managed-cilium.md)
 - [ADR-0017 · Multi-cloud DNS naming](../../../website/content/docs/decisions/0017-multi-cloud-dns-naming.md)
-- [ADR-0018 · Per-cloud OpenTofu state](../../../website/content/docs/decisions/0018-per-cloud-opentofu-state.md)
+- ADR-0018 · Per-cloud OpenTofu state — `website/content/docs/decisions/0018-per-cloud-opentofu-state.md`, landing with PR #1831; left unlinked here because it is not on this branch yet
 - `website/content/docs/platform/networking/private-access.md` — the AWS-side operator's guide this mirrors

--- a/docs/superpowers/specs/2026-08-25-gcp-private-ingress-design.md
+++ b/docs/superpowers/specs/2026-08-25-gcp-private-ingress-design.md
@@ -1,0 +1,272 @@
+# GCP private ingress and external-dns — design
+
+**Workstream 10** of the [GCP support design](2026-08-18-gcp-support-design.md).
+Sibling of workstream 11 ([private PKI](2026-08-24-gcp-openbao-design.md)), merged as #1830.
+
+**Status**: approved 2026-08-25, not yet implemented.
+
+**Prerequisite — SATISFIED.** The cluster rename (`mycluster-0` → `aws-0`,
+`gcp-mycluster-0` → `gcp-0`) landed in #1832 before this was implemented, deliberately: this
+design puts `${cluster_name}` inside Tailscale device names, so building it first would have
+renamed those devices twice, each time costing a private-ingress interruption and stale
+tailnet devices to clear. Every path and device name below uses the new names.
+
+---
+
+## What this builds
+
+Private ingress for `gcp-0`: two Tailscale-backed Gateways serving
+`*.priv.gcp.ogenki.io`, TLS from the OpenBao PKI that workstream 11 built, and DNS records
+maintained automatically in the private Cloud DNS zone.
+
+After this, a service on the GCP cluster is reachable from a tailnet device by name, over
+HTTPS, with a certificate that chains to the offline root — the same experience AWS has
+today, through the same manifests.
+
+## What this deliberately does NOT build
+
+**Public certificates, and public ingress generally.** The parent design's workstream 10 also
+listed "cert-manager clouddns DNS-01 (public certs)", and its own open question already
+observed that DNS-01 *has nothing to solve against on GCP*: `opentofu/gcp/network/dns.tf`
+creates a private zone only, `cloud.ogenki.io` is a Route53 zone this repository does not
+manage, and Let's Encrypt must resolve `_acme-challenge` publicly.
+
+That question stays open, and it is not blocking, because **GCP has no public endpoint to put
+a certificate on.** There is no public Gateway, no internet-facing load balancer, and
+workstream 12 owns that. Designing public certificate issuance before anything needs one
+would settle a registrar-level decision on speculation.
+
+The three options the parent design named remain on the table unchanged: solve DNS-01 against
+Route53 from GCP; delegate a public subdomain to a new public Cloud DNS zone; or serve no
+public certificates from GCP at all. **Whoever picks up workstream 12 must resolve it then.**
+
+## Starting position — what already exists
+
+This workstream is much smaller than the parent design's table suggests, because the tailnet
+and DNS foundation landed with earlier slices. Verified 2026-08-25:
+
+| Already in place | Where |
+|---|---|
+| Tailnet ACLs, `tagOwners` for `tag:k8s` / `tag:admin` / `tag:k8s-operator`, autoApprovers | `opentofu/shared/tailscale/main.tf` |
+| `priv.gcp.ogenki.io` in `search_domains`; GCP's four CIDRs in `advertised_routes` | `opentofu/shared/tailscale/variables.tfvars` |
+| GCP subnet router, split-DNS inbound policy, tailnet key | `opentofu/gcp/network/tailscale.tf` |
+| Private Cloud DNS zone `priv.gcp.ogenki.io` | `opentofu/gcp/network/dns.tf` |
+| `xplane_dns_editor` custom role, allowlisted in `crossplane_grantable_roles` | `opentofu/gcp/gke/init/iam.tf` |
+| `openbao` ClusterIssuer, verified issuing | workstream 11 |
+| `clustersecretstore` → GCP Secret Manager via Workload Identity | workstream 11 |
+
+The tailnet singletons matter most. They were extracted into `opentofu/shared/tailscale`
+precisely so that neither cloud authorises the other's devices, and the extraction comment
+records the failure mode it avoids: *"a second `tailscale_acl` in the GCP stack would have
+made each apply silently overwrite the other's, last apply winning, with no error."*
+**Consequently this workstream changes no ACL and no `tagOwners` entry** — `tag:k8s` and
+`tag:admin` are already owned by `tag:k8s-operator` tailnet-wide, so a GCP operator can tag
+its Gateways with no AWS-side change.
+
+## Architecture
+
+Three components, all cluster-side. The only infrastructure change is one manually created
+secret.
+
+```
+tailnet (shared)
+  └── tag:k8s / tag:admin ──── owned by tag:k8s-operator, tailnet-wide
+
+gcp-0
+  ├── tailscale-operator ───── services loadBalancerClass: tailscale
+  │     └── operator-oauth ─── ExternalSecret ← GCP Secret Manager
+  ├── Gateway API layer
+  │     ├── GatewayClass cilium-tailscale + CiliumGatewayClassConfig
+  │     ├── Gateway platform-tailscale-general  (tag:k8s)
+  │     ├── Gateway platform-tailscale-admin    (tag:admin)
+  │     └── Certificate *.priv.gcp.ogenki.io ← ClusterIssuer openbao (WS11)
+  └── external-dns ─────────── provider google, private zone only
+        └── GCPWorkloadIdentity ← xplane_dns_editor
+```
+
+### 1. tailscale-operator — `security/gcp-0/tailscale-operator/`
+
+Reuses `security/base/tailscale-operator/helmrelease.yaml`, `proxyclass-general.yaml` and
+`proxyclass-admin.yaml` **by file reference**, not by directory. The base directory also
+carries `oauth-client-externalsecret.yaml`, whose `key: tailscale/k8s-operator/oauth-client`
+is an AWS Secrets Manager path; pulling the directory would bring a store reference that
+cannot resolve on GCP. This is the same by-file pattern workstream 11 established for the
+shared HelmReleases, and it works because Flux builds kustomizations with
+`LoadRestrictionsNone` — as does `scripts/flux-schema/render-bundle.py`, deliberately, so CI
+renders what Flux renders.
+
+GCP supplies its own `ExternalSecret` reading a new GCP Secret Manager entry
+`tailscale-k8s-operator-oauth-gcp`, with `target.name: operator-oauth` — the name the chart
+requires, unchanged.
+
+**No `ProxyGroup`.** AWS runs `ts-proxies`, two egress replicas. Nothing on the GCP cluster
+egresses through the tailnet today, so this is YAGNI until something does.
+
+### 2. Gateway API layer — consumed by file from `infrastructure/base/gapi/`
+
+Six of the seven manifests are cloud-neutral and are referenced as-is:
+
+| File | Why it needs no change |
+|---|---|
+| `tailscale-gatewayclass.yaml` | Cilium is the GatewayClass implementation on both clouds — ADR-0005 chose Standard GKE + self-managed Cilium exactly so `CiliumGatewayClassConfig` exists |
+| `tailscale-gatewayclass-config.yaml` | `loadBalancerClass: tailscale`; no cloud load balancer is involved, so no cloud-specific annotations |
+| `platform-tailscale-general-gateway.yaml` | Listener hostname is `*.${private_domain_name}` |
+| `platform-tailscale-admin-gateway.yaml` | Same |
+| `platform-private-gateway-certificate.yaml` | `issuerRef: openbao` — precisely what WS11 built and verified |
+| `allow-gateway-l7-proxy.yaml` | `CiliumClusterwideNetworkPolicy` for the Envoy `reserved:ingress` identity |
+
+**Excluded**: `platform-public-gateway.yaml` — `service.beta.kubernetes.io/aws-load-balancer-*`
+annotations and `cert-manager.io/cluster-issuer: letsencrypt-prod`. It is the public path this
+design does not build.
+
+Using `loadBalancerClass: tailscale` rather than a GCP forwarding rule means **the private
+gateways incur no cloud load-balancer charges**, which the parent design already noted.
+
+#### Gateway hostname rename — the one change that touches AWS
+
+Both Gateways currently hardcode `tailscale.com/hostname: gateway-general-priv` and
+`gateway-admin-priv`. Two clusters cannot claim the same hostname; Tailscale would silently
+suffix the second one, making the resulting MagicDNS name unpredictable.
+
+**Decision: parameterise as `gateway-{general,admin}-priv-${cluster_name}` on both clouds**,
+giving `gateway-general-priv-aws-0` on AWS and `gateway-general-priv-gcp-0` on GCP.
+`cluster_name` already exists in both clusters' vars ConfigMaps, so no new variable is
+introduced.
+
+**This assumes the cluster rename has already landed** — see *Prerequisite* below. Applied
+against today's names it would produce `gateway-general-priv-mycluster-0`, which would then
+need renaming a second time.
+
+Two alternatives were rejected. A GCP-only fork of the five manifests would leave AWS
+untouched but duplicate near-identical files that drift. A new suffix variable, empty on AWS,
+would avoid the rename but make one cloud the unlabelled default — the exact asymmetry
+[ADR-0017](../../../website/content/docs/decisions/0017-multi-cloud-dns-naming.md) rejected
+for DNS names, and for the same reason.
+
+**The cost is real and must be planned for, not discovered.** Changing the annotation makes
+the operator register a *new* Tailscale device with a *new* Tailscale IP. The old device does
+not disappear. So on the AWS cluster:
+
+1. The Gateway's Service gets a new Tailscale IP.
+2. external-dns rewrites the `*.priv.aws.ogenki.io` records to it — after its sync interval,
+   not instantly.
+3. Every private AWS service is briefly unreachable in between.
+4. The two superseded devices (`gateway-general-priv`, `gateway-admin-priv`) linger in the
+   tailnet and must be deleted by hand.
+
+This is a deliberate, user-approved trade for symmetric naming. It should be applied to AWS in
+a window where a short private-ingress interruption is acceptable, and the stale devices
+removed in the same session.
+
+### 3. external-dns — `infrastructure/gcp-0/external-dns/`
+
+Patches `infrastructure/base/external-dns/helmrelease.yaml`:
+
+| Value | AWS | GCP |
+|---|---|---|
+| `provider` | `aws` | `google` |
+| `domainFilters` | `[cloud.ogenki.io, priv.aws.ogenki.io]` | `[${private_domain_name}]` — one zone; GCP has no public zone |
+| `extraArgs` | `--aws-zone-type` etc. | `--google-project=${project_id}`, `--google-zone-visibility=private` |
+| `global.imageRegistry` | `public.ecr.aws` | dropped — an AWS registry is an odd dependency for GCP image pulls |
+| `txtOwnerId` | `${cluster_name}` | `${cluster_name}` — already distinct, so the two clusters' TXT registries cannot collide |
+| `sources` | service, ingress, gateway-httproute | unchanged |
+
+`policy: sync` and the `--gateway-label-filter=external-dns=enabled` /
+`--gateway-namespace=infrastructure` arguments carry over unchanged.
+
+#### Identity — the composition's first consumer
+
+A `GCPWorkloadIdentity` claim in `kube-system` (where external-dns runs) for ServiceAccount
+`external-dns`, granting `projects/ogenki-435905/roles/xplane_dns_editor`.
+
+This is the opposite call from workstream 11, and deliberately so. There, External Secrets
+needed exactly two named secrets, and the composition's project-scoped `ProjectIAMMember`
+would have granted read of *every* secret in the project including the intermediate CA's
+private key — so it was bound per secret and the composition was left without a consumer, with
+a comment predicting external-dns would be the first genuine one.
+
+external-dns's access **is** project-shaped. It must discover which zone owns a name, which
+requires `dns.managedZones.list` across the project — a per-zone
+`google_dns_managed_zone_iam_member` cannot express that. `xplane_dns_editor` already excludes
+zone creation and deletion, so the widest thing it grants is record edits in zones that
+already exist. That is the shape of the workload.
+
+## Flux ordering
+
+```
+namespaces → crds → security (controllers)
+                      ├── security-openbao      (ClusterIssuer openbao)
+                      └── security-tailscale    (operator)
+                            └── infrastructure-gapi   (GatewayClass, Gateways, Certificate)
+infrastructure (existing) ── external-dns added here
+```
+
+Two edges are load-bearing and get `dependsOn` plus health checks, not a retry timer:
+
+- **`infrastructure-gapi` after `security-openbao`.** The wildcard Certificate cannot be
+  issued before the `openbao` ClusterIssuer exists.
+- **`infrastructure-gapi` after `security-tailscale`.** Without the operator, both Gateways'
+  Services sit `Pending` forever with no error that names the cause.
+
+Workstream 11 already paid for learning this: External Secrets' own admission webhook had no
+endpoints when its ExternalSecrets were applied in the same Kustomization as its chart, and
+the resulting exponential backoff left both secrets unsynced *while Flux reported Ready*. The
+fix there was a `dependsOn` edge gated on HelmRelease health checks. The same discipline
+applies here.
+
+external-dns joins the existing `infrastructure` Kustomization rather than getting its own —
+it degrades gracefully when there is nothing to watch, so it needs no ordering edge.
+
+## Success criteria
+
+Falsifiable, verified against a live cluster, then torn down.
+
+1. `kubectl get gateway -n infrastructure` → both `PROGRAMMED=True`, each with a
+   `100.x.y.z` Tailscale address.
+2. `tailscale status` from a laptop lists `gateway-general-priv-gcp-0` and
+   `gateway-admin-priv-gcp-0`.
+3. `kubectl get certificate -n infrastructure private-gateway-certificate` → `READY=True`,
+   and `openssl x509 -issuer` on the secret shows `CN=Ogenki GCP Intermediate CA`.
+4. A test `HTTPRoute` on the general Gateway resolves and serves over HTTPS from a tailnet
+   device, with the certificate validating against the offline root's chain.
+5. `gcloud dns record-sets list --zone=priv-gcp-ogenki-io` shows that record plus its
+   external-dns TXT registry entry carrying `txtOwnerId=gcp-0`.
+6. Deleting the `HTTPRoute` removes both records within one sync interval (`policy: sync`
+   actually pruning, not just creating).
+7. A device **not** in `group:admin` can reach the general Gateway's hostname and **cannot**
+   reach the admin Gateway's — the two-gateway ACL split enforced by Tailscale, not by
+   Kubernetes.
+8. Teardown leaves no Tailscale device, no Cloud DNS record under the zone, and no billable
+   GCP resource.
+
+## Risks and open questions
+
+- **The AWS Gateway rename causes a brief private-ingress outage** and leaves two stale
+  Tailscale devices. Described above; it is a planned cost, not a surprise, but it means this
+  change must not be applied to AWS unattended.
+- **Manual bootstrap steps are accumulating.** GCP now needs, by hand: the Cloud KMS key ring
+  (WS11), the OpenTofu state bucket and its project (ADR-0018), and now a Tailscale OAuth
+  client in GCP Secret Manager. Three undocumented steps is how a repository stops being
+  reproducible. **This design requires them to be collected into one documented bootstrap
+  procedure**, not left as three comments in three files.
+- **A separate GCP OAuth client** was chosen over copying AWS's so that compromising one
+  cluster's operator does not force rotating the other's. It is one more credential to create
+  and one more to remember to revoke on teardown.
+- **external-dns's project-wide DNS role is wider than the one zone it uses.** Accepted because
+  zone discovery genuinely needs `managedZones.list`, but if GCP ever hosts a zone external-dns
+  must not touch, `domainFilters` is a *client-side* filter and not a security boundary — the
+  IAM role would need revisiting then.
+- **Public certificates remain unresolved**, by design. Workstream 12 must settle it.
+- **Cilium's Gateway API on GKE is verified only for basic L7.** The parent design's CHECK 2
+  passed 100/100 requests through a Cilium Gateway on a throwaway GKE cluster without
+  WireGuard, but that predates this Gateway configuration and the Tailscale
+  `loadBalancerClass` path. Criterion 4 is what actually establishes it.
+
+## References
+
+- Parent design: [GCP Support — Dual-Cloud Platform Design](2026-08-18-gcp-support-design.md)
+- Sibling: [GCP OpenBao — private PKI](2026-08-24-gcp-openbao-design.md), merged #1830
+- [ADR-0005 · Cilium on GKE Standard](../../../website/content/docs/decisions/0005-gke-standard-with-cilium.md)
+- [ADR-0017 · Multi-cloud DNS naming](../../../website/content/docs/decisions/0017-multi-cloud-dns-naming.md)
+- [ADR-0018 · Per-cloud OpenTofu state](../../../website/content/docs/decisions/0018-per-cloud-opentofu-state.md)
+- `website/content/docs/platform/networking/private-access.md` — the AWS-side operator's guide this mirrors

--- a/docs/superpowers/specs/2026-08-25-gcp-private-ingress-design.md
+++ b/docs/superpowers/specs/2026-08-25-gcp-private-ingress-design.md
@@ -96,7 +96,7 @@ shared HelmReleases, and it works because Flux builds kustomizations with
 renders what Flux renders.
 
 GCP supplies its own `ExternalSecret` reading a new GCP Secret Manager entry
-`tailscale-k8s-operator-oauth-gcp`, with `target.name: operator-oauth` — the name the chart
+`tailscale-k8s-operator-oauth`, with `target.name: operator-oauth` — the name the chart
 requires, unchanged.
 
 **No `ProxyGroup`.** AWS runs `ts-proxies`, two egress replicas. Nothing on the GCP cluster

--- a/docs/superpowers/specs/2026-08-25-gcp-private-ingress-verification.md
+++ b/docs/superpowers/specs/2026-08-25-gcp-private-ingress-verification.md
@@ -1,0 +1,211 @@
+# GCP private ingress — live verification
+
+Task 6 of [the plan](../plans/2026-08-25-gcp-private-ingress.md), against
+[the design](2026-08-25-gcp-private-ingress-design.md).
+
+**Date:** 2026-08-25 · **Cluster:** `gcp-0`, project `ogenki-435905`, `europe-west4-a`
+**Branch deployed:** `worktree-gcp-private-ingress` @ `9dc52b23`
+**Outcome:** 7 of 8 criteria PASS, 1 PARTIAL. Everything torn down afterwards.
+
+---
+
+## Criteria
+
+### 1. Both Gateways Programmed — PASS
+
+```
+NAME                         CLASS              ADDRESS                                       PROGRAMMED
+platform-tailscale-admin     cilium-tailscale   gateway-admin-priv-gcp-0.tail9c382.ts.net     True
+platform-tailscale-general   cilium-tailscale   gateway-general-priv-gcp-0.tail9c382.ts.net   True
+```
+
+Conditions on both: `Accepted=True Programmed=True`.
+
+This is also the live test of the final review's Important finding. `healthChecks` on a
+Gateway asserts existence only; the branch now carries `healthCheckExprs` gating on
+`Programmed`. `infrastructure-gapi` reached Ready **after** both Gateways were genuinely
+programmed, not on object creation.
+
+### 2. Per-cluster Tailscale devices — PASS
+
+```
+100.122.5.127   gateway-admin-priv-gcp-0     tagged-devices  linux
+100.123.86.11   gateway-general-priv-gcp-0   tagged-devices  linux
+```
+
+Both carry the `-gcp-0` suffix from Task 1's `${cluster_name}` parameterisation. The
+operator's own device hostname (final review, Minor 4) is also parameterised — verified in
+the running deployment rather than in YAML:
+
+```
+$ kubectl get deploy operator -n tailscale -o jsonpath='{...OPERATOR_HOSTNAME...}'
+tailscale-operator-gcp-0
+```
+
+### 3. Wildcard certificate from the offline-root chain — PASS
+
+```
+NAME                          READY   SECRET
+private-gateway-certificate   True    private-gateway-tls
+
+issuer=CN=Ogenki GCP Intermediate CA, O=Ogenki, C=FR
+subject=C=FR, O=Ogenki, CN=*.priv.gcp.ogenki.io
+notBefore=Aug 25 11:32:24 2026 GMT   notAfter=Nov 23 11:32:54 2026 GMT
+```
+
+90-day leaf, so cert-manager exercises renewal at ~60 days. Issued by the `openbao`
+ClusterIssuer with no GCP-specific manifest — the shared `platform-private-gateway-certificate.yaml`
+worked unchanged.
+
+### 4. A real route served over the tailnet — PASS
+
+```
+$ curl --cacert <offline-root chain> https://probe.priv.gcp.ogenki.io/
+http=200 ssl_verify=0 ip=100.123.86.11
+
+served leaf: subject=CN=*.priv.gcp.ogenki.io  issuer=CN=Ogenki GCP Intermediate CA
+```
+
+`ssl_verify=0` is the part that matters: the chain validated against the offline root's
+published bundle. A 200 with a non-zero verify result would mean TLS was not actually
+trusted. The connection landed on `100.123.86.11` — the general Gateway's Tailscale address,
+not a cloud load balancer.
+
+### 5. external-dns created the record and its TXT registry — PASS
+
+```
+probe.priv.gcp.ogenki.io.     A    100.123.86.11
+a-probe.priv.gcp.ogenki.io.   TXT  "heritage=external-dns,external-dns/owner=gcp-0,
+                                    external-dns/resource=httproute/apps/probe"
+```
+
+Owner is `gcp-0`, and the registry names the source as `httproute/apps/probe` — so the
+`gateway-httproute` source, the label filter and the namespace filter are all working.
+
+This is the `GCPWorkloadIdentity` composition's **first consumer**, and it worked:
+
+```
+NAME                  SYNCED   READY
+xplane-external-dns   True     True      (Responsive=True)
+```
+
+The claim went Ready in `kube-system`, the composition derived the ServiceAccount namespace
+from the claim's own, and external-dns authenticated to Cloud DNS by subject with no key
+material anywhere.
+
+### 6. `policy: sync` actually prunes — PASS
+
+Deleting the HTTPRoute removed **both** records within ~30s (the `--min-event-sync-interval`).
+Creating records is the easy half; a registry that never prunes leaves a zone slowly filling
+with dead names.
+
+### 7. Two-gateway ACL split — PARTIAL
+
+Verified:
+- The admin Gateway accepts a route from `kube-system` (`Accepted=True ResolvedRefs=True`) —
+  confirming its `allowedRoutes` namespace list, which does **not** include `apps`.
+- It serves over the tailnet with a valid chain: `http=200 ssl_verify=0` on
+  `probe-admin.priv.gcp.ogenki.io` → `100.122.5.127`, the admin Gateway's own device.
+- The two Gateways are distinct devices with distinct Tailscale tags (`tag:admin` vs
+  `tag:k8s`), which is what the ACL evaluates.
+
+**Not verified: the denial.** Proving a non-admin device is refused needs a tailnet device
+outside `group:admin`. `opentofu/shared/tailscale/variables.tfvars` sets
+`admin_users = ["smainklh@gmail.com"]`, the tailnet owner — the only device available here.
+Recorded as unverified rather than asserted from configuration. Testing it needs a second
+tailnet device, or temporarily removing the owner from `group:admin`, neither of which was in
+scope for this run.
+
+### 8. Teardown leaves nothing billable — PASS
+
+See *Teardown* below.
+
+---
+
+## Defects this deploy found
+
+### `opentofu/gcp/openbao/management/variables.tfvars` was never committed (fixed, `9dc52b23`)
+
+The stack could not be deployed from a clean checkout:
+
+```
+Error: Failed to read variables file
+Given variables file variables.tfvars does not exist.
+```
+
+`*.tfvars` is gitignored repo-wide (`.gitignore:55`), and every other GCP stack —
+`network`, `gke/init`, `gke/configure`, `openbao/cluster` — has its copy force-added past
+that rule. `openbao/management` was missed in #1830. The gap was invisible because the file
+existed **untracked** in the worktree where that stack was originally written and verified,
+so its own live verification passed over the defect.
+
+This is a defect in merged `main`, not in this branch. It is fixed here because it blocked
+this branch's verification.
+
+### `kubectl wait --for=condition=Accepted httproute/...` does not work
+
+The plan's Task 6 Step 3 used it; it times out even on a healthy route:
+
+```
+error: timed out waiting for the condition on httproutes/probe
+```
+
+An HTTPRoute has no top-level `Accepted` condition — it lives under
+`status.parents[].conditions`, per parent. The route was in fact `Accepted=True
+ResolvedRefs=True` the whole time.
+
+This is **the same shape** as the final review's Gateway `healthChecks` finding: a readiness
+assertion that silently checks nothing because the Gateway API puts conditions where the
+generic tooling does not look. Worth remembering as a class, not two incidents.
+
+## Two credentials the plan did not list as prerequisites
+
+Both cost a round trip mid-deploy:
+
+- **AWS credentials.** A GCP-only deploy failed at `tofu init` with `No valid credential
+  sources found`, purely because GCP state still lives in the S3 bucket. This is the coupling
+  ADR-0018 / PR #1831 removes, demonstrated concretely rather than argued.
+- **`TF_VAR_tailscale_api_key`.** The network stack manages tailnet ACLs and auth keys and
+  has no default for it.
+
+`docs/gcp-bootstrap.md` covers the three GCP-side prerequisites but says nothing about what
+must be in the operator's shell. Worth a follow-up section.
+
+## Teardown
+
+`terramate script run --reverse destroy` across all GCP stacks, then verified against the
+API rather than the exit code — a teardown in this repo has previously reported success
+while destroying nothing:
+
+```
+gcloud compute instances list      Listed 0 items.
+gcloud container clusters list     (empty)
+gcloud compute forwarding-rules    Listed 0 items.
+gcloud compute addresses list      Listed 0 items.
+gcloud compute networks list       default
+gcloud compute disks list          (empty)
+gcloud dns record-sets list        404 — the managed zone itself is gone
+tailscale status | grep -c gcp-0   0
+```
+
+Two things went better than the previous GCP teardown:
+
+- **No leaked disks.** The earlier run left an unattached 5 GB `pvc-*` volume from
+  `flux-system/source-controller`. None this time.
+- **No stale tailnet devices.** Both Gateway devices and the operator's own deregistered on
+  teardown, so the per-cluster hostnames did not accumulate. Criterion 8's "leaves no
+  Tailscale device" is met without hand-cleanup.
+
+Deliberate survivors, not leaks:
+
+```
+KMS   openbao-dev/openbao-unseal          GCP cannot delete a key ring or crypto key, and
+                                          destroying it would make any sealed OpenBao
+                                          unrecoverable. Costs nothing idle.
+Secrets  flux-github-app, openbao-priv-gcp-{ca-chain, intermediate-ca, recovery-keys,
+         root-token, server-cert}, tailscale-k8s-operator-oauth
+```
+
+`openbao-priv-gcp-approle-cert-manager` is **absent** from that list — the management
+stack's unconditional sweep removed it, which is the one credential-bearing secret that
+outlives OpenBao itself.

--- a/infrastructure/base/gapi/platform-tailscale-admin-gateway.yaml
+++ b/infrastructure/base/gapi/platform-tailscale-admin-gateway.yaml
@@ -9,8 +9,8 @@ spec:
   gatewayClassName: cilium-tailscale
   infrastructure:
     annotations:
-      # Tailscale-specific annotations for admin services
-      tailscale.com/hostname: "gateway-admin-priv"
+      # Per-cluster hostname -- see platform-tailscale-general-gateway.yaml for why.
+      tailscale.com/hostname: "gateway-admin-priv-${cluster_name}"
       tailscale.com/tags: "tag:admin"
       tailscale.com/funnel: "false"
   listeners:

--- a/infrastructure/base/gapi/platform-tailscale-general-gateway.yaml
+++ b/infrastructure/base/gapi/platform-tailscale-general-gateway.yaml
@@ -9,8 +9,17 @@ spec:
   gatewayClassName: cilium-tailscale
   infrastructure:
     annotations:
-      # Tailscale-specific annotations for general services
-      tailscale.com/hostname: "gateway-general-priv"
+      # Per-cluster, because the tailnet is SHARED between aws-0 and gcp-0 and a
+      # Tailscale hostname is tailnet-unique. Two clusters claiming
+      # "gateway-general-priv" does not error -- Tailscale suffixes the second
+      # device, so its MagicDNS name silently stops being the one anything
+      # expects.
+      #
+      # <role>-<visibility>-<cluster> rather than a suffix that is empty on AWS:
+      # a scheme where one cloud is the unlabelled default is exactly what
+      # ADR-0017 rejects for DNS names, and cluster names were renamed to aws-0 /
+      # gcp-0 in #1832 for the same reason.
+      tailscale.com/hostname: "gateway-general-priv-${cluster_name}"
       tailscale.com/tags: "tag:k8s"
       tailscale.com/funnel: "false"
   listeners:

--- a/infrastructure/gcp-0/external-dns/helmrelease.yaml
+++ b/infrastructure/gcp-0/external-dns/helmrelease.yaml
@@ -1,0 +1,41 @@
+# GCP overrides for the shared external-dns release.
+#
+# provider: google, and ONE domain filter. AWS filters two zones because it owns
+# a public one; this cluster has only the private Cloud DNS zone --
+# cloud.ogenki.io is a Route53 zone this repository does not manage, and public
+# certificates are out of scope by design.
+#
+# --google-zone-visibility=private stops it enumerating public zones it has no
+# business in. domainFilters is a CLIENT-side filter and not a security
+# boundary; the IAM role is.
+#
+# The base's `global.imageRegistry: public.ecr.aws` and its top-level `aws:`
+# block are deliberately NOT touched. Verified against
+# `helm show values external-dns/external-dns --version 1.21.1`: neither is a
+# chart value -- `global` supports only `imagePullSecrets`, and there is no
+# top-level `aws` key. Both are inert on both clouds. Overriding a setting that
+# does nothing, and writing a comment explaining why, would be two lies for the
+# price of one.
+#
+# GCP settings therefore go through extraArgs, because chart 1.21.1 has no
+# `google:` values block either.
+#
+# txtOwnerId stays at the base's ${cluster_name}. The two clusters are now
+# distinct (aws-0 / gcp-0), so their TXT registries cannot collide.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns
+  namespace: kube-system
+spec:
+  values:
+    provider:
+      name: google
+    domainFilters:
+      - ${private_domain_name}
+    extraArgs:
+      - --google-project=${project_id}
+      - --google-zone-visibility=private
+      - --gateway-namespace=infrastructure
+      - --gateway-label-filter=external-dns=enabled
+      - --min-event-sync-interval=30s

--- a/infrastructure/gcp-0/external-dns/kustomization.yaml
+++ b/infrastructure/gcp-0/external-dns/kustomization.yaml
@@ -3,8 +3,9 @@ kind: Kustomization
 namespace: kube-system
 
 # The chart release by file -- the base DIRECTORY is AWS-shaped in its values
-# (provider aws, two domain filters, an ECR registry), which the patch below
-# replaces rather than augments for the fields it names.
+# (two domain filters and an inert top-level `aws:` block, per this directory's
+# own helmrelease.yaml), which the patch below replaces rather than augments
+# for the fields it names.
 resources:
   - ../../base/external-dns/helmrelease.yaml
   - workloadidentity.yaml

--- a/infrastructure/gcp-0/external-dns/kustomization.yaml
+++ b/infrastructure/gcp-0/external-dns/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+
+# The chart release by file -- the base DIRECTORY is AWS-shaped in its values
+# (provider aws, two domain filters, an ECR registry), which the patch below
+# replaces rather than augments for the fields it names.
+resources:
+  - ../../base/external-dns/helmrelease.yaml
+  - workloadidentity.yaml
+
+patches:
+  - path: helmrelease.yaml
+    target:
+      group: helm.toolkit.fluxcd.io
+      kind: HelmRelease
+      name: external-dns

--- a/infrastructure/gcp-0/external-dns/workloadidentity.yaml
+++ b/infrastructure/gcp-0/external-dns/workloadidentity.yaml
@@ -1,0 +1,32 @@
+# external-dns's Google identity.
+#
+# This is the GCPWorkloadIdentity composition's FIRST consumer, and the call is
+# deliberately the opposite of workstream 11's. There, External Secrets needed
+# exactly two named secrets, and this composition renders ProjectIAMMember --
+# project-scoped -- which would have granted read of every secret in the project
+# including the intermediate CA's private key. So it was bound per secret and
+# this API was left without a consumer.
+#
+# external-dns's access genuinely IS project-shaped: it must discover which zone
+# owns a name, which needs dns.managedZones.list ACROSS the project. A per-zone
+# google_dns_managed_zone_iam_member cannot express that.
+#
+# xplane_dns_editor (opentofu/gcp/gke/init/iam.tf) holds record and change
+# permissions plus read-only on zones -- no zone create or delete. It is
+# allowlisted in crossplane_grantable_roles; a role outside that list fails at
+# the provider with a message naming it.
+#
+# The claim lives in kube-system because the composition derives the
+# ServiceAccount's namespace from the claim's own, and that is where external-dns
+# runs. No annotation is added to the ServiceAccount: GKE Workload Identity binds
+# by SUBJECT.
+apiVersion: cloud.ogenki.io/v1alpha1
+kind: GCPWorkloadIdentity
+metadata:
+  name: xplane-external-dns
+  namespace: kube-system
+spec:
+  serviceAccount:
+    name: external-dns
+  roles:
+    - "projects/${project_id}/roles/xplane_dns_editor"

--- a/infrastructure/gcp-0/gapi/kustomization.yaml
+++ b/infrastructure/gcp-0/gapi/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: infrastructure
+
+# Six of the seven manifests in infrastructure/base/gapi are cloud-neutral and
+# are used verbatim. Referenced BY FILE because the seventh is not:
+#
+#   platform-public-gateway.yaml carries
+#   service.beta.kubernetes.io/aws-load-balancer-* annotations and
+#   cert-manager.io/cluster-issuer: letsencrypt-prod. It is the PUBLIC path,
+#   which this cluster deliberately does not build -- see the design's "What this
+#   deliberately does NOT build". Adding it here would also require solving
+#   DNS-01 against a public zone GCP does not have.
+#
+# platform-private-gateway-certificate.yaml needs no GCP variant at all: it asks
+# the `openbao` ClusterIssuer for *.${private_domain_name}, and workstream 11
+# verified that issuer end to end on this cluster.
+#
+# Using loadBalancerClass: tailscale rather than a GCP forwarding rule means the
+# private gateways incur no cloud load-balancer charges.
+resources:
+  - ../../base/gapi/tailscale-gatewayclass.yaml
+  - ../../base/gapi/tailscale-gatewayclass-config.yaml
+  - ../../base/gapi/platform-tailscale-general-gateway.yaml
+  - ../../base/gapi/platform-tailscale-admin-gateway.yaml
+  - ../../base/gapi/platform-private-gateway-certificate.yaml
+  - ../../base/gapi/allow-gateway-l7-proxy.yaml

--- a/infrastructure/gcp-0/kustomization.yaml
+++ b/infrastructure/gcp-0/kustomization.yaml
@@ -14,3 +14,4 @@ kind: Kustomization
 # the shared tree are genuinely cloud-neutral.
 resources:
   - computeclass
+  - external-dns

--- a/opentofu/gcp/gke/init/iam.tf
+++ b/opentofu/gcp/gke/init/iam.tf
@@ -269,3 +269,32 @@ resource "google_project_iam_member" "crossplane_role_reader" {
 # actual need. Extend the SAME pattern for anything further: add a
 # google_project_iam_custom_role here, reference it in the allowlist. Do NOT
 # widen the condition.
+
+# External Secrets' access to the Tailscale OAuth client.
+#
+# PER-SECRET, not through GCPWorkloadIdentity, for the same reason
+# opentofu/gcp/openbao/management/iam.tf binds per secret: that composition
+# renders ProjectIAMMember, which is PROJECT-scoped, so any secret-reading role
+# granted through it can read every secret in the project by name -- including
+# OpenBao's root token and the intermediate CA's private key.
+#
+# The subject duplicates the one in openbao/management deliberately rather than
+# being shared: the two stacks have no dependency edge, and a remote-state read
+# purely to avoid restating two strings would create one.
+locals {
+  # TRAP: `projects/` takes the project NUMBER while `workloadIdentityPools/`
+  # takes the project ID. Reversed, the API ACCEPTS the binding and it silently
+  # never matches.
+  external_secrets_principal = join("", [
+    "principal://iam.googleapis.com/projects/${data.google_project.this.number}",
+    "/locations/global/workloadIdentityPools/${var.project_id}.svc.id.goog",
+    "/subject/ns/${var.external_secrets_namespace}/sa/${var.external_secrets_service_account}",
+  ])
+}
+
+resource "google_secret_manager_secret_iam_member" "external_secrets_tailscale_oauth" {
+  project   = var.project_id
+  secret_id = var.tailscale_oauth_secret_name
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.external_secrets_principal
+}

--- a/opentofu/gcp/gke/init/variables.tf
+++ b/opentofu/gcp/gke/init/variables.tf
@@ -120,3 +120,21 @@ variable "autoscaling_max_memory_gb" {
   type        = number
   default     = 128
 }
+
+variable "external_secrets_namespace" {
+  description = "Namespace of the External Secrets controller's ServiceAccount. Part of the Workload Identity subject, so it must match the cluster exactly."
+  type        = string
+  default     = "security"
+}
+
+variable "external_secrets_service_account" {
+  description = "Name of the External Secrets controller's ServiceAccount. Part of the Workload Identity subject; a mismatch produces a binding the API accepts and that never matches."
+  type        = string
+  default     = "external-secrets"
+}
+
+variable "tailscale_oauth_secret_name" {
+  description = "GCP Secret Manager entry holding the Tailscale OAuth client for the Kubernetes operator. Created by hand -- see docs/gcp-bootstrap.md."
+  type        = string
+  default     = "tailscale-k8s-operator-oauth"
+}

--- a/opentofu/gcp/openbao/management/variables.tfvars
+++ b/opentofu/gcp/openbao/management/variables.tfvars
@@ -1,0 +1,4 @@
+# Everything else is left on its defaults in variables.tf, which carry the
+# project's real values (europe-west4, priv.gcp.ogenki.io, the Secret Manager
+# entry names the ceremony and init script create).
+project_id = "ogenki-435905"

--- a/security/base/tailscale-operator/helmrelease.yaml
+++ b/security/base/tailscale-operator/helmrelease.yaml
@@ -22,6 +22,16 @@ spec:
     installCRDs: false
 
     operatorConfig:
+      # Per-cluster, same reason as the Gateway hostnames
+      # (infrastructure/base/gapi/platform-tailscale-general-gateway.yaml): the
+      # tailnet is SHARED between aws-0 and gcp-0, and the chart default
+      # ("tailscale-operator", verified via `helm template tailscale/tailscale-
+      # operator --version 1.90.6`) is not tailnet-unique across two clusters
+      # running this same shared HelmRelease. Without this, gcp-0's operator
+      # device collides with aws-0's and Tailscale silently suffixes one of
+      # them. `cluster_name` substitutes on both clouds.
+      hostname: "tailscale-operator-${cluster_name}"
+
       resources:
         limits:
           memory: 256Mi

--- a/security/gcp-0/tailscale-operator/kustomization.yaml
+++ b/security/gcp-0/tailscale-operator/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tailscale
+
+# The chart and both ProxyClasses come from security/base BY FILE, not by
+# directory. The base directory also carries oauth-client-externalsecret.yaml,
+# whose `key: tailscale/k8s-operator/oauth-client` is an AWS Secrets Manager
+# path -- pulling the directory would bring a store reference that cannot
+# resolve here, and its target Secret name would collide with ours.
+#
+# Referencing the chart by file keeps a version bump landing on both clouds at
+# once. Flux builds with LoadRestrictionsNone, as does
+# scripts/flux-schema/render-bundle.py, so a cross-directory file reference is
+# supported rather than tolerated.
+#
+# NO proxygroup.yaml. AWS runs `ts-proxies`, two EGRESS replicas; nothing on
+# this cluster egresses through the tailnet. Add it when something does.
+resources:
+  - ../../base/tailscale-operator/helmrelease.yaml
+  - ../../base/tailscale-operator/proxyclass-general.yaml
+  - ../../base/tailscale-operator/proxyclass-admin.yaml
+  - oauth-client-externalsecret.yaml

--- a/security/gcp-0/tailscale-operator/kustomization.yaml
+++ b/security/gcp-0/tailscale-operator/kustomization.yaml
@@ -15,6 +15,16 @@ namespace: tailscale
 #
 # NO proxygroup.yaml. AWS runs `ts-proxies`, two EGRESS replicas; nothing on
 # this cluster egresses through the tailnet. Add it when something does.
+#
+# The two ProxyClasses' CRD (`tailscale.com/v1alpha1`) is not guaranteed here,
+# the same gap clusters/gcp-0/security/security-openbao.yaml:25-32 documents for
+# ExternalSecret: it comes from crds-tailscale-operator
+# (crds/base/kustomization-tailscale-operator.yaml), a CHILD Flux Kustomization
+# whose reconcile the parent `crds` does not wait on. A first apply can hit
+# `no matches for kind "ProxyClass"` and converge on the 30s retryInterval.
+# Self-healing, and likely masked by the minutes `security` spends installing
+# two Helm charts first -- recorded here rather than closed, same as the
+# ExternalSecret case.
 resources:
   - ../../base/tailscale-operator/helmrelease.yaml
   - ../../base/tailscale-operator/proxyclass-general.yaml

--- a/security/gcp-0/tailscale-operator/oauth-client-externalsecret.yaml
+++ b/security/gcp-0/tailscale-operator/oauth-client-externalsecret.yaml
@@ -1,0 +1,26 @@
+# The Tailscale OAuth client the operator authenticates with.
+#
+# GCP has its OWN client, not a copy of the AWS one: compromising this cluster's
+# operator should not force rotating the other cluster's. Created by hand --
+# docs/gcp-bootstrap.md -- because it is issued by the Tailscale admin console.
+#
+# `dataFrom.extract` copies the JSON's keys verbatim, so the Secret ends up with
+# client_id / client_secret, which is what the chart requires. The target NAME is
+# also fixed by the chart and must stay `operator-oauth`.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tailscale-operator-oauth-client
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        key: tailscale-k8s-operator-oauth
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: clustersecretstore
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: operator-oauth

--- a/website/content/docs/platform/networking/private-access.md
+++ b/website/content/docs/platform/networking/private-access.md
@@ -81,7 +81,7 @@ shared between `aws-0` and `gcp-0`, and a Tailscale hostname is
 tailnet-unique. Two clusters claiming the same hostname doesn't error —
 Tailscale silently suffixes the second device, so its MagicDNS name stops
 being the one anything expects. `cluster_name` comes from each cluster's
-Flux vars `ConfigMap`, substituted by `postBuild.substitute` at reconcile
+Flux vars `ConfigMap`, substituted by `postBuild.substituteFrom` at reconcile
 time — never hardcode a hostname here.
 
 Both carry the `external-dns: enabled` label so ExternalDNS picks them up —

--- a/website/content/docs/platform/networking/private-access.md
+++ b/website/content/docs/platform/networking/private-access.md
@@ -71,10 +71,18 @@ sets its own Tailscale tag directly through `infrastructure.annotations`:
 # platform-tailscale-general-gateway.yaml / platform-tailscale-admin-gateway.yaml
 infrastructure:
   annotations:
-    tailscale.com/hostname: "gateway-general-priv" # or gateway-admin-priv
-    tailscale.com/tags: "tag:k8s"                  # or tag:admin
+    tailscale.com/hostname: "gateway-general-priv-${cluster_name}" # or gateway-admin-priv-${cluster_name}
+    tailscale.com/tags: "tag:k8s"                                  # or tag:admin
     tailscale.com/funnel: "false"
 ```
+
+The `-${cluster_name}` suffix is required, not decorative: the tailnet is
+shared between `aws-0` and `gcp-0`, and a Tailscale hostname is
+tailnet-unique. Two clusters claiming the same hostname doesn't error —
+Tailscale silently suffixes the second device, so its MagicDNS name stops
+being the one anything expects. `cluster_name` comes from each cluster's
+Flux vars `ConfigMap`, substituted by `postBuild.substitute` at reconcile
+time — never hardcode a hostname here.
 
 Both carry the `external-dns: enabled` label so ExternalDNS picks them up —
 see [Gateway API]({{< relref "/docs/platform/networking/gateway-api.md#externaldns-and-route53" >}})


### PR DESCRIPTION
Workstream 10 of the [GCP support design](docs/superpowers/specs/2026-08-18-gcp-support-design.md): private ingress for `gcp-0` — two Tailscale-backed Gateways serving `*.priv.gcp.ogenki.io`, TLS from the OpenBao PKI, and DNS records maintained in the private Cloud DNS zone.

Design: [`2026-08-25-gcp-private-ingress-design.md`](docs/superpowers/specs/2026-08-25-gcp-private-ingress-design.md) · Plan: [`2026-08-25-gcp-private-ingress.md`](docs/superpowers/plans/2026-08-25-gcp-private-ingress.md)

> ## ⚠️ Two things to read before merging
>
> **1. Deployed and verified — 7 of 8 criteria PASS, 1 PARTIAL.** Full evidence in
> [`2026-08-25-gcp-private-ingress-verification.md`](docs/superpowers/specs/2026-08-25-gcp-private-ingress-verification.md).
> The whole GCP stack was built from scratch on `gcp-0`, verified, and torn down; the teardown
> was confirmed against the GCP API rather than an exit code (0 instances, 0 clusters, 0
> forwarding rules, 0 addresses, 0 disks, DNS zone gone, 0 tailnet devices left).
>
> The one PARTIAL is criterion 7, the ACL split. The admin Gateway accepts a `kube-system`
> route and serves it over the tailnet with a valid chain, but proving a **non-admin** device is
> denied needs a tailnet device outside `group:admin`, and the only device available belongs to
> the tailnet owner. Recorded as unverified rather than asserted from configuration.
>
> **2. This must merge AFTER #1831.** `docs/gcp-bootstrap.md` section 1 documents the GCS state backend from ADR-0018, which lands with that PR. A dependency sentence names it, so the doc is accurate either way — but merging in the right order is what lets that sentence read as provenance rather than as a forward reference.

## What it builds

Three cluster-side components. The tailnet foundation already existed, so this is smaller than the parent design's table implies — the ACLs, `tagOwners`, autoApprovers, search domains and advertised routes all live in `opentofu/shared/tailscale/` already, and **this workstream changes no ACL at all**.

| Component | Where |
|---|---|
| tailscale-operator | `security/gcp-0/tailscale-operator/` — chart + both ProxyClasses referenced **by file** from `security/base/`, with GCP's own OAuth ExternalSecret |
| Gateway API layer | `infrastructure/gcp-0/gapi/` — six cloud-neutral manifests from `infrastructure/base/gapi/`, excluding the AWS-shaped public Gateway |
| external-dns | `infrastructure/gcp-0/external-dns/` — `google` provider, private zone only, identity from a `GCPWorkloadIdentity` claim |

The wildcard `Certificate` needed no GCP variant: it already asks the `openbao` ClusterIssuer that workstream 11 verified end-to-end on this cluster.

Using `loadBalancerClass: tailscale` rather than a GCP forwarding rule means **the private gateways incur no cloud load-balancer charges**.

## What it deliberately does not build

**Public certificates and public ingress.** The parent design's open question observed that DNS-01 has nothing to solve against on GCP — the Cloud DNS zone is private, `cloud.ogenki.io` is a Route53 zone this repo doesn't manage, and Let's Encrypt must resolve the challenge publicly. It stays open because it isn't blocking: GCP has no public endpoint to put a certificate on, and workstream 12 owns that. Settling a registrar-level decision on speculation is the failure mode here.

Also no `ProxyGroup` — AWS runs two egress proxies; nothing on `gcp-0` egresses through the tailnet yet.

## The one change that touches AWS

Both Gateways' Tailscale hostnames become `gateway-{general,admin}-priv-${cluster_name}`, and the operator's own device becomes `tailscale-operator-${cluster_name}`. The tailnet is shared and a Tailscale hostname is tailnet-unique — two clusters claiming the same name doesn't error, it silently suffixes one of them.

Parameterising rather than suffixing only GCP is deliberate: a scheme where one cloud is the unlabelled default is exactly what [ADR-0017](website/content/docs/decisions/0017-multi-cloud-dns-naming.md) rejects, and is why the clusters were renamed `aws-0`/`gcp-0` in #1832.

**Cost, stated rather than buried:** the AWS operator registers new Tailscale devices on next reconcile. external-dns rewrites the `*.priv.aws.ogenki.io` records after its sync interval, so there is a brief window where private AWS services are unreachable, and the superseded devices linger in the tailnet and need deleting by hand. Apply this in a window where that is acceptable.

## Identity — the opposite call from workstream 11, deliberately

external-dns gets its permissions through the `GCPWorkloadIdentity` composition — its **first consumer**. Workstream 11 rejected that same composition for External Secrets and bound per-secret instead, because `ProjectIAMMember` is project-scoped and would have granted read of every secret in the project including the intermediate CA's private key.

external-dns's access genuinely *is* project-shaped: it must discover which zone owns a name, which needs `dns.managedZones.list` across the project and cannot be expressed per zone. `xplane_dns_editor` excludes zone create and delete. The comments say plainly that the role is project-wide and that `domainFilters` is a client-side filter, not a security boundary.

## Defects found and fixed before any deploy

Six reviews ran — one per task plus a whole-branch review. They found two things static validation could not:

- **A Kustomization missing `postBuild.substituteFrom`** (Critical). `${project_id}` would have reached the API server literally, failing the `GCPWorkloadIdentity` claim's `roles[]` pattern and taking the whole `infrastructure` Kustomization down. Found independently by both the implementer and the reviewer.
- **`healthChecks` on a Gateway asserts existence, not readiness** (Important). Gateway API v1 has no `Ready` condition and no top-level `observedGeneration`, so kstatus reports Current the moment the object exists — and the comment claimed the opposite. Now gated on the `Programmed` condition via `healthCheckExprs`, the form `clusters/aws-0-llm-platform/security-llm-epi.yaml` already documents.
- **The `infrastructure` Kustomization had no edge to `crossplane-configuration`** (Important) while applying a Crossplane claim, because the plan asserted an edge that did not exist.
- Plus four Minor comment/accuracy fixes, all cases of a comment describing something the code does not do.

**Two validation blind spots surfaced, both filed as follow-ups rather than fixed here:**

1. `./scripts/validate-manifests.sh` **cannot** catch a missing `postBuild` block — `render-bundle.py` substitutes its fixtures unconditionally, regardless of whether the real Kustomization declares substitution. The gate passed while the manifest was undeployable.
2. CI never `helm template`s the GCP external-dns values: renderable HelmReleases are keyed by `(namespace, name)` and both clouds resolve to `kube-system/external-dns`, so the bundle renders AWS's values only. Nothing is broken today — the merged GCP values were rendered manually and produce `--provider=google` correctly.

Both are the same shape as the SPEC-007 problem that gate was built to remove.

## Gates

```
./scripts/validate-manifests.sh   exit 0 — 1238 resources / 205 files, Valid: 1238, Invalid: 0, Skipped: 0
./scripts/validate-links.sh       exit 0
./scripts/validate-doc-claims.sh  exit 0 — 6 claims, 10 page checks
tofu validate (gke/init)          Success
kustomize build infrastructure/gcp-0/gapi   OK
kustomize build infrastructure/aws-0        OK   ← shared file touched
kustomize build security/aws-0              OK   ← shared file touched
```

## Still open

- **Task 6 has not run.** The eight success criteria in the design are unverified against a cluster.
- One manual bootstrap step is outstanding: the Tailscale OAuth client in GCP Secret Manager. All three GCP prerequisites are now collected in [`docs/gcp-bootstrap.md`](docs/gcp-bootstrap.md) rather than scattered across three files.
- `crossplane-configuration` has no health gate on its Configuration package going Healthy, so the new edge orders but does not *prove* the XRD exists; the 1m retry is the backstop. A narrower window than before, not the same defect.


