### PR TITLE
feat(runlore): enable the 🔕 silence control

### DIFF
--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -206,6 +206,23 @@ spec:
           # https://runlore.<domain>/slack/interactions.
           signing_secret_env: SLACK_SIGNING_SECRET  # pragma: allowlist secret
           feedback_buttons: true
+          # 🔕, a third control beside 👍/👎: suppress re-investigating THIS
+          # trigger for a chosen window. Gated independently of feedback_buttons,
+          # but its escape hatch is a 👎 (newest human wins), so it only makes
+          # sense with a feedback control enabled somewhere -- which the line
+          # above provides. Runlore warns at startup otherwise.
+          #
+          # A silence is not a mute: it ends early on a CRITICAL, on a 👎, or when
+          # the incident resolves. Until then there is no model call, no
+          # notification and no ledger open -- which is the point, because the
+          # alert this exists for is the one that fires forty times.
+          silence_button: true
+        # Shared presets for the control above. windows[0] is the fallback
+        # wherever no duration can be carried. Requires outcome.ledger_path,
+        # which is set below.
+        silence:
+          windows: [1h, 4h, 24h]
+          max_window: 24h
       telemetry:
         metrics_enabled: true
       model:


### PR DESCRIPTION
Every prerequisite was already in place; only the two keys that turn it on were
missing.

| Requirement | Status |
|---|---|
| `notify.slack.signing_secret_env` | already set — verifies the click |
| a feedback control for the 👎 escape | `feedback_buttons: true` already set |
| `outcome.ledger_path` | already set |
| **`silence_button: true`** | **added** |
| **`notify.silence.windows` / `max_window`** | **added** |

## What it buys

A third control beside 👍/👎 that suppresses re-investigating *that trigger* for
a chosen window — no model call, no notification, no ledger open. The alert this
exists for is the one that fires forty times while someone is already fixing it,
and today the only options are investigate every one or turn the alert off.

**It is not a mute.** The window ends early on a CRITICAL, on a 👎 (newest human
wins), or when the incident resolves.

## Windows

`[1h, 4h, 24h]`, `max_window: 24h` — the upstream preset. `windows[0]` is the
fallback wherever no duration can be carried, so 1h leads deliberately: the
failure mode worth avoiding is a silence outliving the work that justified it.

Shared base, so both clusters get it. Nothing here is cloud-specific.

## Evidence

```
validate-manifests.sh -> 2105 resources, Valid: 2105, Invalid: 0, Skipped: 0
```