### PR TITLE
fix(gcp): point SSO at this cluster's own IdP, and stop a cold boot wedging Helm

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -400,21 +400,21 @@
         "filename": "security/base/zitadel/helmrelease.yaml",
         "hashed_secret": "5bb6016169a24b72f0bb3d2826bd43a262442f44",
         "is_verified": false,
-        "line_number": 54
+        "line_number": 73
       },
       {
         "type": "Secret Keyword",
         "filename": "security/base/zitadel/helmrelease.yaml",
         "hashed_secret": "38d618ea3f63cf36f2e899505f161f05b40935a0",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 74
       },
       {
         "type": "Secret Keyword",
         "filename": "security/base/zitadel/helmrelease.yaml",
         "hashed_secret": "54062eed5e8326a96f845559019aad3bd7003f32",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 155
       }
     ],
     "tooling/base/gha-runners/dagger-scale-set-helmrelease.yaml": [
@@ -441,23 +441,23 @@
         "filename": "tooling/base/harbor/helmrelease-harbor.yaml",
         "hashed_secret": "dcd81eaf8dfbf9757eed9c2a74ccaa1277a768fc",
         "is_verified": false,
-        "line_number": 71
+        "line_number": 81
       },
       {
         "type": "Secret Keyword",
         "filename": "tooling/base/harbor/helmrelease-harbor.yaml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 72
+        "line_number": 82
       },
       {
         "type": "Secret Keyword",
         "filename": "tooling/base/harbor/helmrelease-harbor.yaml",
         "hashed_secret": "fa25e2e0578e0fdb4945a296a2b3349b47dbe33f",
         "is_verified": false,
-        "line_number": 100
+        "line_number": 110
       }
     ]
   },
-  "generated_at": "2026-08-27T15:15:34Z"
+  "generated_at": "2026-08-28T09:25:35Z"
 }

--- a/opentofu/gcp/gke/configure/variables.tfvars
+++ b/opentofu/gcp/gke/configure/variables.tfvars
@@ -37,6 +37,28 @@ public_domain_name     = "gcp.cloud.ogenki.io"
 route53_public_zone_id = "Z002027037R5RFCG05YY6"
 route53_role_arn       = "arn:aws:iam::396740644681:role/gcp-0-route53-dns"
 
+# gcp-0 hosts its OWN ZITADEL (ADR-0024), so this must be true.
+#
+# It is the second of two gates that have to agree, and they did not. The other
+# is `spec.suspend` on clusters/gcp-0/security/zitadel.yaml, which is already
+# false -- Flux deploys ZITADEL here and its TLSRoute serves
+# auth.gcp.cloud.ogenki.io. Leaving this at its default `false` made
+# locals.tf fall back to var.identity_provider_url, whose default names the
+# aws-0 instance, so every consumer on this cluster -- Grafana, the Flux UI,
+# Headlamp, OpenWebUI -- was sent to https://auth.cloud.ogenki.io.
+#
+# That is a live IdP only while aws-0 exists. With aws-0 torn down, SSO fails
+# at the authorize step against a host that answers for someone else's cluster,
+# and nothing on gcp-0 reports a problem: ZITADEL is up, the consumers are
+# healthy, and they simply point somewhere else.
+#
+# variables.tf's own comment predicts the mirror image of this ("setting this
+# true while the Kustomization stays suspended points every consumer at a
+# hostname this cluster does not serve"). Same failure, opposite direction:
+# nothing can enforce the pairing across OpenTofu and Flux, so both halves have
+# to be flipped by hand together.
+deploy_identity_provider = true
+
 # AWS SDK region hint for the route53 solver -- NOT gcp-0's GCP region (see the
 # comment on var.route53_region). Matches opentofu/shared/aws-gcp-federation's
 # aws_region default and opentofu/aws/eks/configure's region.

--- a/security/base/zitadel/helmrelease.yaml
+++ b/security/base/zitadel/helmrelease.yaml
@@ -7,7 +7,26 @@ spec:
   timeout: 45m
   install:
     remediation:
