### PR TITLE
feat(zitadel): provision the Google IdP and groups Action from the repo

### DIFF
--- a/scripts/zitadel-actions/groups-from-roles.js
+++ b/scripts/zitadel-actions/groups-from-roles.js
@@ -1,0 +1,85 @@
+/**
+ * groups-from-roles — flatten ZITADEL's project roles into a `groups` claim.
+ *
+ * WHY THIS EXISTS
+ *
+ * ZITADEL has no groups. It has project roles, and it puts them in the token as
+ * a NESTED object keyed by role, then by org:
+ *
+ *   "urn:zitadel:iam:org:project:roles": {
+ *     "platform-admin": { "273...": "ogenki.io" }
+ *   }
+ *
+ * Every consumer on this platform wants a FLAT array of strings instead:
+ *
+ *   Grafana   role_attribute_path / groups mapping   (auth.generic_oauth)
+ *   Headlamp  OIDC groups claim
+ *   Flux UI   OIDC groups claim
+ *
+ * Nothing in ZITADEL emits that shape, so this Action builds it. It is the
+ * documented approach rather than a workaround: native user groups are still
+ * unfinished upstream (zitadel/zitadel#12308 "complete user groups support" was
+ * open on 2026-08-21), and this instance runs v4.15.3, whose API has no groups
+ * endpoint at all -- /v2/groups/search, /v2beta/groups/search and
+ * /management/v1/groups/_search all 404.
+ *
+ * When native groups do land, this Action is what gets deleted.
+ *
+ * WHY v1 ACTIONS (inline JS) AND NOT v2
+ *
+ * Actions v2 replaces inline JS with an external HTTP "target": ZITADEL calls a
+ * service you host. Both APIs answer on this instance, but v2 would mean
+ * deploying, exposing and securing a webhook service to do fifteen lines of
+ * string manipulation, plus a network path from ZITADEL to it. v1 is deprecated
+ * and it is still the right trade here. If it is removed upstream, the
+ * replacement is a target service -- not a rewrite of this logic.
+ *
+ * FLOW / TRIGGER
+ *
+ * Registered on flow 2 (CustomiseToken) against both triggers, because the two
+ * are not interchangeable and consumers differ in which they read:
+ *
+ *   trigger 4  PreUserinfoCreation      -> the /userinfo response
+ *   trigger 5  PreAccessTokenCreation   -> claims inside the access token
+ *
+ * Grafana reads userinfo; a consumer validating the JWT directly reads the
+ * token. Registering only one leaves the other silently groupless.
+ *
+ * A NOTE ON FAILURE MODE
+ *
+ * This returns early rather than throwing when a user has no grants. An Action
+ * that errors fails the token request, so a user with no roles would be unable
+ * to log in at all -- which is a much worse outcome than logging in with no
+ * groups.
+ */
+function groupsFromRoles(ctx, api) {
+  const grants = ctx.v1.user.grants;
+
+  // No grants at all: emit nothing and let the login proceed. Deliberately not
+  // an empty array -- an absent claim and an empty one mean different things to
+  // some consumers, and "this user has no roles" is better said by absence.
+  if (grants === undefined || grants === null || grants.count === 0) {
+    return;
+  }
+
+  const groups = [];
+  grants.grants.forEach((grant) => {
+    if (grant.roles === undefined || grant.roles === null) {
+      return;
+    }
+    grant.roles.forEach((role) => {
+      // De-duplicate: the same role can arrive from more than one grant when a
+      // user holds it in several orgs, and a repeated entry breaks consumers
+      // that treat the claim as a set.
+      if (groups.indexOf(role) === -1) {
+        groups.push(role);
+      }
+    });
+  });
+
+  if (groups.length === 0) {
+    return;
+  }
+
+  api.v1.claims.setClaim('groups', groups);
+}

