### PR TITLE
fix(gcp): allowlist the one permission barman needs, or v0.4.3 stays inert

### DIFF
--- a/opentofu/gcp/gke/init/iam.tf
+++ b/opentofu/gcp/gke/init/iam.tf
@@ -207,9 +207,29 @@ locals {
   # "readwrite" else "roles/storage.objectViewer"`), and hasOnly matches exact
   # role names, so they belong in this allowlist verbatim, the same way the
   # custom DNS role's deterministic name does.
+  #
+  # legacyBucketReader is here for ONE permission: storage.buckets.get. The
+  # barman-cloud plugin calls it before every archive, objectAdmin does not
+  # carry it, and without it every WAL push and base backup on gcp-0 returned
+  # `403 storage.buckets.get denied (or it may not exist)` -- ambiguous between
+  # "no permission" and "no bucket", which is why it read as a missing bucket.
+  #
+  # Adding it to the allowlist widens what Crossplane may grant by exactly that
+  # one permission, and by nothing else. Measured, not assumed: every other
+  # permission legacyBucketReader carries (objects.list, folders.get/list,
+  # managedFolders.get/list, multipartUploads.list) is ALREADY inside
+  # objectAdmin, which is on this list. Reading a bucket's metadata is strictly
+  # weaker than the object read/write/delete already grantable here, and the
+  # `resource.name.startsWith` clause below still confines it to ogenki- buckets.
+  #
+  # A custom role holding storage.buckets.get alone would be narrower still, by
+  # objects.list. Not worth it: the composition would have to interpolate a
+  # project-scoped role name, which means a release and a pin bump to change one
+  # permission that objectAdmin's objects.list already implies you can enumerate.
   crossplane_bucket_grantable_roles = [
     "roles/storage.objectAdmin",
     "roles/storage.objectViewer",
+    "roles/storage.legacyBucketReader",
   ]
 
   # TRAP 1, and it is silent: `projects/` takes the project NUMBER while


### PR DESCRIPTION
v0.4.3 (#1885) had the SQLInstance composition ask for
roles/storage.legacyBucketReader on the backup bucket, because barman-cloud
calls storage.buckets.get before archiving and objectAdmin does not carry it.
The composition duly created the BucketIAMMember. It has been stuck since:

    Error applying IAM policy for storage bucket
    "b/ogenki-435905-ogenki-cnpg-backups": googleapi: Error 403: Access denied.

Not the same 403. The first one was barman denied on the bucket; this one is
Crossplane denied on the IAM policy -- and it is this repo's own guardrail
firing correctly. crossplane_bucket_grantable_roles gates which roles
provider-gcp may grant at all, via an IAM Condition on modifiedGrantsByRole,
and it listed objectAdmin and objectViewer only. GCP reports a condition denial
as a bare "Access denied.", naming neither the condition nor the role, so
nothing in the error points here.

Worth stating plainly: the guardrail did its job. A new role appeared in a
composition and the platform refused to grant it until someone decided that was
allowed. The bug is that #1885 changed one half of a two-sided contract.

WHAT THIS ACTUALLY WIDENS: one permission.

Measured against the live API rather than assumed. Every permission
legacyBucketReader carries -- objects.list, folders.get/list,
managedFolders.get/list, multipartUploads.list -- is already inside objectAdmin,
which is already on this list. The single exception is storage.buckets.get.

So the delta is: Crossplane may now grant read access to a bucket's METADATA, on
buckets it may already grant object create/delete/overwrite on, restricted by
the unchanged resource.name.startsWith('projects/_/buckets/<project>-ogenki-')
clause. Nothing else changes.

A custom role holding storage.buckets.get alone would be narrower, by
objects.list. Rejected: the composition would have to interpolate a
project-scoped role name, costing a package release and a pin bump, to withhold
enumeration from a principal that objectAdmin already lets write objects.

Kept in crossplane_bucket_grantable_roles and deliberately NOT in
crossplane_grantable_roles, per the N1 note above the two lists:
modifiedGrantsByRole carries the role but not the resource, so a role
allowlisted for the bucket-scoped binding would otherwise be legalised for the
project-scoped one too.

Inert until applied -- the condition lives in project IAM, not in the cluster:

    cd opentofu/gcp/gke/init && TM_GCP_ENABLED=true terramate script run deploy

Evidence:
  gcloud iam roles describe roles/storage.legacyBucketReader -> storage.buckets.get
    plus 6 permissions, all 6 also present in roles/storage.objectAdmin
  tofu fmt -check -> clean
  trivy config -> exit 0, 0 HIGH/CRITICAL
  validate-doc-claims.sh -> 6 claims match
