### PR TITLE
chore(crossplane): pin v0.4.3, and let runlore see the layer below the claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ differences:
 > **Both known blockers are closed; the umbrella stays suspended on cost, not breakage.**
 > Serving pods need a per-claim read-only identity because the FUSE mount authenticates as the
 > mounting pod's own ServiceAccount. That identity **is** rendered by the `InferenceService`
-> composition as of `crossplane-configuration` v0.4.2 — the version already pinned here — which
+> composition as of `crossplane-configuration` v0.4.3 — the version already pinned here — which
 > emits a per-claim ServiceAccount, a Deployment running as it, and a `GCPWorkloadIdentity` granting
 > `roles/storage.objectViewer` scoped to the weights bucket. No pin bump needed. (The second gap,
 > KEDA on `gcp-0`, is also closed — `infrastructure/gcp-0` pulls the shared `base/keda`.)

--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -219,7 +219,7 @@ spec:
         - clone
         - --depth=1
         - --single-branch
-        - --branch=v0.4.2
+        - --branch=v0.4.3
         - https://github.com/Smana/crossplane-configuration.git
         - /repo/crossplane-configuration
       securityContext:

--- a/clusters/gcp-0-llm-platform/README.md
+++ b/clusters/gcp-0-llm-platform/README.md
@@ -45,7 +45,7 @@ GKE cluster. Resuming is a validation run, not a routine enable.
   the node's default identity. So each `InferenceService` claim's serving ServiceAccount needs its
   own read-only `GCPWorkloadIdentity` — the role AWS's per-claim read-only EPI plays. This README
   previously said the composition had no GCP support for that. It does, in
-  `crossplane-configuration` **v0.4.2, the version already pinned** in
+  `crossplane-configuration` **v0.4.3, the version already pinned** in
   `infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml`. Read back from
   that tag's own golden fixture (`tests/golden/inferenceservice-gcp.yaml`), a claim renders:
 

--- a/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
@@ -13,4 +13,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-gcp
 spec:
-  package: ghcr.io/smana/crossplane-configuration-gcp:v0.4.2
+  package: ghcr.io/smana/crossplane-configuration-gcp:v0.4.3

--- a/infrastructure/base/crossplane/configuration/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration/configuration-packages.yaml
@@ -12,4 +12,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-aws
 spec:
-  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.2
+  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.3

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -219,6 +219,47 @@ spec:
         - apiGroups: ["gateway.networking.k8s.io"]
           resources: ["gateways", "httproutes", "tlsroutes", "gatewayclasses"]
           verbs: ["get", "list"]
+        # ── the layer BELOW the claims ────────────────────────────────────
+        #
+        # Added after an investigation that got the answer right and said so
+        # honestly. Diagnosing a stuck ScheduledBackup on 2026-08-28, runlore
+        # reached "barman-cloud gets 403 storage.buckets.get on the GCS bucket"
+        # at 0.78 confidence -- correct, and a real bug -- but listed as gaps:
+        #
+        #   Cannot read Bucket resource status ... cannot confirm whether the
+        #   GCS bucket actually exists in GCP or was created by Crossplane
+        #   Cannot read BucketIAMMember status ... cannot confirm whether the
+        #   IAM binding has propagated
+        #   Cannot read ObjectStore ... cannot inspect the plugin's bucket config
+        #
+        # Its open question was exactly the ambiguity in GCP's error text: a 403
+        # on buckets.get means "no permission" OR "no bucket", and only the
+        # Bucket MR's status separates them. Granted these, that stops being an
+        # open question.
+        #
+        # The claims were already granted (cloud.ogenki.io above); these are the
+        # managed resources those claims COMPOSE INTO, which is where a
+        # Crossplane failure actually shows itself -- a claim can read Ready
+        # while the MR underneath carries the provider's real error.
+        - apiGroups: ["storage.gcp.m.upbound.io"]
+          resources: ["buckets", "bucketiammembers"]
+          verbs: ["get", "list"]
+        - apiGroups: ["cloudplatform.gcp.m.upbound.io"]
+          resources: ["projectiammembers", "serviceaccounts"]
+          verbs: ["get", "list"]
+        # The barman plugin's own CR. postgresql.cnpg.io above covers Cluster
+        # and Backup; ObjectStore is a DIFFERENT group shipped by the plugin,
+        # and it holds the bucket path and credential mode -- the two fields
+        # that decide whether archiving can work at all.
+        - apiGroups: ["barmancloud.cnpg.io"]
+          resources: ["objectstores"]
+          verbs: ["get", "list"]
+        # Crossplane's own plumbing. A claim stuck "Creating" is usually a
+        # provider that never installed or a CRD never activated, and neither is
+        # visible from the claim.
+        - apiGroups: ["pkg.crossplane.io"]
+          resources: ["providers", "providerrevisions", "configurations", "functions"]
+          verbs: ["get", "list"]
     networkPolicy:
       enabled: true
       # Renders a CiliumNetworkPolicy allowing egress to the EKS Pod Identity

--- a/website/content/docs/platform/ai-platform/_index.md
+++ b/website/content/docs/platform/ai-platform/_index.md
@@ -29,7 +29,7 @@ plain Flux reconciliation both leave the cluster LLM-free.
 | **Autoscaling** | KEDA, three vLLM saturation triggers OR-combined, `min=1` (always warm) |
 | **Weights** | Amazon S3 Files (POSIX over S3), RWX PVC shared by a preload Job and the serving pod |
 | **GPUs** | Karpenter `gpu-l4` NodePool — single-GPU `g6` spot instances, Bottlerocket NVIDIA AMI, capped at 4 GPUs |
