### PR TITLE
refactor: drop the domain_name alias, which was AWS-only by accident

### DIFF
--- a/infrastructure/aws-0/gapi/platform-public-gateway.yaml
+++ b/infrastructure/aws-0/gapi/platform-public-gateway.yaml
@@ -29,7 +29,7 @@ spec:
       service.beta.kubernetes.io/aws-load-balancer-type: "external"
   listeners:
     # One listener per public hostname, each with its own TLS secret. NOT a
-    # wildcard: `*.${domain_name}` would put every service under the domain
+    # wildcard: `*.${public_domain_name}` would put every service under the domain
     # behind a single private key, so one leaked Secret or compromised pod would
     # expose all of them. cert-manager's gateway-shim issues one Certificate per
     # listener, with exactly that hostname in its SAN list.
@@ -38,7 +38,7 @@ spec:
     # makes publishing a reviewed edit, so this costs nothing extra and turns
     # the listener list into an auditable inventory of what is internet-facing.
     - name: runlore
-      hostname: "runlore.${domain_name}"
+      hostname: "runlore.${public_domain_name}"
       port: 443
       protocol: HTTPS
       allowedRoutes:

--- a/infrastructure/base/gapi/example-public-gateway.yaml
+++ b/infrastructure/base/gapi/example-public-gateway.yaml
@@ -17,7 +17,7 @@ spec:
       service.beta.kubernetes.io/aws-load-balancer-type: "external"
   listeners:
     - name: http
-      hostname: "myapp.${domain_name}"   # one listener per hostname; never a wildcard
+      hostname: "myapp.${public_domain_name}"   # one listener per hostname; never a wildcard
       port: 443
       protocol: HTTPS
       allowedRoutes:

--- a/observability/base/runlore/httproute.yaml
+++ b/observability/base/runlore/httproute.yaml
@@ -14,7 +14,7 @@ spec:
     - name: platform-public
       namespace: infrastructure
   hostnames:
-    - "runlore.${domain_name}"
+    - "runlore.${public_domain_name}"
   rules:
     - matches:
         - path:

--- a/observability/gcp-0/kustomization.yaml
+++ b/observability/gcp-0/kustomization.yaml
@@ -16,13 +16,29 @@ resources:
 
 # TWO components from aws-0's list are deliberately absent.
 #
-# ../base/runlore — the only observability component that is NOT cloud-neutral.
-# It reads ${domain_name}, a key only aws-0's vars ConfigMap defines (gcp-0 has
-# private_domain_name and public_domain_name, not the bare one). Flux
-# substitutes an undefined variable to EMPTY, so wiring it here would render a
-# hostname with a hole in it rather than fail — the silent-wrong case
-# scripts/flux-schema/check-substitution.py exists to catch. It also drives AWS
-# cloud tools, so a hostname fix alone would not make it useful here.
+# ../base/runlore — still absent, but for a NARROWER reason than before.
+#
+# It used to read ${domain_name}, a key only aws-0's ConfigMap defined. That key
+# is gone: it held the same value as public_domain_name, which both clusters
+# publish, so the HTTPRoute is now cloud-neutral and that blocker is closed.
+#
+# What remains is real and needs a live cluster to settle:
+#   - the HelmRelease hardcodes `cloud: {provider: aws, region, cluster_name}`
+#     and `networkPolicy.awsPodIdentity: true`; a gcp-0 overlay would patch both
+#     to `provider: gcp` / `gcpWorkloadIdentity: true`
+#   - its identity is an EPI (security/base/epis/runlore.yaml); GCP needs a
+#     GCPWorkloadIdentity granting logging.viewer, container.clusterViewer and
+#     compute.viewer — none of which crossplane_grantable_roles in
+#     opentofu/gcp/gke/init/iam.tf allows today. Widening that list is a
+#     deliberate act, per its own comment.
+#   - upstream, the chart's gcpWorkloadIdentity NetworkPolicy uses
+#     `toEntities: host`, which does not reach the GKE metadata server under
+#     Cilium — proven on a live gcp-0 and filed as Smana/runlore#562. Until that
+#     lands, the cloud tools silently disable themselves.
+#
+# Deliberately not wired blind: an overlay written without a cluster to test it
+# on is exactly the kind of "cloud-neutral" claim this repo has been wrong about
+# five times already.
 #
 # ../base/victoria-traces — NOT because it is cloud-specific (it is neutral),
 # but because clusters/gcp-0/observability/observability-victoria-traces.yaml

