### PR TITLE
chore(deps): bump crossplane-configuration to v0.4.1

### DIFF
--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -192,7 +192,7 @@ spec:
         - clone
         - --depth=1
         - --single-branch
-        - --branch=v0.4.0
+        - --branch=v0.4.1
         - https://github.com/Smana/crossplane-configuration.git
         - /repo/crossplane-configuration
       securityContext:

--- a/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
@@ -13,4 +13,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-gcp
 spec:
-  package: ghcr.io/smana/crossplane-configuration-gcp:v0.4.0
+  package: ghcr.io/smana/crossplane-configuration-gcp:v0.4.1

--- a/infrastructure/base/crossplane/configuration/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration/configuration-packages.yaml
@@ -12,4 +12,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-aws
 spec:
-  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.0
+  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.1


### PR DESCRIPTION
## Why

[crossplane-configuration#14](https://github.com/Smana/crossplane-configuration/pull/14) fixed a defect that had **every routed `App` sitting `Ready=False` on aws-0** since ADR-0017 renamed the private domains. Released as **v0.4.1**; this adopts it.

The `App` and `InferenceService` Compositions hardcoded `.priv.cloud.ogenki.io` for route hostnames while the Gateways serve `*.priv.aws.ogenki.io`, so no HTTPRoute they rendered was ever Accepted. Observed live before the fix:

```
apps     app-wizard            SYNCED=True  READY=False
apps     xplane-image-gallery  SYNCED=True  READY=False
apps     xplane-podinfo        SYNCED=True  READY=False
tooling  xplane-pev2           SYNCED=True  READY=False
demo     podinfo               SYNCED=True  READY=True   ← no route
```

Both Compositions now read `envConfig.privateDomainName`, which both clusters already publish correctly.

## What changed here

Three pins, which move together by design:

| | v0.4.0 → v0.4.1 |
|---|---|
| `configuration/configuration-packages.yaml` | `crossplane-configuration-aws` |
| `configuration-gcp/configuration-packages.yaml` | `crossplane-configuration-gcp` |
| `apps/platform/app-wizard/app.yaml` | clone tag (tracks the same pin) |

**No API change** — every XRD, Composition name and claim field is unchanged, so no manifest in this repo needs editing. A cluster whose EnvironmentConfig lacked `privateDomainName` would keep its current behaviour through the fallback; both of ours publish it.

## Expected effect on the running clusters

Once reconciled, the four `App` claims above should go `READY=True` as their HTTPRoutes finally match a Gateway listener. That is the verification this PR exists for, and I'll confirm it on both live clusters rather than assuming.

## Verification

| Gate | Result |
|---|---|
| `./scripts/validate-manifests.sh` | **2054 resources, Invalid: 0, Skipped: 0** |

Worth noting: the first validation run here returned 2047, which was the tell that this worktree had branched from a stale `origin/main` predating #1857. Rebasing brought it to 2054, matching that PR's baseline.
