### PR TITLE
fix(gcp): make SSO actually work on gcp-0 — ZITADEL wiring, and Headlamp behind an auth proxy

### DIFF
--- a/flux/sources/helmrepo-oauth2-proxy.yaml
+++ b/flux/sources/helmrepo-oauth2-proxy.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: oauth2-proxy
+  namespace: tooling
+spec:
+  interval: 24h
+  url: https://oauth2-proxy.github.io/manifests

--- a/scripts/zitadel-actions/groups-from-roles.js
+++ b/scripts/zitadel-actions/groups-from-roles.js
@@ -1,5 +1,15 @@
 /**
- * groups-from-roles — flatten ZITADEL's project roles into a `groups` claim.
+ * groupsFromRoles — flatten ZITADEL's project roles into `groups` and `roles`.
+ *
+ * THE FUNCTION NAME BELOW IS THE ACTION NAME, AND VICE VERSA. ZITADEL v1 does
+ * not take an entrypoint: it looks up a function named after the action and
+ * calls it. Rename one without the other and ZITADEL stores it happily, then
+ * fails EVERY token request with "action run failed: function not found" --
+ * which reaches the user as Grafana's "Failed to get token from provider" and
+ * nothing at all in the ZITADEL UI. The action was created as
+ * "groups-from-roles" on 2026-08-28; a hyphen cannot appear in a JS identifier,
+ * so no function could ever have matched it. zitadel-idp.sh now refuses to run
+ * when the two disagree.
  *
  * WHY THIS EXISTS
  *
@@ -81,5 +91,17 @@ function groupsFromRoles(ctx, api) {
     return;
   }
 
+  // TWO CLAIMS, ONE LIST, because the consumers on this platform disagree about
+  // the name and both are already deployed:
+  //
+  //   groups   Headlamp, Flux UI      (OIDC groups claim)
+  //   roles    Grafana                (role_attribute_path: contains(roles[*], 'admin') ...)
+  //
+  // Grafana's mapping is in the shared vm-common-helm-values ConfigMap and reads
+  // roles[*]. Emitting only `groups` left it matching nothing and falling through
+  // to its 'Viewer' default -- a silent failure, since everyone still logged in,
+  // just never as Admin. Setting both is one line here; renaming the claim would
+  // mean changing consumers on two clusters at once.
   api.v1.claims.setClaim('groups', groups);
+  api.v1.claims.setClaim('roles', groups);
 }

--- a/scripts/zitadel-idp.sh
+++ b/scripts/zitadel-idp.sh
@@ -65,7 +65,20 @@ APPLY="false"
 
 IDP_NAME="Google Workspace"
 IDP_SECRET_KEY="zitadel-google-idp" # pragma: allowlist secret
-ACTION_NAME="groups-from-roles"
+# THE ACTION NAME IS NOT A LABEL. ZITADEL v1 looks up a function in the script
+# BY THIS NAME and runs it, so it must be a valid JS identifier and must match
+# the function in ACTION_FILE exactly.
+#
+# It was "groups-from-roles" for one day. Hyphens cannot appear in a JS
+# identifier, so no function could ever carry that name, and ZITADEL logged
+#     action run failed: function not found
+# on every token request. With allowedToFail=false that FAILS TOKEN ISSUANCE --
+# which surfaces in Grafana as "Failed to get token from provider" and in the
+# ZITADEL UI as nothing at all. Nothing in the API rejects the mismatched name;
+# it is accepted, stored, and only ever fails at runtime.
+#
+# assert_action_name_matches_function() below makes that unrepeatable.
+ACTION_NAME="groupsFromRoles"
 ACTION_FILE="$(cd "$(dirname "$0")" && pwd)/zitadel-actions/groups-from-roles.js"
 
 while [ $# -gt 0 ]; do
@@ -210,6 +223,79 @@ ensure_idp() {
     echo "[created] IdP '${IDP_NAME}' (${id}, client ${client_id})"
 }
 
+# The check that would have caught the day-long outage described at ACTION_NAME:
+# a mismatch is invisible until a real user tries to log in, so it is worth
+# failing the script over rather than discovering it in a browser.
+assert_action_name_matches_function() {
+    if ! grep -qE "^[[:space:]]*function[[:space:]]+${ACTION_NAME}[[:space:]]*\\(" "$ACTION_FILE"; then
+        echo "[FAILED ] ${ACTION_FILE##*/} defines no 'function ${ACTION_NAME}('." >&2
+        echo "           ZITADEL calls the function NAMED AFTER THE ACTION. If they" >&2
+        echo "           disagree it stores fine and then fails every token request" >&2
+        echo "           with 'action run failed: function not found'." >&2
+        echo "           Found instead:" >&2
+        grep -nE "^[[:space:]]*function[[:space:]]+[A-Za-z_$][A-Za-z0-9_$]*" "$ACTION_FILE" >&2 || true
+        return 1
+    fi
+}
+
+# -- the login policy ---------------------------------------------------------
+#
+# CREATING AN IDP DOES NOT ENABLE IT. This is the step whose absence produced
+# "User not found" on gcp-0 while every field of the provider read correct.
+#
+# In ZITADEL an IdP template and the login policy are separate objects. The
+# template says how to talk to Google; the LOGIN POLICY says which providers the
+# login UI may offer. With the template present and the policy empty, ZITADEL
+# renders no Google button, so an email typed at the login screen is resolved as
+# a LOCAL username -- and on a fresh instance no such user exists. The error is
+# therefore literally true and points at entirely the wrong thing: the IdP is
+# fine, autoCreation is on, and the user cannot reach any of it.
+#
+# Nothing warns about this. `allowExternalIdp: true` is the instance default and
+# stays true with zero providers attached, so the policy reads "external login
+# allowed" while allowing none.
+#
+# INSTANCE policy (/admin/v1), matching the IdP's own scope. An org whose policy
+# is still the default inherits this; an org that has overridden its login
+# policy does not, and that case is reported below rather than silently assumed.
+login_policy_has_idp() {
+    local idp_id="$1"
+    api GET /admin/v1/policies/login 2>/dev/null \
+        | jq -e --arg id "$idp_id" '.policy.idps[]? | select(.idpId == $id)' >/dev/null 2>&1
+}
+
+ensure_login_policy_idp() {
+    local idp_id="$1"
+
+    if [ -z "$idp_id" ]; then
+        echo "[dry-run] would add the IdP to the instance login policy"
+        return 0
+    fi
+
+    if login_policy_has_idp "$idp_id"; then
+        echo "[skip   ] IdP already on the instance login policy"
+    elif [ "$APPLY" != "true" ]; then
+        echo "[dry-run] would add IdP ${idp_id} to the instance login policy"
+        return 0
+    else
+        jq -n --arg id "$idp_id" \
+            '{idpId: $id, ownerType: "IDP_OWNER_TYPE_SYSTEM"}' \
+            | api POST /admin/v1/policies/login/idps -d @- >/dev/null
+        echo "[added  ] IdP ${idp_id} to the instance login policy"
+    fi
+
+    # An org that has customised its login policy does NOT inherit the instance
+    # one. Report rather than guess: silently writing an org policy would create
+    # the override this platform does not want.
+    local is_default
+    is_default="$(api GET /management/v1/policies/login 2>/dev/null | jq -r '.policy.isDefault // "unknown"')"
+    if [ "$is_default" != "true" ]; then
+        echo "[WARN   ] the org login policy is NOT the instance default (isDefault=${is_default})." >&2
+        echo "           It will not inherit the provider added above; add it there too via" >&2
+        echo "           POST /management/v1/policies/login/idps with idpId ${idp_id}" >&2
+    fi
+}
+
 # ── the groups action ─────────────────────────────────────────────────────────
 #
 # v1 Actions are ORG-level, with no instance-level equivalent -- so unlike the
