### PR TITLE
feat(ci): fail when a Flux Kustomization applies ${vars} without postBuild

### DIFF
--- a/docs/gcp-bootstrap.md
+++ b/docs/gcp-bootstrap.md
@@ -67,6 +67,29 @@ required `operator-oauth` Secret — do not rename them.
 **Revoke this client on teardown** if the project is being decommissioned; it is
 the one prerequisite that is a live credential rather than an empty container.
 
+## Credentials your shell needs
+
+Distinct from the three prerequisites above: those are things that must EXIST in
+GCP, these are things that must be in the environment you run `terramate` from.
+Both cost a wasted round trip when missing, because the failure surfaces
+mid-deploy rather than up front.
+
+```bash
+gcloud auth login
+gcloud auth application-default login    # OpenTofu uses ADC, not the CLI credential
+export TF_VAR_tailscale_api_key=<tskey-api-...>
+```
+
+- **`TF_VAR_tailscale_api_key`** — `opentofu/gcp/network` manages the tailnet's
+  split-DNS entry and the subnet router's auth key. The variable has no default,
+  so a missing value stops the apply at the prompt.
+- **AWS credentials** — still needed, but only for `opentofu/shared/*`, whose
+  state remains in S3 because the tailnet belongs to neither cloud. Since
+  ADR-0018 the GCP stacks read GCS and need no AWS session of their own. Before
+  that change a GCP-only deploy failed at `tofu init` with
+  `No valid credential sources found` on an expired AWS SSO token, which is the
+  coupling that ADR removed.
+
 ## What is NOT a prerequisite
 
 The offline root CA and the GCP intermediate. Those come from the signing

