### PR TITLE
fix(runlore): pin the released 0.16.0, and put chart and image back in lockstep

### DIFF
--- a/flux/sources/gitrepo-runlore.yaml
+++ b/flux/sources/gitrepo-runlore.yaml
@@ -26,17 +26,24 @@ spec:
   # with the live HelmRelease values and the resulting config replayed through the
   # v0.13.0 binary's own config.Load (KnownFields + Validate): both pass.
   ref:
-    # Pinned to a COMMIT, not a tag, on purpose.
+    # v0.16.0 is the release the previous commit pin was waiting for: it is the
+    # first tag carrying runlore's GCP support -- networkPolicy.gcpWorkloadIdentity,
+    # which allows the GKE metadata server by address (Smana/runlore#563).
+    # v0.15.0's chart has no gcpWorkloadIdentity at all, so a gcp-0 deployment
+    # from it renders an AWS-shaped policy (toEntities: host) that matches
+    # nothing on GKE: every metadata call times out and the failure reads as a
+    # misconfiguration rather than a dropped packet.
     #
-    # runlore's GCP support -- networkPolicy.gcpWorkloadIdentity, which allows
-    # the GKE metadata server by address -- exists only on main. v0.15.0 is the
-    # latest tag and its chart has no gcpWorkloadIdentity at all, so a gcp-0
-    # deployment from it renders an AWS-shaped policy (toEntities: host) that
-    # matches nothing on GKE: every metadata call times out and the failure
-    # reads as a misconfiguration rather than a dropped packet.
+    # WHY THE COMMIT PIN HAD TO GO, beyond being temporary. A commit pin here is
+    # only half a pin: the chart follows the commit, but the IMAGE followed the
+    # mutable `main` tag, and the two are only in step while every build
+    # succeeds. On 2026-08-27 the Build Image run for that exact commit FAILED,
+    # so `main` never moved past its predecessor. gcp-0 then ran a binary one
+    # commit behind the chart it was configured by -- reported by the pod's own
+    # runlore_build_info as main-26372b4 against a chart pinned to 80d4b509 --
+    # and nothing anywhere said so. A failed build is silent; a stale tag has no
+    # status.
     #
-    # This is the commit that fixed it (Smana/runlore#563), 13 commits ahead of
-    # v0.15.0. Replace with `tag: v0.16.0` once that release exists -- a pin to
-    # an unreleased branch is a temporary state, and this comment is the record
-    # of why it was taken.
-    commit: 80d4b50996863aff30db4d00ca1320fb5b8eda77 # pragma: allowlist secret
+    # A released tag closes that: chart and image are cut from the same commit by
+    # the same release, and the image is immutable.
+    tag: v0.16.0

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -75,7 +75,15 @@ spec:
       # crashlooped on `field sweeps not found in type config.Curate`. Before this
       # bump the v0.13.0 chart was rendered with these exact values and the resulting
       # config replayed through the v0.13.0 binary's own config.Load: both pass.
-      tag: "0.13.0"
+      # 0.16.0, in lockstep with the GitRepository's `tag: v0.16.0`.
+      #
+      # This was "0.13.0" while the source had already moved to a COMMIT pin far
+      # past v0.13.0 -- exactly the drift the paragraphs above warn about, and it
+      # went unnoticed because gcp-0's overlay pinned `main` on top and aws-0 was
+      # torn down. The lockstep rule is not decoration: config parsing uses
+      # KnownFields(true), so a chart newer than its binary fails closed on a key
+      # the binary has never heard of.
+      tag: "0.16.0"
       pullPolicy: IfNotPresent
     serviceAccount:
       create: true

--- a/observability/gcp-0/runlore/helmrelease.yaml
+++ b/observability/gcp-0/runlore/helmrelease.yaml
@@ -17,20 +17,25 @@ metadata:
   namespace: runlore
 spec:
   values:
-    # The base pins image 0.13.0, which has no GCP cloud provider at all: with
-    # the chart and the policy both correct, the pod still logged NOTHING about
-    # GCP -- not even a resolution failure -- and reported `"cloud":false`. An
-    # absent provider and a broken one look identical from the outside.
+    # NO image override here any more, deliberately.
     #