@@ -290,6 +376,14 @@ echo "scope:    instance (/admin/v1) for the IdP, org (/management/v1) for the a
 echo
 
 ensure_idp
+
+# Re-read rather than threading a return value out of ensure_idp: that function
+# has three exit paths (skip / dry-run / create) and only one of them knows an
+# id. Looking it up once here is the same answer in every case.
+ensure_login_policy_idp "$(idp_id_by_name || true)"
+
+# Fails the run if the action name and the JS function disagree -- see ACTION_NAME.
+assert_action_name_matches_function
 
 ACTION_ID="$(ensure_action | tail -1)"
 if [ -n "$ACTION_ID" ]; then

--- a/scripts/zitadel-oidc-clients.sh
+++ b/scripts/zitadel-oidc-clients.sh
@@ -211,6 +211,11 @@ CONSUMERS=(
   "grafana|https://grafana.${PRIVATE_DOMAIN}/login/generic_oauth|observability-victoria-metrics-k8s-stack-grafana-envvars"
   "headlamp|https://headlamp.${PRIVATE_DOMAIN}/oidc-callback|headlamp-envvars"
   "flux-ui|https://flux-ui-${CLUSTER}.${PRIVATE_DOMAIN}/oauth2/callback|security-flux-ui-oidc"
+  # gcp-0 only in practice, and harmless on aws-0 where nothing consumes it.
+  # GKE cannot be told to trust ZITADEL, so Headlamp there sits behind
+  # oauth2-proxy and the PROXY holds the OIDC client -- a second client for the
+  # same hostname, on the proxy's own callback path. ADR-0026.
+  "headlamp-proxy|https://headlamp.${PRIVATE_DOMAIN}/oauth2/callback|headlamp-oauth2-proxy"
 )
 
 # Roles are additive and idempotent: ZITADEL rejects a duplicate roleKey, so an
@@ -285,6 +290,19 @@ merge_secret() {
         flux-ui)
             jq -n --argjson base "$existing" --arg id "$client_id" --arg sec "$client_secret" \
                '$base + {clientID: $id, clientSecret: $sec}' ;;
+        headlamp-proxy)
+            # Hyphenated keys, deliberately: the oauth2-proxy chart's
+            # `config.existingSecret` reads exactly client-id / client-secret /
+            # cookie-secret, so the blob is shaped to be consumed by a whole-blob
+            # ExternalSecret extract with no remapping.
+            #
+            # The cookie secret is generated here and then PRESERVED across runs
+            # by the `// $ck` fallback -- regenerating it on every sync would
+            # silently log every user out and look like a broken login.
+            jq -n --argjson base "$existing" --arg id "$client_id" --arg sec "$client_secret" \
+               --arg ck "$(openssl rand -base64 32 | tr -d '\n')" \
+               '$base + {"client-id": $id, "client-secret": $sec,
+                         "cookie-secret": ($base["cookie-secret"] // $ck)}' ;;
     esac
 }
 

