### PR TITLE
chore(app-wizard): bump to v0.2.0 (main-61abd7d)

### DIFF
--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -28,8 +28,16 @@ spec:
     # It understands wizard.yaml (config-file layer), derives the claim GVK from
     # the XRD, and ships github+dev auth only. Bump to the newest main-<short-sha>
     # when the upstream wizard changes.
+    #
+    # Pinned by SHA rather than by the v0.2.0 semver tag on purpose: upstream
+    # derives that tag from a Dockerfile ARG on every main build, so it gets
+    # reassigned to a new image whenever someone forgets to bump it (v0.1.0 moved
+    # from the July image to the August one exactly that way). main-<sha> is the
+    # only genuinely immutable tag it publishes.
+    #
+    # main-61abd7d == release v0.2.0.
     repository: ghcr.io/smana/app-wizard
-    tag: "main-a23e28f"
+    tag: "main-61abd7d"
     pullPolicy: IfNotPresent
 
   # Single stateless replica — the wizard holds no persistent state (sessions


### PR DESCRIPTION
Bumps the App Wizard image from `main-a23e28f` (2026-07-18) to `main-61abd7d`,
which is upstream [v0.2.0](https://github.com/Smana/app-wizard/releases/tag/v0.2.0)
— 19 commits.

## Does this need a config change here?

**No** — but two upstream changes could have broken us, and both were checked
against this repo before bumping.

**1. `wizard.yaml` keys are now required.** The wizard refuses to start rather
than defaulting to `Smana/cloud-native-ref`, which is what a deployment whose
config mount failed to land used to silently target. All five are already set in
`apps/platform/app-wizard/wizard.yaml`:

| key | value here |
|---|---|
| `repo.owner` / `repo.name` | `Smana` / `cloud-native-ref` |
| `schema.xrdPath` | `crossplane-configuration/apis/app/definition.yaml` |
| `render.compositionPath` | `crossplane-configuration/apis/app/composition-aws.yaml` |
| `render.functionsPath` | `infrastructure/base/crossplane/functions/functions.yaml` |

**2. The image no longer ships its own `ui-hints.yaml`.** It described one
platform's XRD, so it moved to the deployment. We already point `uiHintsPath` at
our own copy beside `wizard.yaml`, so nothing changes — and that copy has the
dotted child hints the new upstream guard requires (`image`, `route`, `service`
all resolve; a basic-tier object whose children are unhinted now renders as an
empty box).

## What we gain

- **The XRD drift guard works again.** It had been silently skipping itself
  upstream since the OSS split — which is how the breaking `s3Bucket` →
  `objectStore` rename in crossplane-configuration reached the hints file
  unnoticed.
- **Workload-type gating stops eating input.** It was a hand-written mirror of
  our CEL rules that had drifted, and on load it *deleted* legitimate disabled
  `route` / `autoscaling` blocks from existing worker and cron apps — meaning the
  update PR removed them from Git.
- **`configs` and `labels` are usable.** The map editor's "+ Add" wrote nothing,
  and object-valued maps rendered a single text box where the schema wants an
  object.
- Crossplane CLI **2.4.0**, matching the cluster's HelmRelease (was 2.3.3).
- Nothing in the UI names a cloud provider any more — the secrets editor reads
  its wording from the XRD, so it will read correctly against the GCP
  composition too.

## Why the SHA and not `v0.2.0`

Upstream derives its semver tag from a Dockerfile `ARG` on every `main` build, so
it gets reassigned when someone forgets to bump it — `v0.1.0` moved from the July
image to the August one exactly that way. `main-<sha>` is the only genuinely
immutable tag it publishes. Noted in the manifest so the next bump doesn't
"simplify" it.