--- a/opentofu/aws/eks/configure/kubernetes.tf
+++ b/opentofu/aws/eks/configure/kubernetes.tf
@@ -67,9 +67,19 @@ resource "kubectl_manifest" "flux_cluster_vars" {
       # nothing derives anything else from it, which is what makes one
       # shared key honest here where ${region} was not (see the
       # workstream 13 design).
-      storage_class       = "gp3"
-      environment         = var.env
-      domain_name         = var.public_domain_name
+      storage_class = "gp3"
+      environment   = var.env
+      # `domain_name` used to sit here as a THIRD key holding
+      # var.public_domain_name -- the same value as public_domain_name below,
+      # under a second name. It was removed rather than kept as a harmless
+      # alias, because it was not harmless: gcp-0's ConfigMap never defined it,
+      # so every manifest reaching for ${domain_name} was AWS-only by accident
+      # rather than by design. observability/base/runlore was excluded from
+      # gcp-0 for exactly this reason and nothing else.
+      #
+      # Flux substitutes an undefined variable to EMPTY, so such a manifest does
+      # not fail on GCP -- it renders a hostname with a hole in it. Two keys for
+      # one value is how that happens quietly.
       private_domain_name = var.private_domain_name
       public_domain_name  = var.public_domain_name
 

--- a/scripts/flux-schema/render-bundle.py
+++ b/scripts/flux-schema/render-bundle.py
@@ -70,7 +70,10 @@ NON_MANIFEST_FILES = {
 # Same fixture values CI passed to kubeconform. Substituted so that
 # ${private_domain_name} in a DNS-1123 field validates as a hostname.
 FIXTURE_VARS = {
-    "domain_name": "cluster.local",
+    # No "domain_name": it was removed from the aws-0 ConfigMap, where it was a
+    # second key holding the same value as public_domain_name. A fixture for a
+    # key no cluster defines would let a manifest reference it and still render
+    # here -- which is precisely how the AWS-only usages went unnoticed.
     "private_domain_name": "priv.cluster.local",
     "public_domain_name": "cluster.local",
     "cluster_name": "foobar",

--- a/security/base/cert-manager/le-clusterissuer-prod.yaml
+++ b/security/base/cert-manager/le-clusterissuer-prod.yaml
@@ -11,7 +11,7 @@ spec:
     solvers:
       - selector:
           dnsZones:
-            - "${domain_name}"
+            - "${public_domain_name}"
         dns01:
           route53:
             region: ${region}

--- a/security/base/cert-manager/le-clusterissuer-staging.yaml
+++ b/security/base/cert-manager/le-clusterissuer-staging.yaml
@@ -11,7 +11,7 @@ spec:
     solvers:
       - selector:
           dnsZones:
-            - "${domain_name}"
+            - "${public_domain_name}"
         dns01:
           route53:
             region: ${region}


### PR DESCRIPTION
## Why

aws-0's vars ConfigMap held **three** domain keys where two would do:

```hcl
domain_name         = var.public_domain_name
private_domain_name = var.private_domain_name
public_domain_name  = var.public_domain_name
```

`domain_name` and `public_domain_name` were **the same value under two names**. gcp-0 defined only the latter — so every manifest reaching for `${domain_name}` was AWS-only *by accident*, because a redundant key happened to exist on one cluster.

That is not a harmless alias. Flux substitutes an undefined variable to **empty**, so such a manifest doesn't fail on GCP — it renders a hostname with a hole in it.

**`observability/base/runlore` was excluded from gcp-0 for this reason and no other** — one line, `runlore.${domain_name}` in its HTTPRoute.

## What changed

Five manifests move to `${public_domain_name}`, which both clusters publish and which on aws-0 resolves to the identical value:

- `security/base/cert-manager/le-clusterissuer-{prod,staging}.yaml`
- `observability/base/runlore/httproute.yaml`
- `infrastructure/aws-0/gapi/platform-public-gateway.yaml`
- `infrastructure/base/gapi/example-public-gateway.yaml`

The key is then **removed** from the ConfigMap rather than left as a deprecated alias — and its render fixture with it. Keeping the fixture would let a manifest reference a key no cluster defines and still render clean here, which is exactly how these usages went unnoticed.

**Zero behaviour change on aws-0**: same value, different name.

## runlore is still not wired to gcp-0

The note in `observability/gcp-0/kustomization.yaml` now says why in narrower terms. Three things remain, none of them this one:

1. The HelmRelease hardcodes `cloud: {provider: aws, region, cluster_name}` and `networkPolicy.awsPodIdentity: true` — patchable by an overlay.
2. Its identity is an `EPI`. GCP needs a `GCPWorkloadIdentity` granting `logging.viewer`, `container.clusterViewer` and `compute.viewer` — **none of which `crossplane_grantable_roles` allows today**. Widening that list is a deliberate act, per its own comment.
3. Upstream, the chart's `gcpWorkloadIdentity` NetworkPolicy uses `toEntities: host`, which cannot reach the GKE metadata server under Cilium — proven on a live gcp-0 today and filed as [Smana/runlore#562](https://github.com/Smana/runlore/issues/562).

I deliberately did not write that overlay blind. An untested "cloud-neutral" claim is what this repo has already been wrong about five separate times this week.

## Verification

| Gate | Result |
|---|---|
| `./scripts/validate-manifests.sh` | **2054 resources, Invalid: 0, Skipped: 0** |
| `scripts/flux-schema/check-substitution.py` | 63 Kustomizations consistent **with the key gone** |
| links · doc-paths · `tofu fmt`/`validate`/`tflint` | clean |