--- a/scripts/zitadel-idp.sh
+++ b/scripts/zitadel-idp.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+#
+# Register the Google Workspace identity provider and the groups Action in
+# ZITADEL, from configuration this repository owns.
+#
+# WHY THIS EXISTS
+#
+# Both of these were configured by hand in a console, on aws-0, and lived
+# nowhere else. On 2026-08-28 gcp-0 came up with its own fresh ZITADEL and had
+# neither, and the credentials could not be recovered from either secret store
+# because they had never been put in one -- 68 secrets in AWS Secrets Manager,
+# not a Google key among them.
+#
+# That is worse than it sounds. aws-0's SQLInstance restores from the frozen
+# `zitadel-20260719` prefix on EVERY rebuild, so anything configured in ZITADEL
+# after that snapshot is discarded the next time the cluster is rebuilt. The
+# Google IdP was one rebuild away from being lost on AWS too.
+#
+# So: the credentials go in the secret store, the Action goes in git, and this
+# script applies both. Same shape as zitadel-oidc-clients.sh, deliberately --
+# read that one first if this is unfamiliar.
+#
+# WHAT IT DOES
+#
+#   1. Reads the ZITADEL admin PAT from the cluster.
+#   2. Reads the Google OAuth client from the secret store (`zitadel-google-idp`).
+#   3. Creates the Google IdP if missing, INSTANCE-level, and leaves an existing
+#      one alone -- recreating rotates nothing but does orphan user links.
+#   4. Uploads scripts/zitadel-actions/groups-from-roles.js as a v1 Action.
+#   5. Wires that Action into flow 2 (CustomiseToken) on BOTH triggers.
+#
+# Usage:
+#   zitadel-idp.sh sync --cluster gcp-0 --cloud gcp [--project ID] [--apply]
+#   zitadel-idp.sh sync --cluster aws-0 --cloud aws [--region R]  [--apply]
+#
+# Dry-run unless --apply. The client secret is never printed.
+#
+# THE ONE THING TO DO BY HAND, ONCE PER CLUSTER
+#
+# Google OAuth clients accept MANY authorized redirect URIs -- unlike a GitHub
+# OAuth app, which accepts exactly one and is why app-wizard needs a separate
+# app per cluster. So one Google client serves every cluster, provided each
+# cluster's callback is listed on it:
+#
+#   https://auth.<public_domain_name>/ui/login/login/externalidp/callback
+#
+# That path is ZITADEL's, verified against a live instance rather than
+# constructed: it answers 200 while a nonsense path under the same prefix 404s.
+# This script CANNOT add it for you -- it is a Google-side setting -- so it
+# prints the URI and checks nothing about it. A missing entry fails at Google
+# with redirect_uri_mismatch, naming neither ZITADEL nor the cluster.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+COMMAND="${1:-}"
+[ $# -gt 0 ] && shift
+
+CLUSTER=""
+CLOUD=""
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+GCP_PROJECT=""
+APPLY="false"
+
+IDP_NAME="Google Workspace"
+IDP_SECRET_KEY="zitadel-google-idp" # pragma: allowlist secret
+ACTION_NAME="groups-from-roles"
+ACTION_FILE="$(cd "$(dirname "$0")" && pwd)/zitadel-actions/groups-from-roles.js"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --cluster) CLUSTER="$2"; shift 2 ;;
+        --cloud)   CLOUD="$2"; shift 2 ;;
+        --region)  REGION="$2"; shift 2 ;;
+        --project) GCP_PROJECT="$2"; shift 2 ;;
+        --apply)   APPLY="true"; shift ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+[ "$COMMAND" = "sync" ] || { sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
+[ -n "$CLUSTER" ] || { echo "--cluster is required" >&2; exit 2; }
+case "$CLOUD" in aws|gcp) ;; *) echo "--cloud must be aws or gcp" >&2; exit 2 ;; esac
+[ -r "$ACTION_FILE" ] || { echo "cannot read ${ACTION_FILE}" >&2; exit 1; }
+
+# ── secret store ──────────────────────────────────────────────────────────────
+
+store_read() {
+    case "$CLOUD" in
+        aws) aws secretsmanager get-secret-value \
+                 ${REGION:+--region "$REGION"} \
+                 --secret-id "$1" --query SecretString --output text 2>/dev/null ;;
+        gcp) gcloud secrets versions access latest \
+                 ${GCP_PROJECT:+--project "$GCP_PROJECT"} \
+                 --secret="$1" 2>/dev/null ;;
+    esac
+}
+
+# ── zitadel api ───────────────────────────────────────────────────────────────
+#
+# The admin PAT comes from the CLUSTER, not the secret store: ZITADEL generates
+# it at FirstInstance bootstrap for the `iam-admin` machine user and the chart
+# writes it to this Secret. It is NOT
+# ZITADEL_FIRSTINSTANCE_ORG_LOGINCLIENT_PAT from zitadel-envvars -- that token
+# belongs to the login client, is not authorised for the management API, and
+# answers every call here with a bare 401 that says nothing about why.
+PAT_NAMESPACE="security"
+PAT_SECRET="iam-admin-pat" # pragma: allowlist secret
+
+PAT="$(kubectl get secret "$PAT_SECRET" -n "$PAT_NAMESPACE" \
+        -o jsonpath='{.data.pat}' 2>/dev/null | base64 -d 2>/dev/null)"
+if [ -z "$PAT" ]; then
+    echo "ERROR: could not read ${PAT_NAMESPACE}/${PAT_SECRET} from the cluster." >&2
+    echo "ZITADEL writes it during FirstInstance bootstrap; if it is missing the" >&2
+    echo "setup Job has not finished:  kubectl get jobs -n ${PAT_NAMESPACE}" >&2
+    exit 1
+fi
+
+: "${IDP_URL:?set IDP_URL to the ZITADEL base URL, e.g. https://auth.gcp.cloud.ogenki.io}"
+
+# Same split-DNS escape hatch as zitadel-oidc-clients.sh: pins the host for curl
+# only, keeping SNI and certificate verification intact.
+CURL_RESOLVE=()
+[ -n "${IDP_RESOLVE:-}" ] && CURL_RESOLVE=(--resolve "$IDP_RESOLVE")
+
+api() {
+    local method="$1" path="$2"
+    shift 2
+    curl -fsS -X "$method" "${IDP_URL}${path}" \
+        ${CURL_RESOLVE[@]+"${CURL_RESOLVE[@]}"} \
+        -H "Authorization: Bearer ${PAT}" \
+        -H "Content-Type: application/json" \
+        "$@"
+}
+
+# ── the identity provider ─────────────────────────────────────────────────────
+#
+# INSTANCE-level (/admin/v1), not org-level (/management/v1). Both answer on
+# this instance and both would work; instance scope means every org inherits the
+# provider, which is what a single-tenant platform wants. Org scope would tie it
+# to the `platform` org that zitadel-oidc-clients.sh creates, and a second org
+# would silently have no Google login.
+# TEMPLATES, not /admin/v1/idps/_search.
+#
+# ZITADEL carries two generations of IdP API on the same prefix. The legacy
+# /admin/v1/idps/_search covers hand-rolled OIDC/JWT providers; the typed
+# providers created by POST /admin/v1/idps/google are "templates" and are
+# invisible to it. Both return 200, and the legacy one answers a search for a
+# template-created provider with `{"details":{...}}` and no result array at all
+# -- indistinguishable from "nothing exists".
+#
+# That is not cosmetic: this function decides whether to create. Pointed at the
+# legacy endpoint it reported the freshly created Google provider as absent, so
+# a second --apply would have added a DUPLICATE IdP, which is precisely what the
+# skip below exists to prevent. Caught by re-running the dry run after an apply.
+idp_id_by_name() {
+    api POST /admin/v1/idps/templates/_search -d '{"queries":[]}' 2>/dev/null \
+        | jq -r --arg n "$IDP_NAME" '.result[]? | select(.name == $n) | .id' | head -1
+}
+
+ensure_idp() {
+    local existing
+    existing="$(idp_id_by_name || true)"
+    if [ -n "$existing" ]; then
+        echo "[skip   ] IdP '${IDP_NAME}' already exists (${existing}); leaving it alone"
+        echo "           recreating would orphan every existing user link to it"
+        return 0
+    fi
+
+    local blob client_id client_secret
+    blob="$(store_read "$IDP_SECRET_KEY")"
+    if [ -z "$blob" ]; then
+        echo "[FAILED ] ${IDP_SECRET_KEY} not found in the ${CLOUD} store." >&2
+        echo "           Create it from the Google OAuth client's JSON:" >&2
+        echo '           jq -c "{client_id: .web.client_id, client_secret: .web.client_secret}"' >&2
+        return 1
+    fi
+    client_id="$(jq -r '.client_id // empty' <<< "$blob")"
+    client_secret="$(jq -r '.client_secret // empty' <<< "$blob")"
+    if [ -z "$client_id" ] || [ -z "$client_secret" ]; then
+        echo "[FAILED ] ${IDP_SECRET_KEY} has no client_id/client_secret" >&2
+        return 1
+    fi
+
+    if [ "$APPLY" != "true" ]; then
+        echo "[dry-run] would create IdP '${IDP_NAME}' (client ${client_id})"
+        return 0
+    fi
+
+    # isAutoCreation/isAutoUpdate: a Workspace user logging in for the first time
+    # gets a ZITADEL user created from their Google profile, and later profile
+    # changes follow. Without them the login succeeds and then dead-ends on "user
+    # not found", which is the least helpful possible outcome.
+    #
+    # isLinkingAllowed lets an existing local user attach Google rather than
+    # ending up with two accounts for one human.
+    local resp id
+    resp="$(jq -n --arg n "$IDP_NAME" --arg ci "$client_id" --arg cs "$client_secret" \
+        '{name: $n, clientId: $ci, clientSecret: $cs,
+          scopes: ["openid","profile","email"],
+          providerOptions: {isLinkingAllowed: true, isCreationAllowed: true,
+                            isAutoCreation: true, isAutoUpdate: true}}' \
+        | api POST /admin/v1/idps/google -d @-)"
+    id="$(jq -r '.id // empty' <<< "$resp")"
+    if [ -z "$id" ]; then
+        echo "[FAILED ] IdP creation returned no id: $(jq -c '.' <<< "$resp" | head -c 200)" >&2
+        return 1
+    fi
+    echo "[created] IdP '${IDP_NAME}' (${id}, client ${client_id})"
+}
+
+# ── the groups action ─────────────────────────────────────────────────────────
+#
+# v1 Actions are ORG-level, with no instance-level equivalent -- so unlike the
+# IdP above this cannot follow the same scope. That asymmetry is ZITADEL's, not
+# a choice made here.
+action_id_by_name() {
+    api POST /management/v1/actions/_search -d '{"query":{}}' 2>/dev/null \
+        | jq -r --arg n "$ACTION_NAME" '.result[]? | select(.name == $n) | .id' | head -1
+}
+
+ensure_action() {
+    local script existing payload
+    script="$(cat "$ACTION_FILE")"
+    existing="$(action_id_by_name || true)"
+
+    # Everything human-readable goes to stderr, because this function's STDOUT is
+    # the action id and the caller reads it through command substitution. The
+    # first version printed these to stdout and they vanished into $(...) --
+    # a dry run that silently reported nothing about the action at all.
+    if [ "$APPLY" != "true" ]; then
+        if [ -n "$existing" ]; then
+            echo "[dry-run] would UPDATE action '${ACTION_NAME}' (${existing}) from ${ACTION_FILE##*/}" >&2
+        else
+            echo "[dry-run] would create action '${ACTION_NAME}' from ${ACTION_FILE##*/}" >&2
+        fi
+        # A placeholder rather than the empty string, so the caller still walks
+        # the flow-binding branch and a dry run shows the whole plan.
+        echo "${existing:-DRYRUN-ACTION}"
+        return 0
+    fi
+
+    # allowedToFail: false. A failing Action here breaks token issuance, which
+    # sounds harsh but is correct: silently issuing tokens with no groups claim
+    # would authorise people at the WRONG level rather than not at all.
+    payload="$(jq -n --arg n "$ACTION_NAME" --arg s "$script" \
+        '{name: $n, script: $s, timeout: "10s", allowedToFail: false}')"
+
+    local id
+    if [ -n "$existing" ]; then
+        jq -n --argjson b "$payload" '$b' | api PUT "/management/v1/actions/${existing}" -d @- >/dev/null
+        id="$existing"
+        echo "[updated] action '${ACTION_NAME}' (${id})" >&2
+    else
+        id="$(jq -n --argjson b "$payload" '$b' | api POST /management/v1/actions -d @- | jq -r '.id // empty')"
+        [ -n "$id" ] || { echo "[FAILED ] action creation returned no id" >&2; return 1; }
+        echo "[created] action '${ACTION_NAME}' (${id})" >&2
+    fi
+    echo "$id"
+}
+
+# Flow 2 is CustomiseToken; 4 and 5 are PreUserinfoCreation and
+# PreAccessTokenCreation. Verified against a live instance rather than taken
+# from documentation: GET /management/v1/flows/2 reports
+# Action.Flow.Type.CustomiseToken.
+#
+# BOTH triggers, because they are not interchangeable. Grafana reads the
+# /userinfo response; a consumer validating the JWT itself reads the access
+# token. Wiring one leaves the other silently groupless -- which presents as
+# "SSO works but nobody has permissions", for only some of the tools.
+ensure_flow() {
+    local action_id="$1" trigger
+    for trigger in 4 5; do
+        if [ "$APPLY" != "true" ]; then
+            echo "[dry-run] would bind action to flow 2 trigger ${trigger}"
+            continue
+        fi
+        jq -n --arg a "$action_id" '{actionIds: [$a]}' \
+            | api POST "/management/v1/flows/2/trigger/${trigger}" -d @- >/dev/null
+        echo "[bound  ] flow 2 (CustomiseToken) trigger ${trigger}"
+    done
+}
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+echo "cluster:  ${CLUSTER} (${CLOUD})"
+echo "idp:      ${IDP_URL}"
+echo "scope:    instance (/admin/v1) for the IdP, org (/management/v1) for the action"
+echo
+
+ensure_idp
+
+ACTION_ID="$(ensure_action | tail -1)"
+if [ -n "$ACTION_ID" ]; then
+    ensure_flow "$ACTION_ID"
+elif [ "$APPLY" = "true" ]; then
+    echo "[FAILED ] no action id; flow not wired" >&2
+    exit 1
+fi
+
+echo
+echo "Google-side, once per cluster -- this script cannot do it:"
+echo "  add this to the OAuth client's Authorized redirect URIs"
+echo "    ${IDP_URL}/ui/login/login/externalidp/callback"
+echo
+if [ "$APPLY" != "true" ]; then
+    echo "This was a DRY RUN. Re-run with --apply."
+fi


