### PR TITLE
feat(secret-store): seed the CNPG database credentials

### DIFF
--- a/scripts/secret-store.sh
+++ b/scripts/secret-store.sh
@@ -428,10 +428,24 @@ cmd_migrate_aws() {
 # Not seeded, though it is pure generation: observability-grafana-oncall-*.
 # grafana-oncall is built under observability/base but wired into no
 # Kustomization, so it runs nowhere on either cluster.
+#
+# The two cnpg entries are database credentials the SQLInstance Composition asks
+# for, and their separator is cloud-specific for the same reason it is in the
+# Composition itself: a GCP Secret Manager ID must match [A-Za-z0-9_-]+, so the
+# AWS spelling `cnpg/<instance>/roles/<owner>` names a secret that CANNOT exist
+# on GCP. That mismatch shipped, and the symptom named neither the key nor the
+# cloud: External Secrets said `could not get secret data from provider` while
+# harbor-core sat in CreateContainerConfigError naming a Kubernetes Secret.
+# Fixed in crossplane-configuration v0.4.2; seeded here so a rebuild does not
+# depend on someone remembering.
+_cnpg_sep=$([ "$CLOUD" = "gcp" ] && printf -- "-" || printf -- "/")
+
 GENERATABLE=(
     "harbor-admin-password"
     "harbor-valkey-password"
     "observability-victoria-metrics-k8s-stack-grafana-envvars"
+    "cnpg${_cnpg_sep}xplane-harbor${_cnpg_sep}roles${_cnpg_sep}harbor"
+    "cnpg${_cnpg_sep}xplane-zitadel${_cnpg_sep}superuser"
 )
 
 # 32 bytes of urandom, base64, punctuation removed so no consumer has to worry
@@ -467,6 +481,22 @@ seed_body() {
         observability-victoria-metrics-k8s-stack-grafana-envvars)
             jq -n --arg p "$(gen_password)" \
                 '{GF_SECURITY_ADMIN_USER: "admin", GF_SECURITY_ADMIN_PASSWORD: $p}' ;;
+        # Globs, so one arm serves both spellings: `cnpg/...` on AWS and
+        # `cnpg-...` on GCP. The username is not decoration -- the ExternalSecret
+        # reads `property: username` as well as `password`, so a body carrying
+        # only a password syncs a Secret missing a key the workload mounts.
+        cnpg?xplane-harbor?roles?harbor)
+            # Must match spec.roles[].name on the claim: CNPG creates the role
+            # under that name and Harbor connects as it.
+            jq -n --arg p "$(gen_password)" '{username: "harbor", password: $p}' ;;
+        cnpg?xplane-zitadel?superuser)
+            # `postgres`, because the cluster sets enableSuperuserAccess: true
+            # alongside an explicit superuserSecret -- so CNPG expects US to
+            # supply the pair rather than generating <cluster>-superuser itself.
+            # Observed on gcp-0: superuser access enabled and no such secret
+            # anywhere, leaving it configured and unusable while failing nothing
+            # visibly.
+            jq -n --arg p "$(gen_password)" '{username: "postgres", password: $p}' ;;
         *)
             echo "no generator for $1" >&2; return 1 ;;
     esac


### PR DESCRIPTION
`check` reported two keys missing that `seed` had no idea how to make, so a
rebuild needed a human to remember two secret names, their JSON shape, and which
username each wanted. Harbor's was created by hand on `gcp-0` this morning to get
the cluster moving — this is so that is the last time.

## The subtlety: the separator is cloud-specific

A GCP Secret Manager ID must match `[A-Za-z0-9_-]+`, so the AWS spelling
`cnpg/<instance>/roles/<owner>` names a secret that **cannot** exist on GCP — not
"is missing", cannot. The Composition had the same bug until
`crossplane-configuration` v0.4.2, and its symptom named neither the key nor the
cloud: External Secrets said only `could not get secret data from provider` while
`harbor-core` sat in `CreateContainerConfigError` naming a Kubernetes Secret.

So names are built from `_cnpg_sep`, and the generator arms are globs
(`cnpg?xplane-harbor?roles?harbor`) so one arm serves both spellings.

## Each body carries a username, not just a password

The ExternalSecret reads `property: username` as well as `password`. A
password-only body syncs a Secret missing a key the workload mounts — which fails
at *container start*, not at sync, so `check` would have gone green while Harbor
stayed down.

The usernames are what the cluster actually expects, not conventions:

| Key | Username | Why |
|---|---|---|
| `cnpg…xplane-harbor…roles…harbor` | `harbor` | `spec.roles[].name` on the claim — CNPG creates the role under that name and Harbor connects as it |
| `cnpg…xplane-zitadel…superuser` | `postgres` | the cluster sets `enableSuperuserAccess: true` *with* an explicit `superuserSecret`, so CNPG expects us to supply the pair rather than generating `<cluster>-superuser`. On `gcp-0` it existed nowhere — superuser access enabled and unusable, failing nothing visibly |

## Evidence

```
bash -n, shellcheck -S warning  -> clean
seed --cloud gcp (dry run)      -> 4 present, 1 would create:
                                   cnpg-xplane-zitadel-superuser
separator, both clouds          -> cnpg/xplane-harbor/roles/harbor
                                   cnpg-xplane-harbor-roles-harbor
test-secret-store-lint.sh       -> passed 15, failed 0
```