-    # `main` is the only tag published for this image, built 2026-08-27T10:14:22Z,
-    # three minutes after the commit the chart is pinned to (96688ac5). So it is
-    # the image that matches the chart, not a newer guess.
+    # This used to pin `tag: "main"` with pullPolicy: Always, because the GCP
+    # cloud provider existed only on that branch. It is in 0.16.0 now, which the
+    # base pins, so one pin serves both clouds and there is nothing per-cloud
+    # left to say about the image.
     #
-    # A moving tag is acceptable only because this cluster is rebuilt from
-    # scratch every run. Pin a released tag alongside the chart's v0.16.0.
-    image:
-      tag: "main"
-      pullPolicy: Always
+    # Worth keeping the reason the override was harmful, because it defended
+    # itself as "acceptable, this cluster is rebuilt every run":
+    #
+    #   runlore_build_info{version="main-26372b4"}   <- the binary that ran
+    #   chart pinned to 80d4b50                      <- the config it was given
+    #
+    # The Build Image run for 80d4b50 FAILED on 2026-08-27, so `main` never moved
+    # past its predecessor and gcp-0 spent a day running a binary one commit
+    # behind its own chart. Nothing reported it: a failed build is silent, a
+    # stale tag has no status, and the drift is invisible from inside the
+    # cluster. `main` is a rolling single-arch VALIDATION image from
+    # build-image.yml -- it was never meant to be deployed.
     networkPolicy:
       awsPodIdentity: false
       gcpWorkloadIdentity: true


### PR DESCRIPTION
`gcp-0` was running a binary **one commit behind the chart configuring it**, and
nothing anywhere said so.

```
runlore_build_info{version="main-26372b4"}   <- the binary that ran
GitRepository pinned to 80d4b50              <- the config it was given
```

## The cause is not "a mutable tag drifted"

**The Build Image run for `80d4b50` FAILED** on 2026-08-27, so `main` never moved
past its predecessor. A failed build is silent and a stale tag carries no status,
so from inside the cluster this is indistinguishable from a healthy deploy. This
morning's digest bump (#1865) then pinned the chart to a commit whose image had
never been published.

`0.16.0` is the release the previous commit pin was explicitly waiting for — the
first tag carrying runlore's GCP support (`networkPolicy.gcpWorkloadIdentity`,
Smana/runlore#563), cut today from Smana/runlore#555. Chart and image now come
from one release, and the image is immutable.

## Three pins moved, and the middle one is the find

| File | From | To |
|---|---|---|
| `flux/sources/gitrepo-runlore.yaml` | commit `80d4b50` | `tag: v0.16.0` |
| `observability/base` | **`0.13.0`** | `0.16.0` |
| `observability/gcp-0` | `tag: "main"` | **removed entirely** |

The base had been left at `0.13.0` while the source moved to a commit far past
it — precisely the drift its own comment warns about at length (*"KEEP THIS IN
LOCKSTEP"*, *"move the two together, always"*). It went unnoticed because gcp-0's
overlay pinned `main` on top of it and aws-0 is torn down.

Config parsing uses `KnownFields(true)`, so a chart newer than its binary fails
closed on a key the binary has never heard of — how 0.9.2 crashlooped against the
v0.11.0 chart.

## The gcp-0 override is deleted, not repointed

The provider it existed for is in the release now, so one pin serves both clouds.
`pullPolicy: Always` goes with it — an immutable tag doesn't need re-pulling.

## An asymmetry worth recording

The git tag is `v0.16.0`; the image is `0.16.0`. GoReleaser strips the `v` and
publishes the multi-arch signed release image on `v*` tags. `build-image.yml`
deliberately does **not** build on tags, so `main` is a rolling single-arch
*validation* image that was never meant to be deployed.

## Evidence

```
image ghcr.io/smana/runlore:0.16.0 and chart 0.16.0 both published
kustomize build observability/gcp-0/runlore -> tag: 0.16.0
validate-manifests.sh -> 2105 resources, Valid: 2105, Invalid: 0, Skipped: 0
```