-| **Composition** | `crossplane-inference-service` KCL module `0.9.0`, pinned inside `crossplane-configuration-aws:v0.4.2` |
+| **Composition** | `crossplane-inference-service` KCL module `0.9.0`, pinned inside `crossplane-configuration-aws:v0.4.3` |
 
 ## Why self-host at all
 

--- a/website/content/docs/platform/developer-platform/_index.md
+++ b/website/content/docs/platform/developer-platform/_index.md
@@ -14,11 +14,11 @@ a version:
 ```yaml
 # infrastructure/base/crossplane/configuration/configuration-packages.yaml
 spec:
-  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.2
+  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.3
 ```
 
 `gcp-0` serves the same claims from its own package,
-`ghcr.io/smana/crossplane-configuration-gcp:v0.4.2`, pinned in
+`ghcr.io/smana/crossplane-configuration-gcp:v0.4.3`, pinned in
 `infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml`
 — both clusters currently pin the same release.
 

--- a/website/content/docs/platform/developer-platform/app-field-reference.md
+++ b/website/content/docs/platform/developer-platform/app-field-reference.md
@@ -17,11 +17,11 @@ they live in
 [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration),
 which this repo pins as a `Configuration` package
 (`infrastructure/base/crossplane/configuration/configuration-packages.yaml`,
-currently `ghcr.io/smana/crossplane-configuration-aws:v0.4.2`). This table was
+currently `ghcr.io/smana/crossplane-configuration-aws:v0.4.3`). This table was
 reconciled by hand against that repository's `apis/app/definition.yaml` (the
 CRD schema — types, enums, CEL rules) and `apis/app/kcl/main.k` (composition
 defaults that never appear in the schema, such as resource requests/limits or
-the gateway/route fallback names) at the commit tagged `v0.4.2`.
+the gateway/route fallback names) at the commit tagged `v0.4.3`.
 
 **To regenerate:** check out `Smana/crossplane-configuration` at the tag
 currently pinned above, and read `apis/app/definition.yaml` +

--- a/website/content/docs/platform/developer-platform/app-wizard.md
+++ b/website/content/docs/platform/developer-platform/app-wizard.md
@@ -29,7 +29,7 @@ The wizard clones **two** repositories at startup: this one (for the `App`
 schema, stacks, and its own config) and
 [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration)
 at the tag pinned in `apps/platform/app-wizard/app.yaml`'s
-`fetch-crossplane-configuration` init container — currently `v0.4.2`, the
+`fetch-crossplane-configuration` init container — currently `v0.4.3`, the
 same tag pinned in
 `infrastructure/base/crossplane/configuration/configuration-packages.yaml`.
 This is a deliberate coupling, not an accident: if the wizard's clone drifts


### PR DESCRIPTION

Two changes that belong together: the pin carries a fix runlore diagnosed, and
the RBAC closes the gaps it reported while diagnosing it.

## The pin: v0.4.3 fixes barman's 403

roles/storage.objectAdmin carries storage.objects.* and NO storage.buckets.* at
all, while barman-cloud calls storage.buckets.get before archiving. With
objectAdmin alone every WAL push and base backup returned

    403 storage.buckets.get denied (or it may not exist)

On gcp-0 that took ContinuousArchiving to False at 08:45Z and left a
ScheduledBackup in phase=started for the rest of the day, blocking later runs
with "Backup is already running". v0.4.3 adds roles/storage.legacyBucketReader
alongside objectAdmin -- the narrowest role granting that permission.

Eleven references move together, not just the two package pins: the app-wizard
initContainer clones this same tag, and CLAUDE.md is explicit that the two are
coupled.

## The RBAC: the layer BELOW the claims

runlore reached the diagnosis above at 0.78 confidence and was honest about what
it could not see:

    Cannot read Bucket resource status ... cannot confirm whether the GCS bucket
    actually exists in GCP or was created by Crossplane
    Cannot read BucketIAMMember status ... cannot confirm whether the IAM
    binding has propagated
    Cannot read ObjectStore ... cannot inspect the plugin's bucket config

Its open question was precisely the ambiguity in GCP's error text -- a 403 on
buckets.get means "no permission" OR "no bucket", and only the Bucket managed
resource's status separates the two. It got there anyway from kube_events, but
it was reasoning around the evidence rather than from it, for the second time.

#1876 granted the CLAIMS (cloud.ogenki.io). These are the managed resources
those claims compose INTO, which is where a Crossplane failure actually surfaces:
a claim can read Ready while the MR underneath carries the provider's real error.

  storage.gcp.m.upbound.io          buckets, bucketiammembers
  cloudplatform.gcp.m.upbound.io    projectiammembers, serviceaccounts
  barmancloud.cnpg.io               objectstores
  pkg.crossplane.io                 providers, providerrevisions,
                                    configurations, functions

barmancloud.cnpg.io is a separate group from postgresql.cnpg.io, which #1876
already covers -- ObjectStore holds the bucket path and the credential mode, the
two fields that decide whether archiving can work at all. pkg.crossplane.io is
there because a claim stuck "Creating" is usually a provider that never
installed or a CRD never activated, and neither is visible from the claim.

get and list on all of them, per #1882: the chart ships get-only and
list_resources is denied without list. Still no Secret kind anywhere.

Evidence:
  validate-manifests.sh  -> 2105 resources, Valid: 2105, Invalid: 0, Skipped: 0
                            (schemas fetched from the v0.4.3 release)
  validate-links.sh      -> all relative links resolve
  validate-doc-claims.sh -> 6 claims match, 10 page checks