--- a/scripts/zitadel-oidc-clients.sh
+++ b/scripts/zitadel-oidc-clients.sh
@@ -52,6 +52,25 @@ GCP_PROJECT=""
 APPLY="false"
 ZITADEL_PROJECT_NAME="platform"
 
+# The project roles the platform's OWN RBAC already refers to. These are not a
+# guess: each name is read back out of a manifest in this repo, through the
+# groups/roles claim that zitadel-actions/groups-from-roles.js builds.
+#
+#   admin      security/base/rbac/admin.yaml   Group admin    -> cluster-admin
+#              flux-ui ClusterRoleBinding       Group admin    -> cluster-admin
+#              Grafana role_attribute_path      'admin'        -> Admin
+#   backend    flux-ui ClusterRoleBinding       Group backend  -> edit
+#              Grafana role_attribute_path      'backend'      -> Editor
+#   data       flux-ui ClusterRoleBinding       Group data     -> edit
+#              Grafana role_attribute_path      'data'         -> Editor
+#   frontend   Grafana role_attribute_path      'frontend'     -> Editor
+#
+# Without them the whole chain is inert: ZITADEL has no role to grant, so the
+# Action emits no claim, so every binding above matches nobody and Grafana falls
+# through to Viewer. gcp-0 came up on 2026-08-28 with zero roles on the project
+# and nothing anywhere said so -- login worked, authorisation silently did not.
+ZITADEL_PROJECT_ROLES=(admin backend frontend data)
+
 while [ $# -gt 0 ]; do
     case "$1" in
         --cluster) CLUSTER="$2"; shift 2 ;;
@@ -194,6 +213,37 @@ CONSUMERS=(
   "flux-ui|https://flux-ui-${CLUSTER}.${PRIVATE_DOMAIN}/oauth2/callback|security-flux-ui-oidc"
 )
 