### PR DESCRIPTION
Both of these were configured by hand in a console on aws-0 and lived nowhere
else. `gcp-0` came up on 2026-08-28 with a fresh ZITADEL and had neither, and the
Google credentials couldn't be recovered from either secret store because they'd
never been put in one — **68 secrets in AWS Secrets Manager, not a Google key
among them.**

That was worse than it looked. aws-0's SQLInstance restores from the frozen
`zitadel-20260719` prefix on **every** rebuild, so anything configured in ZITADEL
after that snapshot is discarded on the next one. The Google IdP was one rebuild
from being lost on AWS too — not merely missing on GCP.

Credentials now live in the store (`zitadel-google-idp`, same key on both
clouds), the Action lives in git, and this script applies both. Same shape as
`zitadel-oidc-clients.sh`.

## Applied and verified on gcp-0, not just written

```
IdP 'Google Workspace'      388268745954427245  IDP_STATE_ACTIVE
action 'groups-from-roles'  388268746625515885
flow 2 CustomiseToken  ->  PreUserinfoCreation, PreAccessTokenCreation
```

## Why v1 Actions and inline JS

Actions v2 replaces inline JS with an external HTTP target — ZITADEL calls a
service you host. Both APIs answer here. v2 would mean deploying, exposing and
securing a webhook service to do fifteen lines of string manipulation. v1 is
deprecated and still the right trade; if it's removed, the replacement is a
target service, not a rewrite of the logic.

