### PR TITLE
chore(crossplane): bump the Configuration packages to v0.4.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ differences:
 > **Both known blockers are closed; the umbrella stays suspended on cost, not breakage.**
 > Serving pods need a per-claim read-only identity because the FUSE mount authenticates as the
 > mounting pod's own ServiceAccount. That identity **is** rendered by the `InferenceService`
-> composition as of `crossplane-configuration` v0.4.1 — the version already pinned here — which
+> composition as of `crossplane-configuration` v0.4.2 — the version already pinned here — which
 > emits a per-claim ServiceAccount, a Deployment running as it, and a `GCPWorkloadIdentity` granting
 > `roles/storage.objectViewer` scoped to the weights bucket. No pin bump needed. (The second gap,
 > KEDA on `gcp-0`, is also closed — `infrastructure/gcp-0` pulls the shared `base/keda`.)

--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -219,7 +219,7 @@ spec:
         - clone
         - --depth=1
         - --single-branch
-        - --branch=v0.4.1
+        - --branch=v0.4.2
         - https://github.com/Smana/crossplane-configuration.git
         - /repo/crossplane-configuration
       securityContext:

--- a/clusters/gcp-0-llm-platform/README.md
+++ b/clusters/gcp-0-llm-platform/README.md
@@ -45,7 +45,7 @@ GKE cluster. Resuming is a validation run, not a routine enable.
   the node's default identity. So each `InferenceService` claim's serving ServiceAccount needs its
   own read-only `GCPWorkloadIdentity` — the role AWS's per-claim read-only EPI plays. This README
   previously said the composition had no GCP support for that. It does, in
-  `crossplane-configuration` **v0.4.1, the version already pinned** in
+  `crossplane-configuration` **v0.4.2, the version already pinned** in
   `infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml`. Read back from
   that tag's own golden fixture (`tests/golden/inferenceservice-gcp.yaml`), a claim renders:
 

--- a/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
@@ -13,4 +13,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-gcp
 spec:
-  package: ghcr.io/smana/crossplane-configuration-gcp:v0.4.1
+  package: ghcr.io/smana/crossplane-configuration-gcp:v0.4.2

--- a/infrastructure/base/crossplane/configuration/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration/configuration-packages.yaml
@@ -12,4 +12,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-aws
 spec:
-  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.1
+  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.2

--- a/website/content/docs/platform/ai-platform/_index.md
+++ b/website/content/docs/platform/ai-platform/_index.md
@@ -29,7 +29,7 @@ plain Flux reconciliation both leave the cluster LLM-free.
 | **Autoscaling** | KEDA, three vLLM saturation triggers OR-combined, `min=1` (always warm) |
 | **Weights** | Amazon S3 Files (POSIX over S3), RWX PVC shared by a preload Job and the serving pod |
 | **GPUs** | Karpenter `gpu-l4` NodePool — single-GPU `g6` spot instances, Bottlerocket NVIDIA AMI, capped at 4 GPUs |
-| **Composition** | `crossplane-inference-service` KCL module `0.9.0`, pinned inside `crossplane-configuration-aws:v0.4.1` |
+| **Composition** | `crossplane-inference-service` KCL module `0.9.0`, pinned inside `crossplane-configuration-aws:v0.4.2` |
 
 ## Why self-host at all
 

--- a/website/content/docs/platform/developer-platform/_index.md
+++ b/website/content/docs/platform/developer-platform/_index.md
@@ -14,11 +14,11 @@ a version:
 ```yaml
 # infrastructure/base/crossplane/configuration/configuration-packages.yaml
 spec:
-  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.1
+  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.2
 ```
 
 `gcp-0` serves the same claims from its own package,
-`ghcr.io/smana/crossplane-configuration-gcp:v0.4.1`, pinned in
+`ghcr.io/smana/crossplane-configuration-gcp:v0.4.2`, pinned in
 `infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml`
 — both clusters currently pin the same release.
 

--- a/website/content/docs/platform/developer-platform/app-field-reference.md
+++ b/website/content/docs/platform/developer-platform/app-field-reference.md
@@ -17,11 +17,11 @@ they live in
 [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration),
 which this repo pins as a `Configuration` package
 (`infrastructure/base/crossplane/configuration/configuration-packages.yaml`,
-currently `ghcr.io/smana/crossplane-configuration-aws:v0.4.1`). This table was
+currently `ghcr.io/smana/crossplane-configuration-aws:v0.4.2`). This table was
 reconciled by hand against that repository's `apis/app/definition.yaml` (the
 CRD schema — types, enums, CEL rules) and `apis/app/kcl/main.k` (composition
 defaults that never appear in the schema, such as resource requests/limits or
-the gateway/route fallback names) at the commit tagged `v0.4.1`.
+the gateway/route fallback names) at the commit tagged `v0.4.2`.
 
 **To regenerate:** check out `Smana/crossplane-configuration` at the tag
 currently pinned above, and read `apis/app/definition.yaml` +

--- a/website/content/docs/platform/developer-platform/app-wizard.md
+++ b/website/content/docs/platform/developer-platform/app-wizard.md
@@ -29,7 +29,7 @@ The wizard clones **two** repositories at startup: this one (for the `App`
 schema, stacks, and its own config) and
 [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration)
 at the tag pinned in `apps/platform/app-wizard/app.yaml`'s
-`fetch-crossplane-configuration` init container — currently `v0.4.1`, the
+`fetch-crossplane-configuration` init container — currently `v0.4.2`, the
 same tag pinned in
 `infrastructure/base/crossplane/configuration/configuration-packages.yaml`.
 This is a deliberate coupling, not an accident: if the wizard's clone drifts


### PR DESCRIPTION
Picks up the GCP secret-key fix
([crossplane-configuration#15](https://github.com/Smana/crossplane-configuration/pull/15),
released as `v0.4.2`).

## What it fixes

The GCP SQLInstance Composition rendered ExternalSecret keys in the AWS shape —
`cnpg/<instance>/roles/<owner>` — and a GCP Secret Manager ID must match
`[A-Za-z0-9_-]+`, so those keys named secrets that **could not exist**. Harbor
never started on `gcp-0`:

```
tooling/xplane-harbor-cnpg-registry  ->  could not get secret data from provider
harbor-core                          ->  secret "xplane-harbor-cnpg-registry" not found
```

ZITADEL looked healthy only because CNPG generates its own superuser when the
supplied one does not resolve — so its ExternalSecret had been failing silently
for as long as it existed.

**No-op for `aws-0`**: both AWS golden fixtures matched untouched upstream.

## Eleven references, not two

The two package pins are the load-bearing pair, but the app-wizard's
`fetch-crossplane-configuration` initContainer clones this same tag, and
`CLAUDE.md` is explicit that they are coupled — otherwise the wizard builds its
form and render preview against a different API version than the cluster serves.

Checked before bumping that `apis/app/definition.yaml` and
`apis/app/composition-aws.yaml` — the two paths `wizard.yaml` resolves *inside*
the tag — still exist at `v0.4.2`. A rename there is silent and no gate catches
it.

The remainder is prose in `CLAUDE.md`, the `gcp-0` LLM README and four website
pages, each naming the pinned version as fact.

## Evidence

```
validate-manifests.sh  -> 2105 resources, Valid: 2105, Invalid: 0, Skipped: 0
                          (schemas fetched from the v0.4.2 release, so this also
                           proves no claim in the repo broke against the new XRDs)
validate-links.sh      -> all relative links resolve
validate-doc-claims.sh -> 6 claims match, 10 page checks
verify-doc-paths.sh    -> every referenced path exists
```