### PR TITLE
chore(app-wizard): pin the v0.2.1 release tag

### DIFF
--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -24,20 +24,21 @@ spec:
     # the SPEC-009 split). The image ships neutral; wizard.yaml supplies this
     # platform's config.
     #
-    # Immutable <branch>-<short-sha> tag from Smana/app-wizard's build workflow.
-    # It understands wizard.yaml (config-file layer), derives the claim GVK from
-    # the XRD, and ships github+dev auth only. Bump to the newest main-<short-sha>
-    # when the upstream wizard changes.
+    # Release tag from Smana/app-wizard. The wizard understands wizard.yaml
+    # (config-file layer), derives the claim GVK from the XRD, and ships
+    # github+dev auth only.
     #
-    # Pinned by SHA rather than by the v0.2.0 semver tag on purpose: upstream
-    # derives that tag from a Dockerfile ARG on every main build, so it gets
-    # reassigned to a new image whenever someone forgets to bump it (v0.1.0 moved
-    # from the July image to the August one exactly that way). main-<sha> is the
-    # only genuinely immutable tag it publishes.
+    # Now pinned to the semver tag rather than main-<sha>. The previous comment
+    # here warned that upstream derived its semver tag from a Dockerfile ARG on
+    # every main build — so it was reassigned whenever someone forgot to bump it,
+    # and v0.1.0 silently moved from the July image to the August one. That is
+    # fixed upstream: a semver tag is now produced ONLY by a `v*` git tag push, so
+    # vX.Y.Z can only ever name the commit that was tagged.
     #
-    # main-61abd7d == release v0.2.0.
+    # Bump to the newest release tag. Do NOT use `v0.2` or `latest` — those float
+    # by design and would let a reconcile change what is deployed.
     repository: ghcr.io/smana/app-wizard
-    tag: "main-61abd7d"
+    tag: "v0.2.1"
     pullPolicy: IfNotPresent
 
   # Single stateless replica — the wizard holds no persistent state (sessions


### PR DESCRIPTION
Follow-up to #1866. Moves the App Wizard pin from `main-61abd7d` to `v0.2.1`.

## Why a semver tag is now acceptable here

#1866 deliberately pinned `main-<sha>` and explained why: upstream derived its
semver tag from a Dockerfile `ARG` on **every** main build, so the tag was
reassigned whenever someone forgot to bump it — `v0.1.0` moved from the July
image to the August one across a breaking `wizard.yaml` change.

That is fixed upstream in [Smana/app-wizard#5](https://github.com/Smana/app-wizard/pull/5).
A semver tag is now produced **only** by a `v*` git tag push, so `vX.Y.Z` can
only ever name the commit that was tagged. Verified against the registry rather
than assumed — the main build that followed the fix published:

```
main-b75b115                 ← branch push: sha only
v0.2.1, v0.2, latest         ← tag push: the release
```

`v0.2.0` was untouched by that main build, which under the old workflow it would
have absorbed.

## What actually changes on the cluster

Nothing functional. `v0.2.1` is release-tooling only — no runtime change from the
`v0.2.0` image currently pinned. Both images carry
`org.opencontainers.image.revision` pointing at the upstream commit they were
built from; the `v0.2.1` artifact is a separate build of the same tree as
`main-b75b115`, so their digests differ while their contents do not.

## One caution recorded in the manifest

`v0.2` and `latest` are **not** safe to pin — they float by design, and a
floating tag in a GitOps manifest lets a reconcile silently change what is
deployed. Only the full `vX.Y.Z` is stable.
