### PR TITLE
fix: close the two gaps that made the GCP teardown leak resources

### DIFF
--- a/observability/gcp-0/victoria-metrics-k8s-stack/kustomization.yaml
+++ b/observability/gcp-0/victoria-metrics-k8s-stack/kustomization.yaml
@@ -8,8 +8,9 @@ kind: Kustomization
 # downstream depends on, so it has to reach Ready before grafana-operator and
 # the rest of observability apply.
 #
-# Nothing is patched: the base is cloud-neutral, and its PVCs read
-# ${storage_class}, which is standard-rwo on this cluster.
+# The base is otherwise cloud-neutral -- its PVCs read ${storage_class}, which
+# is standard-rwo on this cluster. The single patch below is the one thing that
+# could not be parameterised.
 resources:
   - ../../base/victoria-metrics-k8s-stack
 

--- a/opentofu/gcp/gke/init/workflows.tm.hcl
+++ b/opentofu/gcp/gke/init/workflows.tm.hcl
@@ -162,6 +162,57 @@ script "destroy" {
   }
 
   job {
+    name        = "stage2-reclaim-volumes"
+    description = "Reclaim CSI-provisioned PD disks while the cluster still exists"
+    commands = [
+      ["bash", "-c", <<-BASH
+        if [ "$${TM_GCP_ENABLED:-}" != "true" ]; then
+          echo "[skip] GKE init destroy (stage2-reclaim-volumes): set TM_GCP_ENABLED=true"
+          exit 0
+        fi
+        set -euo pipefail
+
+        # Deleting the cluster with PVCs still bound skips the reclaim entirely:
+        # the PD CSI controller dies with the cluster and every PVC-backed disk
+        # is orphaned in the project with nothing left referencing it. Nothing
+        # reports it -- destroy says "Destroy complete" and the disks bill on.
+        # The 2026-08-27 gcp-0 teardown left three that way (20/10/5 GB), which
+        # is the GCP replay of an EBS leak EKS already had a step for.
+        #
+        # Runs BEFORE stage2-destroy-addons on purpose: once Cilium is gone the
+        # cluster's networking is unreliable, and the CSI controller needs to be
+        # both running and reachable for a PVC delete to actually detach a disk.
+        #
+        # Never gates the teardown, for the same reason stage 2 does not: the
+        # control-plane endpoint is PRIVATE, so the usual reason to be running
+        # destroy is that the cluster or the tailnet is unreachable. The script
+        # exits 0 when it cannot reach the cluster, and the disks it misses are
+        # caught by the sweep in the network stack's destroy.
+        #
+        # A throwaway KUBECONFIG so a teardown never edits the operator's own
+        # kubeconfig or leaves a context behind for a cluster that is about to
+        # stop existing.
+        KUBECONFIG="$(mktemp -t gke-teardown-kubeconfig.XXXXXX)"
+        export KUBECONFIG
+        trap 'rm -f "$${KUBECONFIG}"' EXIT
+
+        name="$(${global.provisioner} output -raw cluster_name)"
+        location="$(${global.provisioner} output -raw cluster_location)"
+        project="$(${global.provisioner} output -raw project_id)"
+
+        if gcloud container clusters get-credentials "$${name}" \
+             --location "$${location}" --project "$${project}" 2>/dev/null; then
+          bash "${terramate.root.path.fs.absolute}/scripts/k8s-reclaim-csi-volumes.sh" || true
+        else
+          echo "[warn] could not fetch credentials for $${name}; skipping the in-cluster"
+          echo "       reclaim. Any orphaned disks are swept by the network stack destroy."
+        fi
+      BASH
+      ],
+    ]
+  }
+
+  job {
     name        = "stage2-destroy-addons"
     description = "Attempt a graceful Cilium and Flux teardown; never blocks the cluster deletion"
     commands = [

--- a/opentofu/gcp/network/workflows.tm.hcl
+++ b/opentofu/gcp/network/workflows.tm.hcl
@@ -103,6 +103,31 @@ script "destroy" {
         set -euo pipefail
         bash "${terramate.root.path.fs.absolute}/scripts/terramate-destroy-confirm.sh"
         ${global.provisioner} init -lock-timeout=5m
+
+        # Empty the private Cloud DNS zone first. external-dns wrote a record for
+        # every HTTPRoute on the cluster and nothing removes them when the
+        # cluster goes -- the controller that owned them went with it. Cloud DNS
+        # then refuses to delete a non-empty zone:
+        #
+        #   Error 400: The container is not empty., containerNotEmpty
+        #
+        # which lands at the END of the destroy, after the rest of the VPC is
+        # already gone, leaving the stack half-torn-down. On 2026-08-27 that meant
+        # deleting twelve records by hand before this stack would destroy.
+        #
+        # Reads the zone name from state rather than re-deriving it, so it cannot
+        # drift from the resource. Tolerated if the zone is already gone: the
+        # script exits 0 when there is nothing to purge, which keeps a re-run of a
+        # partially completed destroy working.
+        zone="$(${global.provisioner} output -raw private_dns_zone_name 2>/dev/null || true)"
+        project="$(${global.provisioner} output -raw project_id 2>/dev/null || true)"
+        if [ -n "$${zone}" ] && [ -n "$${project}" ]; then
+          bash "${terramate.root.path.fs.absolute}/scripts/gcp-purge-dns-records.sh" \\
+            "$${zone}" "$${project}"
+        else
+          echo "[warn] no DNS zone in state; skipping the record purge."
+        fi
+
         ${global.provisioner} destroy -auto-approve -var-file=variables.tfvars
       BASH
       ],

--- a/scripts/eks-prepare-destroy.sh
+++ b/scripts/eks-prepare-destroy.sh
@@ -103,61 +103,16 @@ done
 # also fires during destroy when the gateway-api CRDs go away).
 kubectl delete validatingadmissionpolicybinding --all --wait=false 2>/dev/null || true
 
-# Reclaim CSI-provisioned volumes BEFORE any node teardown. Destroying the
-# cluster with PVCs still bound skips the reclaim (the EBS CSI controller
-# dies with the cluster) and every PVC-backed EBS volume is orphaned in the
-# account — 62 volumes (~518Gi) had accumulated across rebuilds by 2026-07.
-# Must run while the CSI controller is schedulable, i.e. before the
-# Karpenter NodePool deletion below starts draining nodes.
-echo "Reclaiming CSI-provisioned volumes..."
-
-# 1. Belt-and-braces: make every PV reclaimable (covers future Retain PVs).
-for pv in $(kubectl get pv -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
-	kubectl patch pv "$pv" --type=merge -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}' >/dev/null 2>&1 || true
-done
-
-# 2. CNPG clusters own their pods AND PVCs (recreating both if deleted from
-#    under them) — delete the Cluster CRs so the operator reclaims cleanly.
-if kubectl api-resources --api-group=postgresql.cnpg.io 2>/dev/null | grep -q clusters; then
-	kubectl delete clusters.postgresql.cnpg.io --all --all-namespaces --wait=false 2>/dev/null || true
-fi
-
-# 3. Scale to 0 exactly the Deployments/StatefulSets that mount PVCs (STS
-#    would recreate PVCs from their templates if we only deleted pods).
-#    Selecting by PVC-presence never touches kube-system's CSI controller.
-kubectl get deploy,statefulset --all-namespaces -o json 2>/dev/null \
-	| jq -r '.items[] | select((([.spec.template.spec.volumes[]? | select(.persistentVolumeClaim)] | length) > 0) or (((.spec.volumeClaimTemplates // []) | length) > 0)) | "\(.kind|ascii_downcase) \(.metadata.namespace) \(.metadata.name)"' 2>/dev/null \
-	| while read -r kind ns name; do
-		[ -z "$name" ] && continue
-		kubectl scale "$kind" -n "$ns" "$name" --replicas=0 >/dev/null 2>&1 || true
-	done
-
-# 4. Catch-all for remaining PVC-mounting pods (Jobs, naked pods): PVC
-#    deletion blocks on the pvc-protection finalizer while any pod uses it.
-kubectl get pods --all-namespaces -o json 2>/dev/null \
-	| jq -r '.items[] | select(([.spec.volumes[]? | select(.persistentVolumeClaim)] | length) > 0) | "\(.metadata.namespace) \(.metadata.name)"' 2>/dev/null \
-	| while read -r ns name; do
-		[ -z "$name" ] && continue
-		kubectl delete pod -n "$ns" "$name" --wait=false 2>/dev/null || true
-	done
-
-# 5. Delete the PVCs and wait for the CSI driver to reclaim every PV (the
-#    moment the PV list is empty, the EBS volumes are gone from AWS too).
-kubectl delete pvc --all --all-namespaces --wait=false 2>/dev/null || true
-echo "Waiting for PersistentVolumes to be reclaimed (up to 300s)..."
-for _ in $(seq 1 60); do
-	pv_count=$(kubectl get pv --no-headers 2>/dev/null | wc -l)
-	[ "$pv_count" = "0" ] && break
-	sleep 5
-done
-if [ "${pv_count:-0}" != "0" ]; then
-	echo "WARNING: ${pv_count} PV(s) not reclaimed — their backing volumes may be orphaned:"
-	kubectl get pv -o jsonpath='{range .items[*]}{.metadata.name}{" -> "}{.spec.csi.volumeHandle}{"\n"}{end}' 2>/dev/null || true
-	echo "The EBS sweep below deletes any that reach 'available' before this script exits;"
-	echo "volumes still attached to draining nodes are caught by the NEXT prepare-destroy run."
-else
-	echo "All PersistentVolumes reclaimed."
-fi
+# Reclaim CSI-provisioned volumes BEFORE any node teardown. Must run while the
+# CSI controller is still schedulable, i.e. before the Karpenter NodePool
+# deletion below starts draining nodes.
+#
+# Every step of it is plain Kubernetes and applies to any CSI driver, so it
+# lives in a shared script rather than here: GKE orphaned three PD disks on the
+# 2026-08-27 gcp-0 teardown for want of exactly this, and a second copy would
+# have been a second thing to forget. The EBS sweep below is the AWS-specific
+# half, and stays here.
+"$(dirname "$0")/k8s-reclaim-csi-volumes.sh" || true
 
 # Sweep EBS volumes this cluster orphaned in EARLIER runs. The reclaim above
 # only covers PVs that still exist; anything left behind by a previous destroy

--- a/scripts/gcp-purge-dns-records.sh
+++ b/scripts/gcp-purge-dns-records.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Empty a Cloud DNS managed zone so the zone itself can be destroyed.
+#
+# WHY THIS EXISTS
+#
+# Cloud DNS refuses to delete a managed zone that still holds record sets:
+#
+#   Error 400: The container is not empty., containerNotEmpty
+#
+# external-dns writes records into the private zone for every HTTPRoute on the
+# cluster, and those records outlive the cluster -- nothing deletes them when
+# the GKE cluster goes away, because the controller that owned them is gone
+# with it. So `tofu destroy` of the network stack fails at the very end, after
+# it has already torn down the VPC's other contents, and the teardown has to be
+# finished by hand.
+#
+# That is exactly what happened on 2026-08-27: twelve records (six A, six `a-`
+# TXT ownership entries) had to be deleted one at a time with gcloud before
+# gcp/network would destroy.
+#
+# NS and SOA at the zone apex are deliberately left alone. Cloud DNS creates
+# them with the zone, refuses to delete them independently, and removes them
+# when the zone goes -- so they never block the destroy.
+#
+# Usage:
+#   gcp-purge-dns-records.sh <zone-name> <project-id>
+#
+# Safe to run when the zone is already gone or already empty: it reports and
+# exits 0 either way, so a destroy that is re-run does not fail here.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ZONE="${1:-}"
+PROJECT="${2:-}"
+
+if [ -z "$ZONE" ] || [ -z "$PROJECT" ]; then
+    echo "usage: $(basename "$0") <zone-name> <project-id>" >&2
+    exit 2
+fi
+
+if ! gcloud dns managed-zones describe "$ZONE" --project "$PROJECT" >/dev/null 2>&1; then
+    echo "Cloud DNS zone '${ZONE}' does not exist — nothing to purge."
+    exit 0
+fi
+
+# name<TAB>type, apex NS/SOA excluded.
+records=$(gcloud dns record-sets list \
+    --zone "$ZONE" --project "$PROJECT" \
+    --format='value[separator="	"](name,type)' 2>/dev/null \
+    | awk -F'\t' '$2 != "NS" && $2 != "SOA"')
+
+if [ -z "$records" ]; then
+    echo "Cloud DNS zone '${ZONE}' holds no deletable records."
+    exit 0
+fi
+
+count=$(printf '%s\n' "$records" | wc -l)
+echo "Purging ${count} record set(s) from '${ZONE}' so the zone can be destroyed:"
+
+failed=0
+while IFS=$'\t' read -r name type; do
+    [ -z "$name" ] && continue
+    if gcloud dns record-sets delete "$name" --type "$type" \
+         --zone "$ZONE" --project "$PROJECT" >/dev/null 2>&1; then
+        echo "  deleted  ${type} ${name}"
+    else
+        echo "  FAILED   ${type} ${name}"
+        failed=$((failed + 1))
+    fi
+done <<< "$records"
+
+if [ "$failed" -gt 0 ]; then
+    echo
+    echo "WARNING: ${failed} record set(s) could not be deleted. The zone destroy will"
+    echo "fail with containerNotEmpty until they are removed."
+    exit 1
+fi
+
+echo "Zone '${ZONE}' is empty apart from its apex NS/SOA, which go with the zone."

--- a/scripts/k8s-reclaim-csi-volumes.sh
+++ b/scripts/k8s-reclaim-csi-volumes.sh
@@ -42,6 +42,24 @@ fi
 
 echo "Reclaiming CSI-provisioned volumes..."
 
+# 0. Suspend Flux first. Everything below deletes or scales down objects Flux
+#    owns, and a running reconciler puts every one of them straight back --
+#    the PVCs included, so the reclaim would appear to work and leave the
+#    volumes bound.
+#
+#    eks-prepare-destroy.sh already suspends Flux earlier for its own reasons,
+#    so on AWS this is a no-op. It is here because it is a PRECONDITION of the
+#    steps below, not a step of the caller's: a second caller that forgot it
+#    would get a silent, plausible-looking failure.
+if "${KCTL[@]}" api-resources --api-group=kustomize.toolkit.fluxcd.io >/dev/null 2>&1; then
+    echo "Suspending Flux kustomizations..."
+    if [ -n "$CONTEXT" ]; then
+        flux --context "$CONTEXT" suspend kustomization --all 2>/dev/null || true
+    else
+        flux suspend kustomization --all 2>/dev/null || true
+    fi
+fi
+
 # 1. Belt-and-braces: make every PV reclaimable (covers Retain PVs).
 for pv in $("${KCTL[@]}" get pv -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
     "${KCTL[@]}" patch pv "$pv" --type=merge \

--- a/scripts/k8s-reclaim-csi-volumes.sh
+++ b/scripts/k8s-reclaim-csi-volumes.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Reclaim CSI-provisioned volumes before a cluster is destroyed. CLOUD-NEUTRAL.
+#
+# Destroying a cluster with PVCs still bound skips the reclaim entirely: the CSI
+# controller dies with the cluster, and every PVC-backed volume is orphaned in
+# the cloud account with nothing left to reference it. Nothing reports this --
+# `tofu destroy` says "Destroy complete", and the volumes bill quietly.
+#
+# The history is on both clouds now:
+#   AWS  62 EBS volumes (~518Gi) accumulated across rebuilds by 2026-07, and 12
+#        more (~138Gi) from a single 2026-07-21 rebuild.
+#   GCP  3 orphaned PD disks (35Gi) survived the 2026-08-27 gcp-0 teardown --
+#        Harbor's registry, its CNPG cluster and trivy. GKE had no equivalent of
+#        this step at all; it was AWS-only because that is where it first hurt.
+#
+# Extracted from scripts/eks-prepare-destroy.sh rather than copied: every step
+# below is plain Kubernetes, and a second copy is a second thing to forget.
+#
+# MUST run while the CSI controller is still schedulable -- before any node
+# draining starts.
+#
+# Usage:
+#   k8s-reclaim-csi-volumes.sh [kube-context]
+#
+# With no argument the current context is used. Never fails the caller: a
+# cluster that is already gone, or unreachable, leaves nothing to reclaim and
+# the cloud-side sweep is the backstop.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CONTEXT="${1:-}"
+KCTL=(kubectl)
+[ -n "$CONTEXT" ] && KCTL=(kubectl --context "$CONTEXT")
+
+if ! "${KCTL[@]}" --request-timeout=20s get ns >/dev/null 2>&1; then
+    echo "cluster unreachable — nothing to reclaim in-cluster; the cloud-side sweep is the backstop"
+    exit 0
+fi
+
+echo "Reclaiming CSI-provisioned volumes..."
+
+# 1. Belt-and-braces: make every PV reclaimable (covers Retain PVs).
+for pv in $("${KCTL[@]}" get pv -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    "${KCTL[@]}" patch pv "$pv" --type=merge \
+        -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}' >/dev/null 2>&1 || true
+done
+
+# 2. CNPG clusters own their pods AND PVCs (recreating both if deleted from
+#    under them) — delete the Cluster CRs so the operator reclaims cleanly.
+if "${KCTL[@]}" api-resources --api-group=postgresql.cnpg.io 2>/dev/null | grep -q clusters; then
+    "${KCTL[@]}" delete clusters.postgresql.cnpg.io --all --all-namespaces --wait=false 2>/dev/null || true
+fi
+
+# 3. Scale to 0 exactly the Deployments/StatefulSets that mount PVCs (an STS
+#    would recreate PVCs from its templates if we only deleted pods).
+#    Selecting by PVC-presence never touches kube-system's CSI controller.
+"${KCTL[@]}" get deploy,statefulset --all-namespaces -o json 2>/dev/null \
+    | jq -r '.items[] | select((([.spec.template.spec.volumes[]? | select(.persistentVolumeClaim)] | length) > 0) or (((.spec.volumeClaimTemplates // []) | length) > 0)) | "\(.kind|ascii_downcase) \(.metadata.namespace) \(.metadata.name)"' 2>/dev/null \
+    | while read -r kind ns name; do
+        [ -z "$name" ] && continue
+        "${KCTL[@]}" scale "$kind" -n "$ns" "$name" --replicas=0 >/dev/null 2>&1 || true
+    done
+
+# 4. Catch-all for remaining PVC-mounting pods (Jobs, naked pods): PVC deletion
+#    blocks on the pvc-protection finalizer while any pod still uses it.
+"${KCTL[@]}" get pods --all-namespaces -o json 2>/dev/null \
+    | jq -r '.items[] | select(([.spec.volumes[]? | select(.persistentVolumeClaim)] | length) > 0) | "\(.metadata.namespace) \(.metadata.name)"' 2>/dev/null \
+    | while read -r ns name; do
+        [ -z "$name" ] && continue
+        "${KCTL[@]}" delete pod -n "$ns" "$name" --wait=false 2>/dev/null || true
+    done
+
+# 5. Delete the PVCs and wait for the CSI driver to reclaim every PV. The moment
+#    the PV list is empty, the backing cloud volumes are gone too.
+"${KCTL[@]}" delete pvc --all --all-namespaces --wait=false 2>/dev/null || true
+echo "Waiting for PersistentVolumes to be reclaimed (up to 300s)..."
+for _ in $(seq 1 60); do
+    pv_count=$("${KCTL[@]}" get pv --no-headers 2>/dev/null | wc -l)
+    [ "$pv_count" = "0" ] && break
+    sleep 5
+done
+
+if [ "${pv_count:-0}" != "0" ]; then
+    echo "WARNING: ${pv_count} PV(s) not reclaimed — their backing volumes may be orphaned:"
+    "${KCTL[@]}" get pv -o jsonpath='{range .items[*]}{.metadata.name}{" -> "}{.spec.csi.volumeHandle}{"\n"}{end}' 2>/dev/null || true
+    echo "The cloud-side sweep is the backstop; anything still attached to a draining"
+    echo "node is caught by the NEXT destroy run."
+else
+    echo "All PersistentVolumes reclaimed."
+fi

--- a/website/content/docs/get-started/aws/teardown.md
+++ b/website/content/docs/get-started/aws/teardown.md
@@ -61,7 +61,9 @@ Before OpenTofu deletes anything, the script:
 - Disables Kyverno's and the Cilium operator's blocking admission webhooks —
   once their pods are evicted with the nodes, every subsequent delete would
   otherwise fail against a webhook with no live endpoint.
-- Reclaims CSI-provisioned EBS volumes: patches **every** PV's
+- Reclaims CSI-provisioned EBS volumes, by calling
+  `scripts/k8s-reclaim-csi-volumes.sh` — the same script the GKE teardown
+  calls, since every step of it is plain Kubernetes. It patches **every** PV's
   `persistentVolumeReclaimPolicy` to `Delete` — including PVs deliberately
   set to `Retain` — deletes CloudNativePG `Cluster` resources so the operator
   releases their PVCs cleanly, scales down every Deployment/StatefulSet that

--- a/website/content/docs/get-started/gcp/teardown.md
+++ b/website/content/docs/get-started/gcp/teardown.md
@@ -1,0 +1,132 @@
+---
+title: Teardown
+weight: 30
+description: Tear the GCP platform down safely, in reverse dependency order.
+lastVerified: 2026-08-27
+---
+
+Same shape as the [AWS teardown](../aws/teardown.md), with GCP's own traps. Two
+of them cost a manual cleanup on the 2026-08-27 gcp-0 teardown and are now
+handled by the destroy workflow itself.
+
+{{< callout type="warning" >}}
+Every GCP stack is gated on `TM_GCP_ENABLED=true`. Without it each job prints
+`[skip]` and exits 0 — including the destroy jobs. A teardown that appears to
+succeed instantly did nothing at all; check for `[skip]` lines before believing
+the cluster is gone.
+{{< /callout >}}
+
+## GKE only
+
+```bash
+cd opentofu/gcp/gke/init
+TM_GCP_ENABLED=true terramate script run destroy
+```
+
+Four jobs, defined in `opentofu/gcp/gke/init/workflows.tm.hcl`:
+
+1. **confirm + init** — `scripts/terramate-destroy-confirm.sh`, then `tofu init`.
+   Init runs *before* anything is destroyed on purpose: a lock file predating a
+   new provider must fail here, not once resources have started disappearing.
+2. **`stage2-reclaim-volumes`** — reclaims CSI-provisioned PD disks while the
+   cluster still exists (see below).
+3. **`stage2-destroy-addons`** — destroys the `gke/configure` stack (Gateway API
+   CRDs, Cilium, Flux). Never gates the cluster deletion.
+4. **`stage1-destroy-cluster`** — destroys the cluster itself. This one *is*
+   allowed to fail loudly: it is the billable resource.
+5. **`stage2-reconcile-state`** — drops any stage-2 state left behind, now that
+   the cluster holding those objects is provably gone.
+
+## Full teardown
+
+```bash
+cd opentofu
+TM_GCP_ENABLED=true terramate script run --reverse destroy
+```
+
+Destroys every stack — GKE, OpenBao, Network — in reverse dependency order, with
+a single confirmation cached for 10 minutes.
+
+## The two leaks this workflow now prevents
+
+### Orphaned Persistent Disks
+
+Deleting the cluster with PVCs still bound skips the reclaim entirely: the PD
+CSI controller dies with the cluster, and every PVC-backed disk is orphaned in
+the project with nothing left referencing it. Nothing reports this — `tofu
+destroy` says "Destroy complete" and the disks keep billing. Three survived the
+2026-08-27 teardown (20/10/5 GB), the GCP replay of an EBS leak EKS already had
+a step for.
+
+`stage2-reclaim-volumes` calls `scripts/k8s-reclaim-csi-volumes.sh`, shared with
+the AWS teardown because every step of it is plain Kubernetes. It suspends Flux,
+patches **every** PV to `Delete` — including PVs deliberately set to `Retain` —
+deletes CloudNativePG `Cluster` resources, scales down every workload mounting a
+PVC, then deletes all PVCs and waits up to 300s for reclaim.
+
+{{< callout type="warning" >}}
+**This step deletes PVC data unconditionally**, regardless of the reclaim policy
+a PV was created with. There is no flag that skips it. Back up anything you need
+*before* running the destroy.
+{{< /callout >}}
+
+It never gates the teardown. The control-plane endpoint is private, so the usual
+reason to be running destroy at all is that the cluster or the tailnet is
+unreachable — the script says so and exits 0. Disks it misses stay in the
+project; list them with:
+
+```bash
+gcloud compute disks list --project <project> \
+  --filter="-users:*" --format="table(name,sizeGb,zone)"
+```
+
+### `containerNotEmpty` on the Cloud DNS zone
+
+external-dns writes a record into the private zone for every HTTPRoute, and
+nothing removes them when the cluster goes — the controller that owned them went
+with it. Cloud DNS then refuses to delete a non-empty zone:
+
+```
+Error 400: The container is not empty., containerNotEmpty
+```
+
+which lands at the *end* of the network destroy, after the rest of the VPC is
+already gone, leaving the stack half torn down. On 2026-08-27 that meant deleting
+twelve records by hand.
+
+The network stack's destroy now runs `scripts/gcp-purge-dns-records.sh` first,
+reading the zone name from state rather than re-deriving it. Apex NS and SOA are
+left alone: Cloud DNS will not delete them separately and removes them with the
+zone. Safe to re-run — it exits 0 when the zone is already gone or already empty.
+
+## What is not deleted
+
+Secrets in Secret Manager outlive the cluster, by design — they are what a
+rebuild reads back. See [ADR-0023](../../decisions/0023-portable-secret-store-names.md).
+List and remove them by hand once you are certain:
+
+```bash
+gcloud secrets list --project <project> --format='value(name)'
+```
+
+The three hand-created bootstrap prerequisites — the state bucket, the Cloud KMS
+key ring, and the Tailscale OAuth client — are also left alone. Cloud KMS key
+rings cannot be deleted at all.
+
+## Verifying nothing is left
+
+Teardown is not finished because a script said so. Check the project:
+
+```bash
+gcloud container clusters list --project <project>
+gcloud compute instances list --project <project>
+gcloud compute disks list --project <project>
+gcloud compute addresses list --project <project>
+gcloud dns managed-zones list --project <project>
+gcloud compute networks list --project <project>   # only `default` should remain
+```
+
+## Non-interactive
+
+`TM_DESTROY_CONFIRMED=true` skips the interactive `y/n` prompt. It exists for
+CI; skip it on a first manual teardown so you get the confirmation.


### PR DESCRIPTION
Both gaps were found by tearing `gcp-0` down for real on 2026-08-27 and then
looking at the project, instead of trusting "Destroy complete".

## 1. Orphaned Persistent Disks

Deleting the cluster with PVCs still bound skips the reclaim entirely — the CSI
controller dies with the cluster and every PVC-backed disk is orphaned with
nothing referencing it. Nothing reports it. Three survived (20/10/5 GB).

EKS already had this step. It was written **inline** in
`eks-prepare-destroy.sh`, so GKE never got it — the gap existed *because* the
logic had no shared home. Every step of it is plain Kubernetes and
driver-agnostic, so it moves to `scripts/k8s-reclaim-csi-volumes.sh` and both
clouds call it.

**The shared script now suspends Flux itself.** `eks-prepare-destroy.sh` already
did that earlier for its own reasons, but it is a *precondition* of the reclaim,
not a step of the caller's: a running reconciler puts the PVCs straight back, so
the reclaim would appear to work and leave every disk bound. A second caller
that forgot it would get a silent, plausible-looking failure.

The GKE job runs **before** `stage2-destroy-addons` — once Cilium is gone the
networking is unreliable, and the CSI controller has to be reachable for a PVC
delete to actually detach a disk. It never gates teardown: the control-plane
endpoint is private, and an unreachable cluster is the usual reason to be
running destroy at all. It uses a throwaway `KUBECONFIG` so a teardown never
edits the operator's own kubeconfig or leaves behind a context for a cluster
that is about to stop existing.

## 2. `containerNotEmpty` on the Cloud DNS zone

external-dns wrote a record per HTTPRoute and nothing removes them when the
cluster goes. The zone destroy then failed at the **end** of the network
teardown, after the rest of the VPC was already gone, leaving the stack half
torn down. Twelve records had to be deleted by hand.

`scripts/gcp-purge-dns-records.sh` empties the zone first, reading its name from
state rather than re-deriving it. Apex NS/SOA are left alone — Cloud DNS will
not delete them separately and removes them with the zone.

## Verified end to end

Against `ogenki-435905` with a throwaway zone, because the parsing and delete
loop were the parts most likely to be subtly wrong:

```
create zone + A + external-dns-style TXT
delete zone     → HTTPError 400: cannot be deleted because it contains
                  one or more 'resource records'          ← the bug, reproduced
purge script    → deleted TXT a-app.…   deleted A app.…
delete zone     → Deleted [.../claude-teardown-test]
zones list      → empty                                   ← nothing left behind
```

The reclaim script's unreachable path was exercised too — prints the backstop
line and exits `0`, so it can never gate a destroy.

```
shellcheck              clean on all four scripts¹
terramate script list   both workflows parse
validate-manifests.sh   2054 resources, Valid: 2054, Invalid: 0, Skipped: 0
validate-links.sh / verify-doc-paths.sh / validate-doc-claims.sh   pass
```

¹ the 3 remaining SC2016 in `eks-prepare-destroy.sh` are pre-existing JMESPath
quoting, on lines this PR doesn't touch.

## Docs

GCP had no teardown page while AWS did — a coverage gap that mattered more than
usual here, since the GCP teardown has two traps AWS doesn't. The new page
documents the destroy order, both leaks, what deliberately outlives the cluster,
and the `gcloud` commands to verify the project is actually empty.

It leads with the `TM_GCP_ENABLED` warning: without it every destroy job prints
`[skip]` and exits 0, so a teardown that appears to succeed instantly did
nothing at all.

Also carries over the AWS page's warning that the reclaim **deletes PVC data
unconditionally**, with no flag to skip it.

## Not fixed here

The `--reverse destroy` ordering problem the AWS page documents applies to GCP
too: `gke/configure` is a separately registered stack whose own bare `destroy`
script never calls the reclaim. The GKE-only path is the safe one, and is what
the new page tells you to use.
