### PR TITLE
fix(gcp): two things that stopped oauth2-proxy from ever starting

### DIFF
--- a/scripts/zitadel-oidc-clients.sh
+++ b/scripts/zitadel-oidc-clients.sh
@@ -299,8 +299,16 @@ merge_secret() {
             # The cookie secret is generated here and then PRESERVED across runs
             # by the `// $ck` fallback -- regenerating it on every sync would
             # silently log every user out and look like a broken login.
+            #
+            # EXACTLY 32 CHARACTERS. `openssl rand -base64 32` alone emits 44,
+            # and oauth2-proxy refuses to start on it:
+            #   cookie_secret must be 16, 24, or 32 bytes to create an AES
+            #   cipher, but is 44 bytes
+            # It measures the STRING, not the decoded bytes, so the base64 has to
+            # be truncated to the cipher length rather than sized to decode into
+            # it. `head -c 32` is the recipe the chart's own values.yaml gives.
             jq -n --argjson base "$existing" --arg id "$client_id" --arg sec "$client_secret" \
-               --arg ck "$(openssl rand -base64 32 | tr -d '\n')" \
+               --arg ck "$(openssl rand -base64 32 | head -c 32)" \
                '$base + {"client-id": $id, "client-secret": $sec,
                          "cookie-secret": ($base["cookie-secret"] // $ck)}' ;;
     esac

--- a/tooling/gcp-0/headlamp/network-policy.yaml
+++ b/tooling/gcp-0/headlamp/network-policy.yaml
@@ -27,12 +27,29 @@ spec:
             dns:
               - matchPattern: "*"
 
-    # ZITADEL is reached over its PUBLIC hostname (auth.<public domain>), which
-    # resolves to the public Gateway's external LoadBalancer -- so this leaves the
-    # cluster and comes back, and `world` is the honest entity for it rather than
-    # a cluster-internal selector.
+    # ZITADEL over its PUBLIC hostname (auth.<public domain>), which resolves to
+    # this cluster's own Gateway LoadBalancer -- traffic leaves and comes back.
+    #
+    # `all`, NOT `world`, and that is a measured result rather than laziness.
+    # With every narrower selector the connection was reset during the TLS
+    # ClientHello, 0 successes out of 6-10 attempts each:
+    #
+    #   world                              0/10     cluster    0/8
+    #   host                               0/8      remote-node 0/8
+    #   ingress                            0/8      all        6/6
+    #
+    # An unlabelled pod on the same node reached the same URL 12/12, which is
+    # what isolated the policy as the variable. `cilium-dbg bpf ipcache get`
+    # reports the LB address as `identity=1` (reserved:host) -- yet allowing
+    # `host` does not match it, so the ipcache identity is not what the egress
+    # decision uses for a hairpinned LoadBalancer VIP. Cilium logged no drop for
+    # any of it, which is why this took measurement rather than reading a verdict.
+    #
+    # It is still a restriction, not an opt-out: `all` is scoped to TCP 443 and
+    # every other port stays denied, as does all ingress except from the gateway.
+    # Narrow it again if a future Cilium classifies these VIPs usefully.
     - toEntities:
-        - world
+        - all
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
fix(gcp): two things that stopped oauth2-proxy from ever starting

Both found by deploying it, not by review. #1888 shipped the design; this is what
the cluster said about it.

## 1. The cookie secret was 44 characters

    cookie_secret must be 16, 24, or 32 bytes to create an AES cipher,
    but is 44 bytes

`openssl rand -base64 32` emits 44 characters, and oauth2-proxy measures the
STRING, not the decoded bytes -- so the base64 has to be TRUNCATED to the cipher
length rather than sized to decode into it. `head -c 32`, which is the recipe the
chart's own values.yaml gives and which I should have copied the first time.

## 2. `toEntities: world` does not reach this cluster's own LoadBalancer

oauth2-proxy talks to ZITADEL on its public hostname, which resolves to the
Gateway LoadBalancer of the cluster it is running in. The connection was reset
during the TLS ClientHello, every time.

Measured with a probe pod carrying the policy's label, then the same pod without
it -- one variable, same node, same image:

    world        0/10        cluster       0/8
    host          0/8        remote-node   0/8
    ingress       0/8        all           6/6
    no policy at all        12/12

So `all`, scoped to TCP 443. Every other port stays denied and ingress still only
admits the gateway, so this is a narrowed rule and not an opt-out.

Two things made this slow, and both are worth writing down:

  - `cilium-dbg bpf ipcache get 34.13.200.159` reports `identity=1`, which is
    reserved:host -- and allowing `host` does NOT match it. The ipcache identity
    is not what the egress decision uses for a hairpinned LoadBalancer VIP.
  - `cilium-dbg monitor --type drop` logged NOTHING throughout. There is no
    verdict to read, which is why this needed measurement rather than diagnosis.

I also got this wrong once mid-investigation: an early "it is not the policy"
reading came from retesting seconds after relabelling the probe, before Cilium
had reprogrammed the endpoint. Both directions need ~35s before the result means
anything.

Evidence:
  validate-manifests.sh  2093 resources, Valid: 2093, Invalid: 0, Skipped: 0
  live probe             the table above
  bash -n + shellcheck   clean