+# Roles are additive and idempotent: ZITADEL rejects a duplicate roleKey, so an
+# existing role is left alone rather than rewritten. Granting a role to a USER is
+# deliberately NOT done here -- a user exists only after their first login, and
+# guessing who should be admin is not this script's business.
+ensure_project_roles() {
+    local project_id="$1" role existing
+    [ -n "$project_id" ] || return 0
+
+    if [ "$project_id" = "DRYRUN-PROJECT" ]; then
+        echo "[dry-run] would ensure roles: ${ZITADEL_PROJECT_ROLES[*]}"
+        return 0
+    fi
+
+    existing="$(api POST "/management/v1/projects/${project_id}/roles/_search" -d '{"query":{"limit":100}}' 2>/dev/null \
+                | jq -r '.result[]?.key' || true)"
+
+    for role in "${ZITADEL_PROJECT_ROLES[@]}"; do
+        if grep -qx "$role" <<< "$existing"; then
+            echo "[skip   ] role '${role}' already exists"
+            continue
+        fi
+        if [ "$APPLY" != "true" ]; then
+            echo "[dry-run] would create role '${role}'"
+            continue
+        fi
+        jq -n --arg k "$role" --arg d "$role" '{roleKey: $k, displayName: $d}' \
+            | api POST "/management/v1/projects/${project_id}/roles" -d @- >/dev/null
+        echo "[created] role '${role}'"
+    done
+}
+
 ensure_project() {
     local id
     id=$(api POST /management/v1/projects/_search -d '{"queries":[]}' \
@@ -247,6 +297,8 @@ cmd_sync() {
     local project_id
     project_id="$(ensure_project)"
     [ -n "$project_id" ] || { echo "could not resolve or create the ZITADEL project" >&2; exit 1; }
+
+    ensure_project_roles "$project_id"
 
     local created=0 skipped=0
     for entry in "${CONSUMERS[@]}"; do

--- a/tooling/gcp-0/headlamp/externalsecret-oauth2-proxy.yaml
+++ b/tooling/gcp-0/headlamp/externalsecret-oauth2-proxy.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: headlamp-oauth2-proxy
+  namespace: tooling
+spec:
+  # The blob holds exactly the three keys the chart's existingSecret expects, so
+  # a whole-blob extract lands them under the right names with no remapping.
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        key: headlamp-oauth2-proxy
+  refreshInterval: 20m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: clustersecretstore
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: headlamp-oauth2-proxy

--- a/tooling/gcp-0/headlamp/headlamp-proxy-auth.yaml
+++ b/tooling/gcp-0/headlamp/headlamp-proxy-auth.yaml
@@ -1,0 +1,46 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: headlamp
+  namespace: tooling
+spec:
+  values:
+    config:
+      # OIDC OFF ON THIS CLUSTER. Not a preference -- GKE cannot be made to trust
+      # ZITADEL. aws-0 associates the issuer with the EKS control plane
+      # (identity_providers in opentofu/aws/eks/init/variables.tfvars), so there
+      # Headlamp forwards the user's id_token and the API server validates it.
+      # GKE exposes no equivalent knob, and Identity Service for GKE -- the thing
+      # that used to provide one -- is deprecated as of 2026-07-01 and unsupported
+      # in GKE 1.37+. See ADR-0026.
+      #
+      # Emptying the block removes the -oidc-* flags the chart would otherwise
+      # render, and with them the headlamp-envvars mount. Leaving OIDC on would
+      # be worse than useless: Headlamp would authenticate the human and then send
+      # a token the API server rejects, which is the "logs in, then every call
+      # 401s" failure.
+      oidc:
+        secret:
+          create: false
+        externalSecret:
+          enabled: false
+
+      # Headlamp now talks to the API server as its OWN ServiceAccount, for every
+      # user. The chart calls this flag unsafe and it is right to: per-user
+      # Kubernetes RBAC is gone, so anyone oauth2-proxy admits has whatever the
+      # headlamp SA has. That is why allowed-group=admin on the proxy is
+      # load-bearing rather than defence in depth, and why the SA's binding is
+      # worth re-reading before widening the proxy's audience.
+      unsafeUseServiceAccountToken: true
+
+      # config.extraArgs, NOT a top-level extraArgs. The chart nests it under
+      # `config:`; at the top level it renders nothing at all, silently, and the
+      # Deployment comes up without proxy-auth -- caught by grepping the rendered
+      # bundle for the flags rather than trusting that the values "looked right".
+      extraArgs:
+        # Trust the proxy's identity headers and skip Headlamp's own login screen.
+        - "-proxy-auth=true"
+        # PLURAL. oauth2-proxy emits X-Forwarded-Groups; Headlamp defaults to the
+        # singular X-Forwarded-Group and would silently see no groups. Verified
+        # against the flag list of the running v0.44.0 binary, not the docs.
+        - "-proxy-auth-group-header=X-Forwarded-Groups"

--- a/tooling/gcp-0/headlamp/httproute-oauth2-proxy.yaml
+++ b/tooling/gcp-0/headlamp/httproute-oauth2-proxy.yaml
@@ -1,0 +1,49 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: headlamp
+  namespace: tooling
+spec:
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        # THE SECURITY PROPERTY THIS WHOLE DESIGN RESTS ON.
+        #
+        # Headlamp now believes whoever X-Forwarded-User says it is, and grants
+        # that identity its ServiceAccount's permissions. If a client could set
+        # those headers itself, it would authenticate as anyone -- Headlamp's own
+        # documentation says so plainly: "a client could spoof these headers and
+        # impersonate another user if Headlamp is reachable without that
+        # protection at the edge."
+        #
+        # So the edge removes them from every inbound request, before oauth2-proxy
+        # sets its own. `remove` runs on the request as it enters the gateway, so a
+        # client-supplied value cannot survive to the backend, and oauth2-proxy
+        # adds them downstream of this filter.
+        #
+        # X-Auth-Request-* are stripped too: --set-xauthrequest emits them, and a
+        # future Headlamp flag pointed at one must not be spoofable either.
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            remove:
+              - X-Forwarded-User
+              - X-Forwarded-Email
+              - X-Forwarded-Groups
+              - X-Forwarded-Group
+              - X-Forwarded-Id-Token
+              - X-Auth-Request-User
+              - X-Auth-Request-Email
+              - X-Auth-Request-Groups
+              - X-Auth-Request-Access-Token
+      backendRefs:
+        # Traffic now enters oauth2-proxy, which authenticates against ZITADEL and
+        # then proxies to headlamp:80 itself (its --upstream). The Headlamp Service
+        # keeps existing and is still reachable in-cluster -- the CiliumNetworkPolicy
+        # beside this file is what stops anything but the proxy using it.
+        - group: ""
+          kind: Service
+          name: headlamp-oauth2-proxy
+          port: 80

--- a/tooling/gcp-0/headlamp/kustomization.yaml
+++ b/tooling/gcp-0/headlamp/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tooling
+
+# Headlamp on GKE, authenticated by a proxy instead of by the cluster.
+#
+# aws-0 uses the plain base: EKS is told to trust ZITADEL, Headlamp forwards the
+# user's id_token, and per-user Kubernetes RBAC works. GKE offers no equivalent,
+# and the feature that used to (Identity Service for GKE) is deprecated as of
+# 2026-07-01 and gone in 1.37+. ADR-0026 records the choice and what it costs.
+#
+# The pieces only make sense together:
+#   oauth2-proxy.yaml            authenticates the human against ZITADEL
+#   headlamp-proxy-auth.yaml     Headlamp trusts its headers, drops OIDC
+#   httproute-oauth2-proxy.yaml  routes via the proxy AND strips spoofable headers
+#   network-policy.yaml          makes the proxy the only path to Headlamp
+resources:
+  - ../../base/headlamp
+  - externalsecret-oauth2-proxy.yaml
+  - oauth2-proxy.yaml
+  - network-policy.yaml
+
+patches:
+  - path: headlamp-proxy-auth.yaml
+    target:
+      group: helm.toolkit.fluxcd.io
+      kind: HelmRelease
+      name: headlamp
+  - path: httproute-oauth2-proxy.yaml
+    target:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: headlamp

--- a/tooling/gcp-0/headlamp/network-policy.yaml
+++ b/tooling/gcp-0/headlamp/network-policy.yaml
@@ -1,0 +1,81 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: headlamp-oauth2-proxy
+  namespace: tooling
+spec:
+  description: "Headlamp's auth proxy: in from the gateway, out to ZITADEL and headlamp"
+  endpointSelector:
+    matchLabels:
+      k8s:app.kubernetes.io/name: oauth2-proxy
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          # L7 DNS inspection, without which no toFQDNs rule anywhere can work.
+          # Not needed by the rules below -- they use toEntities -- but omitting
+          # it is the trap documented in .claude/rules/cilium-network-policies.md,
+          # so it stays even though nothing here depends on it yet.
+          rules:
+            dns:
+              - matchPattern: "*"
+
+    # ZITADEL is reached over its PUBLIC hostname (auth.<public domain>), which
+    # resolves to the public Gateway's external LoadBalancer -- so this leaves the
+    # cluster and comes back, and `world` is the honest entity for it rather than
+    # a cluster-internal selector.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+
+    # The upstream it proxies to.
+    - toEndpoints:
+        - matchLabels:
+            k8s:app.kubernetes.io/name: headlamp
+      toPorts:
+        - ports:
+            - port: "4466"
+              protocol: TCP
+
+  ingress:
+    - fromEntities:
+        - ingress
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: headlamp
+  namespace: tooling
+spec:
+  # The other half of the design: with -proxy-auth Headlamp trusts identity
+  # headers, so anything that can reach it directly can claim to be anyone. The
+  # HTTPRoute strips those headers at the edge; this makes sure the edge is the
+  # only way in, by allowing ingress ONLY from the proxy. Without it the gateway
+  # filter is a fence with the gate left open beside it -- any pod in the cluster
+  # could call headlamp:4466 with an X-Forwarded-User of its choosing.
+  description: "Headlamp accepts traffic only from its auth proxy"
+  endpointSelector:
+    matchLabels:
+      k8s:app.kubernetes.io/name: headlamp
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:app.kubernetes.io/name: oauth2-proxy
+      toPorts:
+        - ports:
+            - port: "4466"
+              protocol: TCP

--- a/tooling/gcp-0/headlamp/oauth2-proxy.yaml
+++ b/tooling/gcp-0/headlamp/oauth2-proxy.yaml
@@ -1,0 +1,89 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: headlamp-oauth2-proxy
+  namespace: tooling
+spec:
+  interval: 30m
+  driftDetection:
+    mode: enabled
+  chart:
+    spec:
+      chart: oauth2-proxy
+      version: "10.7.0"
+      sourceRef:
+        kind: HelmRepository
+        name: oauth2-proxy
+      interval: 12h
+  values:
+    # Without this the chart names everything <release>-<chart>, i.e.
+    # `headlamp-oauth2-proxy-oauth2-proxy`, and the HTTPRoute beside this file
+    # would point at a Service that does not exist. Rendered and checked rather
+    # than assumed.
+    fullnameOverride: headlamp-oauth2-proxy
+
+    # Credentials come from the store, written by zitadel-oidc-clients.sh. The
+    # chart expects exactly these three keys, which is why the payload function
+    # in that script emits `client-id` / `client-secret` / `cookie-secret`
+    # verbatim rather than the OAUTH2_PROXY_* env names.
+    config:
+      existingSecret: headlamp-oauth2-proxy  # pragma: allowlist secret
+
+    extraArgs:
+      provider: oidc
+      oidc-issuer-url: "${identity_provider_url}"
+      redirect-url: "https://headlamp.${private_domain_name}/oauth2/callback"
+      upstream: "http://headlamp.tooling.svc.cluster.local:80"
+
+      # THE HEADER CONTRACT WITH HEADLAMP, and the half of it that is easy to get
+      # wrong. --pass-user-headers makes oauth2-proxy set X-Forwarded-User and
+      # X-Forwarded-Email, and the group header it emits is X-Forwarded-GroupS,
+      # PLURAL. Headlamp's -proxy-auth-group-header defaults to the SINGULAR
+      # X-Forwarded-Group, so left alone the two never meet: login succeeds, the
+      # user has no groups, and nothing logs an error. The Headlamp side names
+      # the plural form explicitly -- see headlamp-proxy-auth.yaml.
+      pass-user-headers: "true"
+      set-xauthrequest: "true"
+
+      # No Authorization header upstream. Headlamp must NOT receive a bearer
+      # token here: it authenticates to the API server with its own ServiceAccount
+      # (see the patch), and a stray Authorization header would be a second,
+      # unintended credential path.
+      pass-basic-auth: "false"
+      pass-authorization-header: "false"
+
+      # WHO GETS IN. This is the whole authorisation model now -- Kubernetes RBAC
+      # can no longer tell these users apart, so the gate has to be here.
+      #
+      # `admin` is the ZITADEL project role, reaching the token through
+      # zitadel-actions/groups-from-roles.js. If a login is refused with
+      # "Permission Denied", the cause is almost certainly that the claim did not
+      # reach the ID token rather than a wrong role -- oauth2-proxy logs the
+      # groups it saw, so check the pod log before changing anything.
+      email-domain: "ogenki.io"
+      allowed-group: "admin"
+      oidc-groups-claim: "groups"
+      scope: "openid profile email"
+
+      cookie-secure: "true"
+
+    # The chart's own defaults are already restricted-PSS compliant here
+    # (seccompProfile RuntimeDefault, caps dropped, non-root, read-only rootfs),
+    # so this restates only what it leaves open.
+    securityContext:
+      enabled: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi

--- a/tooling/gcp-0/kustomization.yaml
+++ b/tooling/gcp-0/kustomization.yaml
@@ -20,7 +20,9 @@ kind: Kustomization
 #
 # Nothing here can express step 2, which is why it is written down.
 resources:
-  - ../base/headlamp
+  # NOT ../base/headlamp: on GKE Headlamp is fronted by an auth proxy, because
+  # the cluster cannot be told to trust ZITADEL. See ./headlamp and ADR-0026.
+  - ./headlamp
   - ./harbor
   - ../base/homepage
   - ../base/pev2

--- a/website/content/docs/decisions/0026-headlamp-auth-proxy-on-gke.md
+++ b/website/content/docs/decisions/0026-headlamp-auth-proxy-on-gke.md
@@ -1,0 +1,145 @@
+---
+title: Headlamp authenticates behind an auth proxy on GKE, not against the cluster
+linkTitle: 0026 · Headlamp auth on GKE
+weight: 260
+description: GKE cannot be told to trust ZITADEL, so on gcp-0 Headlamp sits behind oauth2-proxy and talks to the API server as its own ServiceAccount — trading per-user Kubernetes RBAC for an authorisation gate at the proxy. aws-0 keeps real per-user OIDC.
+lastVerified: 2026-08-28
+---
+
+**Status**: Accepted
+**Date**: 2026-08-28
+**Deciders**: Platform Team
+
+---
+
+## Context
+
+Headlamp runs `-in-cluster` with OIDC and forwards the user's `id_token` to the
+Kubernetes API server. That only works if the API server trusts the issuer.
+
+On `aws-0` it does, because the EKS cluster is told to:
+
+```hcl
+# opentofu/aws/eks/init/variables.tfvars
+identity_providers = {
+  zitadel = {
+    issuer_url     = "https://auth.cloud.ogenki.io"
+    username_claim = "email"
+    groups_claim   = "groups"
+  }
+}
+```
+
+With that, `groups` from `zitadel-actions/groups-from-roles.js` become real
+Kubernetes groups, and `security/base/rbac/admin.yaml` (Group `admin` →
+`cluster-admin`) does the authorising.
+
+**GKE exposes no equivalent.** The managed control plane takes no
+`--oidc-issuer-url`. `gcp-0` therefore had a Headlamp that could authenticate a
+human and then fail every API call, which is how the gap surfaced on 2026-08-28:
+after fixing two unrelated ZITADEL bugs, login worked and nothing else did.
+
+Three things were checked before choosing:
+
+- **Identity Service for GKE**, the feature that used to provide the missing
+  knob, is **deprecated as of 2026-07-01 and unsupported in GKE 1.37+**. The
+  cluster runs 1.35, so it would work today and stop working on upgrade. Note
+  the blocker is deprecation, not licensing — Google's docs state no GKE
+  Enterprise requirement for it.
+- **Workforce Identity Federation**, Google's named replacement, is an IAM
+  feature needing no in-cluster components — but it authenticates a client
+  *to Google*, via an STS token exchange. Headlamp cannot forward a ZITADEL
+  `id_token` into it. It solves human `kubectl` access, not this.
+- **Headlamp's own OIDC impersonation** would have sidestepped the whole problem
+  by sending `Impersonate-User` instead of the raw token. It is
+  [broken and open](https://github.com/kubernetes-sigs/headlamp/issues/4198)
+  (v0.38.0, reported Nov 2025, no maintainer response).
+
+## Decision
+
+**On `gcp-0`, oauth2-proxy authenticates the user and Headlamp trusts its
+headers.** Headlamp talks to the API server as its own ServiceAccount.
+
+This is the upstream-documented answer for exactly this case: Headlamp's
+identity-aware-proxy guide covers "in-cluster users who want to use OIDC based
+authentication when the kubernetes cluster itself doesn't have OIDC
+authentication". The chart's own flag for it is named `unsafeUseServiceAccountToken`,
+and that name is accurate rather than alarmist.
+
+`aws-0` is untouched and keeps per-user OIDC. The divergence lives in
+`tooling/gcp-0/headlamp/`, not in `base/`.
+
+Four pieces, none of which is optional:
+
+| File | Role |
+|---|---|
+| `oauth2-proxy.yaml` | authenticates against ZITADEL, `--allowed-group=admin` |
+| `headlamp-proxy-auth.yaml` | `-proxy-auth=true`, OIDC off, SA token on |
+| `httproute-oauth2-proxy.yaml` | routes via the proxy **and strips spoofable headers** |
+| `network-policy.yaml` | makes the proxy the only path to Headlamp |
+
+## What this accepts
+
+**Per-user Kubernetes RBAC is gone on `gcp-0`.** Every admitted user acts as the
+`headlamp` ServiceAccount, so the API server cannot tell them apart — the
+`admin` / `backend` / `data` tiers that `flux-ui` still distinguishes collapse to
+one. Authorisation moves entirely to `--allowed-group=admin` on the proxy, which
+is why that flag is load-bearing rather than defence in depth.
+
+**Two things must both hold, or the model fails open.** Headlamp believes
+`X-Forwarded-User`. So (1) the HTTPRoute removes every `X-Forwarded-*` and
+`X-Auth-Request-*` header from inbound requests before the proxy sets its own,
+and (2) a CiliumNetworkPolicy allows ingress to Headlamp only from the proxy.
+Without (2) any pod in the cluster could call `headlamp:4466` claiming to be
+anyone; the gateway filter alone is a fence with the gate open beside it.
+
+This is acceptable **because these clusters are disposable and already behind
+Tailscale** — reaching the hostname at all requires a `tag:k8s` device. It would
+not be acceptable on a long-lived multi-tenant cluster; there, Pinniped below is
+the answer.
+
+## Alternatives considered
+
+**Pinniped Concierge in impersonation-proxy mode.** Apache-2.0, no licence cost,
+GKE explicitly supported, and the impersonation-proxy strategy exists precisely
+because managed control planes take no API-server flags. It would **preserve
+per-user RBAC** and keep `gcp-0` identical to `aws-0`'s model. Rejected for now
+on weight: Concierge plus a Supervisor to federate ZITADEL, a LoadBalancer or
+ClusterIP with its own certificates, for a cluster that is deleted after every
+validation run — and it was not verified that Headlamp can target an
+impersonation endpoint instead of `-in-cluster`. **This is the upgrade path** the
+moment per-user RBAC matters on GCP.
+
+**Identity Service for GKE.** Deprecated 2026-07-01, unsupported in 1.37+.
+Adopting it would mean adopting a component with a known removal date.
+
+**Workforce Identity Federation.** Not a substitute (see Context). Worth adopting
+separately for human `kubectl` access to `gcp-0`.
+
+**Do nothing and drop Headlamp from `gcp-0`.** Honest, and briefly tempting since
+Grafana and Flux UI authenticate at the application layer and need nothing from
+the API server. Rejected because "the cluster dashboard does not work on this
+cloud" is exactly the kind of asymmetry this repository exists to remove.
+
+## Consequences
+
+- `gcp-0` gains a second ZITADEL OIDC client for the same hostname —
+  `headlamp-proxy`, on `/oauth2/callback` — because the proxy, not Headlamp,
+  now holds the client. `zitadel-oidc-clients.sh` creates it.
+- The `headlamp-envvars` ExternalSecret still syncs on `gcp-0` and nothing reads
+  it. Left in place rather than patched out of `base/`: it is inert, and removing
+  it from the shared base would affect `aws-0`, which does read it.
+- Widening the proxy's audience widens cluster-admin. `--allowed-group=admin` and
+  the `headlamp` ServiceAccount's binding must be read together, and a reviewer
+  changing one should look at the other.
+- The `groups` claim now has a second consumer with different spelling.
+  oauth2-proxy emits `X-Forwarded-Groups`; Headlamp's default is the singular
+  `X-Forwarded-Group`, so the flag is set explicitly. Left at defaults the login
+  succeeds with no groups and nothing logs an error.
+
+## Related
+
+- [ADR-0024](0024-identity-provider-per-cloud.md) — where ZITADEL *runs*; this
+  record is about what the API server will *believe*, which ADR-0024 does not cover
+- [ADR-0002](0002-eks-pod-identity-over-irsa.md) — the AWS identity model this
+  diverges from

--- a/website/content/docs/decisions/_index.md
+++ b/website/content/docs/decisions/_index.md
@@ -68,5 +68,6 @@ single-file fixes never need one.
 | [0023]({{< relref "/docs/decisions/0023-portable-secret-store-names.md" >}}) | Secret store keys use a name grammar both clouds accept | Accepted | 2026-08-27 |
 | [0024]({{< relref "/docs/decisions/0024-identity-provider-per-cloud.md" >}}) | The identity provider is deployable on either cloud, defaulting to AWS | Accepted | 2026-08-27 |
 | [0025]({{< relref "/docs/decisions/0025-cloud-managed-secret-stores.md" >}}) | Cloud-managed secret stores as the store of record, OpenBao scoped to the PKI | Accepted | 2026-08-27 |
+| [0026]({{< relref "/docs/decisions/0026-headlamp-auth-proxy-on-gke.md" >}}) | Headlamp authenticates behind an auth proxy on GKE, not against the cluster | Accepted | 2026-08-28 |
 
 Starting a new one? Copy the [template]({{< relref "/docs/decisions/template.md" >}}).


### PR DESCRIPTION
Two separate bugs, both shipped by #1884, both silent, both fatal to SSO on
gcp-0. Each was found from a live instance; each is fixed live and here.

## 1. "User not found" -- creating an IdP does not enable it

In ZITADEL the IdP template and the login policy are different objects. The
template says how to talk to Google; the LOGIN POLICY lists which providers the
login UI may offer. #1884 created the template and stopped.

    GET /admin/v1/policies/login  ->  { "allowExternalIdp": true, "idps": [] }

With no provider on the policy there is no Google button, so an email typed at
the login screen is resolved as a LOCAL username -- and gcp-0's ZITADEL had
exactly two users, the bootstrap admin and the iam-admin machine account. Hence
"User not found": literally true, and pointing at entirely the wrong thing. The
provider was correct in every field, autoCreation included; the user could not
reach it.

Nothing warns. `allowExternalIdp: true` is the instance default and stays true
with zero providers attached, so the policy reads "external login allowed"
while allowing none.

`ensure_login_policy_idp` adds it, idempotently, at instance scope to match the
IdP's own. An org that has overridden its login policy does not inherit that, so
the script checks `isDefault` and warns instead of silently writing an org
policy.

## 2. "Failed to get token from provider" -- the action name IS the entrypoint

ZITADEL v1 Actions take no entrypoint: ZITADEL looks up a function NAMED AFTER
THE ACTION and calls it. The action was created as `groups-from-roles`. A hyphen
cannot appear in a JS identifier, so no function could ever have matched, and
the file defined `groupsFromRoles`.

The API accepts the mismatched name, stores it, and fails only at runtime:

    "message":"action run failed: function not found","logLevel":"error"

It was registered with `allowedToFail: false` -- correct, since issuing a token
with no groups claim authorises people at the wrong level -- so every token
request failed. Grafana reported "Failed to get token from provider"; the
ZITADEL UI reported nothing.

Renamed to `groupsFromRoles`, and `assert_action_name_matches_function` now
fails the script when the name and the function disagree, before anything is
sent. Verified both ways: it matches the new name and rejects the old one.

## 3. Grafana matched a claim nothing emitted

Found while proving #2. Grafana's `role_attribute_path` in the shared
vm-common-helm-values ConfigMap reads `contains(roles[*], 'admin')`, while the
Action set only `groups`. Everyone logged in and fell through to the 'Viewer'
default -- a failure with no error anywhere.

The Action now sets both `groups` (Headlamp, Flux UI) and `roles` (Grafana) from
one list. One line, versus renaming a claim across consumers on two clusters.

## 4. The project had no roles for any of this to grant

`platform` had ZERO roles, so the chain was inert end to end: no role to grant,
so no claim, so every binding matches nobody.

`ensure_project_roles` creates admin / backend / frontend / data. Not invented --
each is read back out of a manifest in this repo: security/base/rbac/admin.yaml
and the flux-ui ClusterRoleBindings bind Groups admin, backend and data;
Grafana's role_attribute_path names all four. Granting a role to a USER stays
manual: a user exists only after their first login, and guessing who is admin is
not a script's business.

Evidence, all against the live gcp-0 instance:
  login policy idps        [] -> [{Google Workspace}]
  action name              groups-from-roles -> groupsFromRoles, both triggers intact
  live script emits roles  yes
  bash -n + shellcheck -S warning   clean, both scripts
  node --check                      clean


---

# Part 2 — Headlamp could not have worked either

Headlamp runs -in-cluster and forwards the user's id_token to the API server.
That works on aws-0 because EKS is told to trust the issuer:

    identity_providers = { zitadel = { issuer_url = "...", groups_claim = "groups" } }

GKE takes no such flag. So gcp-0 had a Headlamp that authenticated the human and
then failed every API call -- which is exactly what surfaced today once two
unrelated ZITADEL bugs (#1888) were out of the way and login started working.

Three alternatives were checked before choosing, and the obvious one is a trap:
Identity Service for GKE, the feature that used to provide the missing knob, is
DEPRECATED as of 2026-07-01 and unsupported in GKE 1.37+. The cluster runs 1.35,
so adopting it would mean adopting a component with a known removal date. The
blocker is deprecation, not licensing -- Google documents no GKE Enterprise
requirement for it. Full reasoning, including Pinniped and Workforce Identity
Federation, in ADR-0026.

WHAT THIS DOES

oauth2-proxy authenticates against ZITADEL; Headlamp trusts its headers and
talks to the API server as its own ServiceAccount. This is the case Headlamp's
own docs cover -- "in-cluster users who want to use OIDC based authentication
when the kubernetes cluster itself doesn't have OIDC authentication" -- and the
chart's flag for it is called `unsafeUseServiceAccountToken`, accurately.

aws-0 is untouched. The divergence lives in tooling/gcp-0/headlamp/, not base/.

WHAT IT COSTS, STATED PLAINLY

Per-user Kubernetes RBAC is gone on gcp-0. Everyone admitted acts as one
ServiceAccount, so admin/backend/data collapse to one tier and the API server
cannot tell users apart. Authorisation moves entirely to --allowed-group=admin
on the proxy. That flag is load-bearing, not defence in depth.

TWO THINGS MUST BOTH HOLD OR IT FAILS OPEN

Headlamp believes X-Forwarded-User. So:

  1. The HTTPRoute strips every X-Forwarded-* and X-Auth-Request-* header from
     inbound requests, before oauth2-proxy sets its own.
  2. A CiliumNetworkPolicy allows ingress to Headlamp ONLY from the proxy.

(2) is not belt-and-braces. Without it any pod in the cluster could call
headlamp:4466 with an X-Forwarded-User of its choosing -- the gateway filter
alone is a fence with the gate left open beside it.

THREE THINGS VERIFIED AGAINST REALITY RATHER THAN DOCS

  - `-proxy-auth`, the three header flags and `-unsafe-use-service-account-token`
    all exist: read out of `headlamp-server --help` in the RUNNING v0.44.0 pod.
    An unsupported flag would have crashlooped it.
  - oauth2-proxy emits X-Forwarded-GroupS, plural; Headlamp defaults to the
    SINGULAR X-Forwarded-Group. Left alone, login succeeds, the user has no
    groups, and nothing logs an error. The flag is set explicitly.
  - config.extraArgs is nested under `config:`, not top-level. My first version
    put it at the top level; it rendered NOTHING, silently, and the Deployment
    came up without proxy-auth. Caught by grepping the rendered bundle for the
    flags rather than trusting that the values looked right.

The chart would also have named the Service headlamp-oauth2-proxy-oauth2-proxy,
which the HTTPRoute does not point at; fullnameOverride pins it.

Evidence:
  validate-manifests.sh    2093 resources, Valid: 2093, Invalid: 0, Skipped: 0
  rendered args            -proxy-auth=true, -proxy-auth-group-header=X-Forwarded-Groups,
                           -unsafe-use-service-account-token; no -oidc-* remain
  check-substitution.py    68 Kustomizations, wiring consistent
  validate-links.sh        all relative links resolve
  validate-doc-claims.sh   7 claims, 12 page checks
  trivy config             exit 0
  bash -n + shellcheck     clean

NOT YET DEPLOYED. oauth2-proxy needs its ZITADEL client to exist first:
  ./scripts/zitadel-oidc-clients.sh sync --cluster gcp-0 --cloud gcp --apply
