### PR TITLE
chore(app-wizard): bump to v0.2.2

### DIFF
--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -38,7 +38,7 @@ spec:
     # Bump to the newest release tag. Do NOT use `v0.2` or `latest` — those float
     # by design and would let a reconcile change what is deployed.
     repository: ghcr.io/smana/app-wizard
-    tag: "v0.2.1"
+    tag: "v0.2.2"
     pullPolicy: IfNotPresent
 
   # Single stateless replica — the wizard holds no persistent state (sessions


### PR DESCRIPTION
Picks up [Smana/app-wizard#6](https://github.com/Smana/app-wizard/pull/6): a
token GitHub rejects is now treated as a **stale session**, not a broken
upstream.

The wizard showed *"Something went wrong / failed to fetch user"* with no way
forward, and reloading never cleared it. `Me()` turned **any** `CurrentUser`
error into 502, including GitHub's 401 — and a stale session is easy to acquire
here, because the cookie is signed by `SESSION_KEY`, which lives in the secret
store and **outlives the cluster**. A session issued by a previous OAuth app, or
a previous cluster, decrypts perfectly and carries a token GitHub no longer
honours.

Verified on `gcp-0` before the fix: `api.github.com` answered **200** from a pod
carrying app-wizard's own labels — so Cilium applied the real policy and the
network was never the problem.

Now: a 401 clears the session and returns 401 so the client offers a sign-in;
anything else stays 502 with the session untouched. **403 is deliberately not
folded in** — that's a live token missing a scope, and re-authenticating doesn't
add one. The handler also logs the non-auth branch, which it didn't before: the
502 was undiagnosable from the pod logs.

Release tag rather than a `main-<sha>` tag, following #1869.

## Evidence

```
image ghcr.io/smana/app-wizard:v0.2.2 published 2026-08-28T10:39:47Z
validate-manifests.sh -> 2105 resources, Valid: 2105, Invalid: 0, Skipped: 0
```