### PR TITLE
feat(gcp): bind token_bound_cidrs on both AppRole roles, from a live measurement

### DIFF
--- a/opentofu/gcp/openbao/management/auth.tf
+++ b/opentofu/gcp/openbao/management/auth.tf
@@ -26,10 +26,12 @@ resource "vault_approle_auth_backend_role" "snapshot" {
   # (secrets.tf), so there is no manifest-literal reason to fix this value --
   # let both be generated.
 
-  # NOTE: no token_bound_cidrs, same deferral as cert_manager's below: the
-  # candidate ranges (node_cidr, pod_cidr) are known, but which one the
-  # snapshot CronJob's egress actually presents to the internal LB has not
-  # been measured on this cluster. Bind once that measurement is taken.
+  # Bound now. The deferral this replaced said the ranges were known but which
+  # one the CronJob's egress actually presents had "not been measured on this
+  # cluster" -- it has been, on a live gcp-0 (2026-08-26). See
+  # local.approle_bound_cidrs for the measurement and why both ranges are bound
+  # rather than only the node CIDR the packets currently carry.
+  token_bound_cidrs = local.approle_bound_cidrs
 }
 
 resource "vault_approle_auth_backend_role" "cert_manager" {
@@ -63,24 +65,22 @@ resource "vault_approle_auth_backend_role" "cert_manager" {
   token_ttl     = 600
   token_max_ttl = 1200
 
-  # NOTE: no token_bound_cidrs, unlike AWS. DEFERRED, not impossible.
+  # Bound now, resolving the deferral this comment used to carry.
   #
-  # An earlier version of this comment said the source address could not be
-  # predicted because the caller reached OpenBao "over the tailnet". That is
-  # wrong, and it contradicted openbao/cluster/firewall.tf: cert-manager is a POD
-  # on gcp-0 talking to the internal LB inside the VPC, and never
-  # traverses the tailnet. The candidate ranges are perfectly predictable --
-  # node_cidr and pod_cidr, both already reachable from this stack through the
-  # network remote state.
+  # That deferral was right to exist and right about the diagnosis: cert-manager
+  # is a POD on gcp-0 talking to the internal LB inside the VPC, never over the
+  # tailnet, so the candidate ranges were always node_cidr and pod_cidr. What it
+  # correctly refused to guess was WHICH one the packet presents, since Cilium
+  # displaced GKE's CNI here.
   #
-  # What is NOT yet known is WHICH of the two the packet actually presents.
-  # Cilium displaced GKE's CNI here, so whether pod egress to an in-VPC LB is
-  # masqueraded to the node IP or arrives with the pod IP is a measurement
-  # nobody has taken on this cluster. Binding to the wrong one fails closed at
-  # issuance, with an error that names the AppRole and says nothing about the
-  # network.
+  # It has now been measured on a live gcp-0 (2026-08-26): native routing with
+  # the native-routing CIDR set to the POD range, masquerading on, and the LB
+  # outside that range -- so pod egress is SNATed to the node IP. Details in
+  # local.approle_bound_cidrs.
   #
-  # So: measure it against a running cluster (`hubble observe` on the
-  # cert-manager pod, or the OpenBao audit log's remote_address), then bind to
-  # what it shows. Do not guess.
+  # One correction the deferral also needs: it said both ranges were "already
+  # reachable from this stack through the network remote state". They were not.
+  # That data source lived only in openbao/cluster/data.tf; this stack had none
+  # until it was added alongside this change.
+  token_bound_cidrs = local.approle_bound_cidrs
 }

--- a/opentofu/gcp/openbao/management/data.tf
+++ b/opentofu/gcp/openbao/management/data.tf
@@ -16,3 +16,22 @@ data "google_secret_manager_secret_version" "intermediate_ca" {
   secret  = var.intermediate_ca_secret_name
   project = var.project_id
 }
+
+# The network stack owns the VPC and its ranges. Consumed here for one reason:
+# both AppRole roles in auth.tf bind `token_bound_cidrs`, and the ranges a gcp-0
+# pod may legitimately present to OpenBao's internal LB are the node and pod
+# CIDRs, which this stack has no other way to learn.
+#
+# auth.tf previously claimed these were "already reachable from this stack
+# through the network remote state". They were not -- that block lived in
+# openbao/cluster/data.tf, the sibling stack, and never here. This adds it,
+# mirroring that block verbatim rather than introducing variables: two sources
+# for one pair of values is how the stacks drift apart.
+data "terraform_remote_state" "network" {
+  backend = "gcs"
+
+  config = {
+    bucket = "ogenki-cloud-native-ref-tfstate"
+    prefix = "cloud-native-ref/gcp/network"
+  }
+}

--- a/opentofu/gcp/openbao/management/locals.tf
+++ b/opentofu/gcp/openbao/management/locals.tf
@@ -1,3 +1,31 @@
 locals {
   openbao_address = "https://bao.${var.private_domain_name}:8200"
+
+  # Source ranges an in-cluster caller may present to OpenBao's internal LB.
+  #
+  # MEASURED on a live gcp-0 (2026-08-26), not inferred -- auth.tf carried this
+  # as an explicit deferral pending exactly this measurement:
+  #
+  #   cilium-dbg status        -> Routing: Native; Masquerading: IPTables [IPv4: Enabled]
+  #   cilium-config            -> ipv4-native-routing-cidr = 100.65.0.0/16 (the POD cidr)
+  #   OpenBao internal LB      -> 10.10.0.9, inside the NODE cidr 10.10.0.0/16
+  #
+  # The LB sits OUTSIDE the native-routing CIDR, and masquerading is on, so pod
+  # egress to it is SNATed to the node IP -- observed as 10.10.0.5. So today the
+  # node CIDR is the range that actually matters.
+  #
+  # Both are bound anyway, and that is deliberate rather than hedging: it is the
+  # exact analogue of what AWS binds. There, allowed_cidr_blocks is the whole VPC
+  # (10.0.0.0/16), which already contains both node and pod addresses because
+  # VPC-CNI gives pods VPC IPs. On GCP the two ranges are disjoint, so covering
+  # the same surface takes two entries. Binding node-only would also fail closed
+  # if a future datapath change (bpf.masquerade, a wider native-routing CIDR)
+  # stopped SNATing -- and it fails at AUTH, with an error naming the AppRole and
+  # saying nothing about the network.
+  approle_bound_cidrs = [
+    local.network.node_cidr,
+    local.network.pod_cidr,
+  ]
+
+  network = data.terraform_remote_state.network.outputs
 }


### PR DESCRIPTION
## What

Binds `token_bound_cidrs` on both GCP AppRole roles (`snapshot-agent` and `cert-manager`), closing a
deferral `auth.tf` has carried since workstream 11.

That deferral was correct to exist. It named the candidate ranges — `node_cidr` and `pod_cidr` — and
then refused to pick one, because Cilium displaced GKE's CNI here and nobody had measured whether pod
egress to an in-VPC load balancer arrives masqueraded to the node IP or as the pod IP. Binding the
wrong one **fails closed at authentication**, with an error that names the AppRole and says nothing
about the network.

## The measurement

Taken on a live `gcp-0` during workstream 9's deploy, not inferred:

```
cilium-dbg status  ->  Routing: Native;  Masquerading: IPTables [IPv4: Enabled]
cilium-config      ->  ipv4-native-routing-cidr = 100.65.0.0/16   (the POD cidr)
OpenBao LB         ->  10.10.0.9, inside the NODE cidr 10.10.0.0/16
observed node IP   ->  10.10.0.5
```

The LB sits **outside** the native-routing CIDR and masquerading is on, so pod egress to it is SNATed
to the node IP. The node CIDR is the range that actually matters today.

## Why both ranges are bound, not just the node CIDR

This is the analogue of what AWS already does, not hedging. On `aws-0`, `allowed_cidr_blocks` is the
whole VPC (`10.0.0.0/16`) — which already contains *both* node and pod addresses, because VPC-CNI
gives pods VPC IPs. On GCP the two ranges are disjoint, so covering the same surface takes two
entries.

It also survives a datapath change. If `bpf.masquerade` were ever enabled, or the native-routing CIDR
widened, packets could start arriving with pod IPs — and a node-only binding would fail closed at
auth, for both the snapshot job *and* cert-manager, which issues the cluster's certificates.

## A false claim corrected while here

The deferral asserted that both ranges were *"already reachable from this stack through the network
remote state"*. **They were not.** That `terraform_remote_state "network"` block lives in
`openbao/cluster/data.tf` — the sibling stack — and never existed here. Anyone implementing from that
comment would have reached for a data source that wasn't there.

Added to this stack, mirroring the sibling block verbatim rather than introducing variables: two
sources for one pair of values is how the two stacks drift apart.

## Verification

```
$ tofu -chdir=opentofu/gcp/openbao/management fmt -check   # exit 0
$ tofu -chdir=opentofu/gcp/openbao/management validate
Success! The configuration is valid.
```

`opentofu/gcp/network/outputs.tf` exports both `node_cidr` and `pod_cidr`, so the references resolve.
No `apply` was run — no cluster is deployed. `opentofu/aws/` is untouched.
