### PR TITLE
fix(runlore): grant `list`, and repoint a runbook_url that 404s

### DIFF
--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -142,37 +142,54 @@ spec:
       # NAMES and not secret material -- which is the whole point of being able
       # to answer "which key is it asking for, and does it exist?".
       resourceSpecRules:
-        # ── the chart's shipped ten, verbatim ──────────────────────────────
+        # ── the chart's shipped ten, with `list` added ─────────────────────
+        #
+        # The rules are the chart's; the verbs are not. It ships `["get"]` only,
+        # which serves resource_spec (fetch one named object) and leaves
+        # list_resources denied on all 28 shipped types. An investigation on
+        # 2026-08-28 reported exactly that, twice, having already been granted
+        # the kinds:
+        #
+        #   list_resources on VMRule in observability  -> FORBIDDEN
+        #   list_resources on CronJobs in security     -> FORBIDDEN
+        #
+        # while `kubectl auth can-i` confirmed get=yes, list=no for every one of
+        # them. The five platform rules below were added with get AND list and
+        # never hit this, which is what made the asymmetry visible.
+        #
+        # "Is there a CronJob in this namespace at all?" is a listing question,
+        # and answering it from an ABSENT resource_spec result is guesswork
+        # dressed as evidence. Still no Secret kind anywhere in this grant.
         - apiGroups: [""]
           resources: ["services", "persistentvolumeclaims", "persistentvolumes", "nodes", "namespaces"]
-          verbs: ["get"]
+          verbs: ["get", "list"]
         - apiGroups: ["apps"]
           resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
-          verbs: ["get"]
+          verbs: ["get", "list"]
         - apiGroups: ["batch"]
           resources: ["jobs", "cronjobs"]
-          verbs: ["get"]
+          verbs: ["get", "list"]
         - apiGroups: ["networking.k8s.io"]
           resources: ["ingresses", "networkpolicies", "ingressclasses"]
-          verbs: ["get"]
+          verbs: ["get", "list"]
         - apiGroups: ["autoscaling"]
           resources: ["horizontalpodautoscalers"]
-          verbs: ["get"]
+          verbs: ["get", "list"]
         - apiGroups: ["policy"]
           resources: ["poddisruptionbudgets"]
-          verbs: ["get"]
+          verbs: ["get", "list"]
         - apiGroups: ["storage.k8s.io"]
           resources: ["volumeattachments"]
-          verbs: ["get"]
+          verbs: ["get", "list"]
         - apiGroups: ["apiextensions.k8s.io"]
           resources: ["customresourcedefinitions"]
-          verbs: ["get"]
+          verbs: ["get", "list"]
         - apiGroups: ["operator.victoriametrics.com"]
           resources: ["vmservicescrapes", "vmpodscrapes", "vmscrapeconfigs", "vmrules", "vmagents", "vmalerts"]
-          verbs: ["get"]
+          verbs: ["get", "list"]
         - apiGroups: ["monitoring.coreos.com"]
           resources: ["servicemonitors", "podmonitors", "prometheusrules", "probes"]
-          verbs: ["get"]
+          verbs: ["get", "list"]
         # ── this platform's own operators ─────────────────────────────────
         # Named in the data gaps above. A SecretSyncedError is unreadable
         # without the ExternalSecret's spec: the remoteRef key IS the diagnosis.

--- a/observability/base/victoria-metrics-k8s-stack/vmrules/openbao.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmrules/openbao.yaml
@@ -138,7 +138,7 @@ spec:
               Note that `bao operator raft snapshot save` only works against raft
               storage — in dev mode the cluster runs the file backend and this
               job cannot succeed at all.
-            runbook_url: "https://github.com/Smana/cloud-native-ref/blob/main/opentofu/aws/openbao/management/docs/backup_restore.md"
+            runbook_url: "https://github.com/Smana/cloud-native-ref/blob/main/container-images/openbao-snapshot/README.md"
             dashboard: "https://grafana.${private_domain_name}/dashboards"
 
         # Two arms on purpose. kube-state-metrics only emits
@@ -162,5 +162,5 @@ spec:
               disaster-recovery position is degrading silently — a backup with no
               freshness signal is not a backup, and one that has never run is not
               a backup at all.
-            runbook_url: "https://github.com/Smana/cloud-native-ref/blob/main/opentofu/aws/openbao/management/docs/backup_restore.md"
+            runbook_url: "https://github.com/Smana/cloud-native-ref/blob/main/container-images/openbao-snapshot/README.md"
             dashboard: "https://grafana.${private_domain_name}/dashboards"


### PR DESCRIPTION
Both findings come from runlore reporting its **own blind spots** — the second
time today that's been worth more than the investigation's conclusion.

## 1. `list_resources` was denied on every kind it had been granted

The chart's `resourceSpecRules` ship `verbs: ["get"]`. That serves
`resource_spec` (fetch one named object) and leaves `list_resources` denied
across all 28 shipped types. An investigation reported exactly that, twice, on
kinds it had already been given:

```
list_resources on VMRule in observability  -> FORBIDDEN
list_resources on CronJobs in security     -> FORBIDDEN
```

`kubectl auth can-i` confirms the asymmetry on every shipped rule:

| verb | vmrules | cronjobs | services |
|---|---|---|---|
| `get` | yes | yes | yes |
| `list` | **no** | **no** | **no** |

The five platform rules added in #1876 carry `get` **and** `list` and never hit
this — which is what made it visible: the same tool succeeded on
`externalsecrets` and failed on `cronjobs`.

`list` is added to the shipped ten. The rules stay the chart's; only the verbs
change. *"Is there a CronJob in this namespace at all?"* is a listing question,
and the investigation answered it by inferring from an ABSENT `resource_spec`
result and a missing metric series — guesswork dressed as evidence.

Still no `Secret` kind anywhere in this grant.

## 2. The OpenBao `runbook_url` points at a file that doesn't exist

Two alerts in `vmrules/openbao.yaml` annotate:

```
runbook_url: .../opentofu/aws/openbao/management/docs/backup_restore.md
```

That path isn't in the repository and, from git history, never was. runlore
listed it as *"could not access the runbook_url"* — which reads like a network
problem and is actually a **404 baked into an alert that only fires when someone
is already having a bad day**.

Repointed at `container-images/openbao-snapshot/README.md`, which documents the
`save` and `restore` the alerts are about.

**Neither gate could catch this:** `validate-links.sh` resolves *relative*
markdown links; this is an absolute URL inside a YAML annotation.

## Evidence

```
kubectl auth can-i (before) -> get=yes list=no on vmrules, cronjobs, services
validate-manifests.sh       -> 2105 resources, Valid: 2105, Invalid: 0, Skipped: 0
validate-links.sh           -> all relative links resolve
```