--- a/scripts/flux-schema/check-substitution.py
+++ b/scripts/flux-schema/check-substitution.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Fail when a Flux Kustomization applies `${var}` but declares no postBuild.
+
+The gap this closes, measured 2026-08-25:
+
+`clusters/gcp-0/infrastructure/infrastructure.yaml` had no
+`spec.postBuild.substituteFrom`. Its path then gained the first manifests under
+it to reference `${project_id}` and `${private_domain_name}`. Flux applies the
+literal text when substitution is not wired, so a `GCPWorkloadIdentity` claim
+would have reached the API server with
+
+    roles: ["projects/${project_id}/roles/xplane_dns_editor"]
+
+which fails the XRD's `roles[]` pattern -- `$`, `{`, `}` are not in the allowed
+charset -- taking the whole `infrastructure` Kustomization down with it.
+
+`validate-manifests.sh` could not see it. render-bundle.py substitutes its
+FIXTURE_VARS unconditionally, so the bundle shows what Flux WOULD render if
+substitution were wired, never whether it is. The gate passed on an undeployable
+manifest.
+
+Fixing that inside the renderer would mean coupling it to the cluster's
+Kustomization graph, which its own `top_most_overlays` docstring explains it
+deliberately avoids. So this is a separate, narrow check that reads the
+Kustomizations directly -- the source of truth the renderer only approximates.
+
+WHY `kustomize build` RATHER THAN GREPPING THE DIRECTORY: a kustomization may
+reference files outside its own tree (`../../base/foo.yaml`), which this repo
+does deliberately and often. Grepping only the path's own directory misses
+those, which is a false negative on exactly the interesting cases. Building the
+overlay renders what Flux actually applies.
+
+Deliberately NOT checked here: whether each `${var}` is a key of the ConfigMap
+named in `substituteFrom`. Those keys come from OpenTofu
+(`opentofu/*/configure/kubernetes.tf`), and parsing HCL to find out would trade
+a precise check for a fragile one. An undefined variable is a different failure
+with a different fix.
+"""
+import pathlib
+import re
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CLUSTERS_DIR = REPO_ROOT / "clusters"
+KUSTOMIZE_BIN = "kustomize"
+
+# Matches ${var}. `$${var}` (the Grafana-dashboard escape that survives Flux
+# substitution on purpose) also contains a `${var}`, so it is excluded first --
+# otherwise every dashboard JSON would be a false positive.
+VAR_RE = re.compile(r"(?<!\$)\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
+ESCAPED_RE = re.compile(r"\$\$\{[a-zA-Z_][a-zA-Z0-9_]*\}")
+
+
+def flux_kustomizations():
+    """Every Flux Kustomization under clusters/, with its path and postBuild."""
+    try:
+        import yaml
+    except ImportError:
+        print("error: PyYAML is required", file=sys.stderr)
+        sys.exit(2)
+
+    for f in sorted(CLUSTERS_DIR.rglob("*.yaml")):
+        for doc in yaml.safe_load_all(f.read_text()):
+            if not isinstance(doc, dict):
+                continue
+            if doc.get("kind") != "Kustomization":
+                continue
+            if not str(doc.get("apiVersion", "")).startswith("kustomize.toolkit.fluxcd.io/"):
+                continue
+            spec = doc.get("spec") or {}
+            yield {
+                "file": f.relative_to(REPO_ROOT),
+                "name": (doc.get("metadata") or {}).get("name", "<unnamed>"),
+                "path": (spec.get("path") or "").lstrip("./"),
+                "post_build": spec.get("postBuild") or {},
+                "suspended": bool(spec.get("suspend")),
+            }
+
+
+def rendered_vars(path):
+    """Variables in what Flux would apply for this path, or None if unreadable.
+
+    Two shapes, because Flux accepts both:
+
+    - A kustomize root (has kustomization.yaml) -- build it, because a
+      kustomization may reference files outside its own tree
+      (`../../base/foo.yaml`), which this repo does deliberately. Grepping the
+      directory alone would miss those, a false negative on the interesting
+      cases.
+    - A plain directory of manifests (no kustomization.yaml) -- flux/sources,
+      flux/notifications and flux/observability are applied this way. Scan the
+      YAML directly. An earlier version of this check returned None for these
+      and skipped them, which was a blind spot of exactly the kind it exists to
+      remove.
+    """
+    target = REPO_ROOT / path
+    if not target.is_dir():
+        return None
+
+    if (target / "kustomization.yaml").is_file():
+        proc = subprocess.run(
+            [KUSTOMIZE_BIN, "build", str(target), "--load-restrictor=LoadRestrictionsNone"],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            return None
+        text = proc.stdout
+    else:
+        text = "\n".join(
+            f.read_text(errors="replace") for f in sorted(target.rglob("*.yaml"))
+        )
+
+    text = ESCAPED_RE.sub("", text)
+    return sorted(set(VAR_RE.findall(text)))
+
+
+def main():
+    failures = []
+    checked = 0
+    skipped = []
+
+    for k in flux_kustomizations():
+        if not k["path"]:
+            continue
+        variables = rendered_vars(k["path"])
+        if variables is None:
+            # Not a kustomize root in this repo (a remote source, or a path
+            # built from an ExternalArtifact that is not on disk here).
+            skipped.append(f"{k['name']} ({k['path']})")
+            continue
+        checked += 1
+        if not variables:
+            continue
+        wired = bool(k["post_build"].get("substituteFrom") or k["post_build"].get("substitute"))
+        if not wired:
+            failures.append(
+                f"  {k['file']}\n"
+                f"    Kustomization/{k['name']} path={k['path']}\n"
+                f"    renders {len(variables)} variable(s) with NO spec.postBuild: "
+                f"{', '.join('${' + v + '}' for v in variables)}\n"
+                f"    -> Flux would apply the literal text. Add:\n"
+                f"         postBuild:\n"
+                f"           substituteFrom:\n"
+                f"             - kind: ConfigMap\n"
+                f"               name: <cluster>-vars"
+            )
+
+    if skipped:
+        print(f"note: {len(skipped)} Kustomization(s) not buildable from this repo, not checked:")
+        for s in skipped:
+            print(f"  - {s}")
+
+    if failures:
+        print(
+            f"\nFAIL: {len(failures)} Flux Kustomization(s) apply substituted "
+            f"manifests without postBuild wired:\n",
+            file=sys.stderr,
+        )
+        for f in failures:
+            print(f, file=sys.stderr)
+            print(file=sys.stderr)
+        print(
+            "This is invisible to validate-manifests.sh: render-bundle.py substitutes "
+            "its fixtures unconditionally, so the bundle shows what Flux WOULD render "
+            "if substitution were wired, not whether it is.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"==> {checked} Flux Kustomization(s) checked; substitution wiring is consistent")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate-manifests.sh
+++ b/scripts/validate-manifests.sh
@@ -3,9 +3,10 @@
 #
 # Runs the same three steps locally and in CI, so "it validates" is a claim
 # backed by a command anyone — human or agent — can reproduce:
-#   1. generate the schema catalog (XRDs + Envoy AI Gateway CRDs)
-#   2. render the repo into a bundle (kustomize + envsubst + helm template)
-#   3. gate the bundle: flux schema validate, then polaris audit
+#   1. check every Flux Kustomization that applies ${vars} declares postBuild
+#   2. generate the schema catalog (XRDs + Envoy AI Gateway CRDs)
+#   3. render the repo into a bundle (kustomize + envsubst + helm template)
+#   4. gate the bundle: flux schema validate, then polaris audit
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -25,17 +26,24 @@ fi
 
 BUNDLE_DIR="${BUNDLE_DIR:-.bundle}"
 
-echo "==> [1/3] Generating schema catalog"
+# Runs FIRST and fails fast, because it is the one check the bundle cannot make.
+# render-bundle.py substitutes its fixtures unconditionally, so a Kustomization
+# missing postBuild renders correctly in the bundle and lands as literal
+# `${var}` text on the cluster. Measured 2026-08-25; see the script's docstring.
+echo "==> [1/4] Checking Flux variable substitution wiring"
+python3 scripts/flux-schema/check-substitution.py
+
+echo "==> [2/4] Generating schema catalog"
 ./scripts/flux-schema/gen-catalog.sh > /dev/null
 
-echo "==> [2/3] Rendering manifests into ${BUNDLE_DIR}/"
+echo "==> [3/4] Rendering manifests into ${BUNDLE_DIR}/"
 rm -rf "${BUNDLE_DIR}"
 python3 scripts/flux-schema/render-bundle.py "${BUNDLE_DIR}"
 
-echo "==> [3/3] Gate 1 — flux schema validate (structure + CEL)"
+echo "==> [4/4] Gate 1 — flux schema validate (structure + CEL)"
 "${FLUX_BIN}" schema validate "${BUNDLE_DIR}" --config .fluxschema.yml
 
-echo "==> [3/3] Gate 2 — polaris audit (workload best practices)"
+echo "==> [4/4] Gate 2 — polaris audit (workload best practices)"
 polaris audit \
   --audit-path "${BUNDLE_DIR}" \
   --config .polaris.yaml \


### PR DESCRIPTION
Closes the validation blind spot that let a Critical reach a live deploy during workstream 10, and documents the shell credentials a GCP deploy needs.

## The gap

`clusters/gcp-0/infrastructure/infrastructure.yaml` had no `postBuild.substituteFrom`. Its path then gained the first manifests to reference `${project_id}` and `${private_domain_name}`, so Flux would have applied literal text — and a `GCPWorkloadIdentity` claim would have reached the API server as:

```
roles: ["projects/${project_id}/roles/xplane_dns_editor"]
```

That fails the XRD's `roles[]` pattern (`$`, `{`, `}` are not in the allowed charset), taking the whole `infrastructure` Kustomization down with it.

**`validate-manifests.sh` passed the entire time.** `render-bundle.py` substitutes its `FIXTURE_VARS` unconditionally, so the bundle shows what Flux *would* render if substitution were wired — never whether it is. The manifest was read by two implementers and two reviewers; it was caught by a reviewer reasoning about the cluster graph, not by the gate.

## Why a separate check rather than fixing the renderer

The renderer discovers overlays by filesystem heuristic and never reads the Flux Kustomizations. Its own `top_most_overlays` docstring says so:

> This is a filesystem heuristic that approximates the true source of truth — the `spec.path` of every Flux Kustomization under clusters/. Deriving roots from those directly would be more exact but couples the renderer to the cluster's Kustomization graph.

Rather than take on that coupling, this reads the Kustomizations directly — the source of truth the renderer approximates.

## Two details that matter

**It builds each path instead of grepping it.** This repo references files across directories (`../../base/foo.yaml`) deliberately and often; grepping a path's own directory would miss exactly those, a false negative on the interesting cases.

**Plain manifest directories are scanned too.** `flux/sources`, `flux/notifications` and `flux/observability` have no `kustomization.yaml` — Flux applies them as plain YAML. An earlier draft returned `None` for those and skipped four Kustomizations, which would have been a blind spot of exactly the kind this check exists to remove.

Deliberately **not** checked: whether each `${var}` is a key of the ConfigMap named in `substituteFrom`. Those keys come from OpenTofu, and parsing HCL would trade a precise check for a fragile one. An undefined variable is a different failure with a different fix.

It runs **first** and fails fast — it is the one check the bundle cannot make.

## Verified by reintroducing the defect

A check that has never failed is not known to work:

```
postBuild present   ->  exit 0
postBuild removed   ->  exit 1, naming all four variables (${cluster_name},
                        ${private_domain_name}, ${project_id}, ${region})
                        and printing the fix
restored            ->  exit 0
```

## Also: credentials in docs/gcp-bootstrap.md

The three existing prerequisites are things that must EXIST in GCP. This adds what must be in the operator's *shell* — `TF_VAR_tailscale_api_key`, and AWS credentials, which since ADR-0018 are needed only for `opentofu/shared/*`. Both cost a round trip during the workstream 10 deploy because they surface mid-run rather than up front.

## Gates

```
./scripts/validate-manifests.sh   exit 0 — 44 Kustomizations checked, 0 skipped;
                                  Valid: 1238, Invalid: 0, Skipped: 0
./scripts/validate-links.sh       exit 0
./scripts/validate-doc-claims.sh  exit 0 — 6 claims, 10 page checks
```

## Follow-up, not in this PR

CI never `helm template`s the GCP external-dns values — renderable HelmReleases are keyed `(namespace, name)` and both clouds resolve to `kube-system/external-dns`, so only AWS's values are rendered. Same family of gap; being fixed separately since it changes rendering behaviour and bundle contents.