-      retries: 5
+      # Unbounded, and the distinction from `upgrade` below is the point.
+      #
+      # This chart's pre-install hook, Job/zitadel-init, waits for the database
+      # to accept connections. On a FIRST bootstrap that database does not exist
+      # yet: the SQLInstance claim has to reach Crossplane, render a CNPG
+      # Cluster, pull images and (on a cold cluster) wait for a node to be
+      # scaled up for it. Observed on gcp-0 on 2026-08-28 -- the init Job failed
+      # `timed out waiting for the condition`, five retries burned in minutes,
+      # and the release parked on RetriesExceeded permanently.
+      #
+      # Nothing recovers from that on its own. The database came up healthy
+      # twenty minutes later and the release stayed Failed, so the Kustomization
+      # health check failed every interval and paged Slack every interval, until
+      # a human ran `flux reconcile --reset`. A finite count here is a bet on how
+      # long a cold bootstrap takes, and it is a bet this repo keeps losing.
+      #
+      # An install racing its dependencies is a timing problem and retrying is
+      # the correct answer. An UPGRADE failing repeatedly is a regression and
+      # should stop and be looked at -- so that one stays finite.
+      retries: -1
   upgrade:
     remediation:
       retries: 3

--- a/tooling/base/harbor/helmrelease-harbor.yaml
+++ b/tooling/base/harbor/helmrelease-harbor.yaml
@@ -16,7 +16,17 @@ spec:
   interval: 10m0s
   install:
     remediation:
-      retries: 3
+      # Unbounded on INSTALL only -- see the same change on
+      # security/base/zitadel/helmrelease.yaml for the full reasoning.
+      #
+      # Harbor waits on its own database the same way, and hit this on gcp-0 on
+      # 2026-08-28: the install timed out while the CNPG cluster was blocked on
+      # a secret, three retries were spent long before the database existed, and
+      # the release stayed InstallFailed after every pod had gone Running.
+      #
+      # An install racing its dependencies is a timing problem. An upgrade
+      # failing repeatedly is a regression, so that one is left finite.
+      retries: -1
   # The harbor chart renders `strategy.rollingUpdate: null` on every Deployment
   # even when updateStrategy.type=Recreate, which the API server rejects
   # ("rollingUpdate may not be specified when type is Recreate") on the RWO


### PR DESCRIPTION
Two bootstrap defects with the same shape: something only true on a **first**
deploy, left to a human to notice.

## 1. Every SSO consumer on gcp-0 was sent to aws-0's identity provider

`locals.tf` derives the URL from a flag:

```hcl
identity_provider_url = var.deploy_identity_provider
  ? "https://auth.${var.public_domain_name}"
  : var.identity_provider_url
```

Two gates must agree, and they didn't:

| Gate | Value | Meaning |
|---|---|---|
| `clusters/gcp-0/security/zitadel.yaml` `spec.suspend` | `false` | gcp-0 **does** host its own IdP — its TLSRoute serves `auth.gcp.cloud.ogenki.io` |
| `deploy_identity_provider` | unset → default `false` | so the URL falls back to aws-0's |

Grafana, the Flux UI, Headlamp and OpenWebUI were all sending users to
`https://auth.cloud.ogenki.io`. That is a live IdP only while `aws-0` exists —
with `aws-0` torn down, SSO fails at the authorize step. Nothing on `gcp-0`
reports a problem: ZITADEL is up, the consumers are healthy, they simply point
at someone else's cluster.

`variables.tf` predicts the mirror image of this — *"setting this true while the
Kustomization stays suspended points every consumer at a hostname this cluster
does not serve."* Same failure, opposite direction.

## 2. A slow database wedged two HelmReleases permanently

Both charts wait on a database that doesn't exist yet on a first bootstrap: the
`SQLInstance` claim must reach Crossplane, render a CNPG Cluster, pull images,
and wait for a node to be scaled up for it.

Observed today on `gcp-0`:

- **zitadel** — pre-install hook failed `timed out waiting for the condition`, five retries burned in minutes
- **harbor** — install timed out while its cluster was blocked on a secret, three retries burned

Both parked on `RetriesExceeded`. Twenty minutes later both databases were
healthy and every pod was `Running` — and **both releases were still Failed**,
because nothing retries once remediation is exhausted. The Kustomization health
check then failed every interval and paged Slack every interval, until someone
ran `flux reconcile --reset`.

A finite retry count is a bet on how long a cold bootstrap takes, and it's a bet
this repo keeps losing. Install remediation is now unbounded on both.

**Upgrade remediation stays finite, deliberately.** An install racing its
dependencies is a timing problem and retrying is the right answer; an upgrade
failing repeatedly is a regression and should stop and be looked at.

## Evidence

```
tofu fmt -check / tofu validate -> clean / Success
validate-manifests.sh -> 2105 resources, Valid: 2105, Invalid: 0, Skipped: 0
```

`.secrets.baseline` is refreshed only because the added comments moved line
numbers; the pragmas are unchanged.