## Why the Action exists at all

ZITADEL has no groups — it has project roles, emitted as a nested object keyed by
role then org. Grafana, Headlamp and Flux UI all want a flat array of strings.

Native groups are still unfinished upstream (`zitadel/zitadel#12308` open as of
2026-08-21), and this instance runs **v4.15.3**, whose API has no groups endpoint
at all — `/v2/groups/search`, `/v2beta/groups/search` and
`/management/v1/groups/_search` all 404. **When native groups land, this Action is
what gets deleted.**

## Three things verified against the live instance rather than taken from docs

1. **The callback path.** ZITADEL's docs say to copy it from the console rather
   than construct it, so it was probed: `/ui/login/login/externalidp/callback`
   answers 200 while a nonsense path under the same prefix 404s.
2. **Flow/trigger IDs.** `GET /management/v1/flows/2` self-reports
   `Action.Flow.Type.CustomiseToken`; triggers 4 and 5 are `PreUserinfoCreation`
   and `PreAccessTokenCreation`. **Both** are bound — Grafana reads `/userinfo`, a
   consumer validating the JWT reads the access token, and wiring one leaves the
   other silently groupless.
3. **IdP lookup must use `/admin/v1/idps/TEMPLATES/_search`.** ZITADEL carries two
   generations of IdP API on one prefix; the legacy search can't see providers
   created by `POST /admin/v1/idps/google`. Both return 200, and the legacy one
   answers `{"details":{...}}` with no result array — indistinguishable from
   "nothing exists". Pointed there, the script reported the provider it had just
   created as absent, so a second `--apply` would have created a **duplicate**.
   Caught by re-running the dry run after the apply.

Instance-level for the IdP so every org inherits it. v1 Actions are org-level
with no instance equivalent, so the scopes differ — that asymmetry is ZITADEL's.

## The one manual step stays manual, and is printed every run

A Google client's authorized redirect URIs are a Google-side setting. Unlike a
GitHub OAuth app — which accepts exactly **one** callback, and is why app-wizard
needs an app per cluster — Google accepts many, so one client serves every
cluster once each callback is listed.

## Evidence

```
bash -n, shellcheck -S warning     -> clean
node --check groups-from-roles.js  -> clean
dry run after apply -> "[skip] IdP already exists", action UPDATE (idempotent)
```