### PR TITLE
fix(gcp): a port-scoped egress rule cannot reach our own Gateway

### DIFF
--- a/tooling/gcp-0/headlamp/network-policy.yaml
+++ b/tooling/gcp-0/headlamp/network-policy.yaml
@@ -27,33 +27,41 @@ spec:
             dns:
               - matchPattern: "*"
 
-    # ZITADEL over its PUBLIC hostname (auth.<public domain>), which resolves to
-    # this cluster's own Gateway LoadBalancer -- traffic leaves and comes back.
+    # ZITADEL over its PUBLIC hostname, which resolves to THIS cluster's own
+    # Gateway LoadBalancer. No port restriction, and no narrower selector, and
+    # that is a measured result rather than laziness.
     #
-    # `all`, NOT `world`, and that is a measured result rather than laziness.
-    # With every narrower selector the connection was reset during the TLS
-    # ClientHello, 0 successes out of 6-10 attempts each:
+    # Cilium's Gateway API Service has no real backend: its EndpointSlice is the
+    # sentinel 192.192.192.192:9999, meaning "the L7 proxy handles this". Socket
+    # load-balancing rewrites the destination BEFORE policy is evaluated, to an
+    # Envoy listener whose port is allocated at runtime -- so a rule naming a
+    # port cannot match, whatever entity it names.
     #
-    #   world                              0/10     cluster    0/8
-    #   host                               0/8      remote-node 0/8
-    #   ingress                            0/8      all        6/6
+    # Measured on gcp-0, 6-10 attempts each, from a pod on a node that does NOT
+    # run the zitadel pod (co-located pods succeed regardless, which is what made
+    # this look like a node problem first):
     #
-    # An unlabelled pod on the same node reached the same URL 12/12, which is
-    # what isolated the policy as the variable. `cilium-dbg bpf ipcache get`
-    # reports the LB address as `identity=1` (reserved:host) -- yet allowing
-    # `host` does not match it, so the ipcache identity is not what the egress
-    # decision uses for a hairpinned LoadBalancer VIP. Cilium logged no drop for
-    # any of it, which is why this took measurement rather than reading a verdict.
+    #   world / cluster / host / remote-node / ingress, port 443     0
+    #   all, port 443                                                0
+    #   all, ports 443 + 9999 (the sentinel port)                    0
+    #   toServices: cilium-gateway-zitadel                           0
+    #   all, NO toPorts                                              6/6
+    #   no policy at all                                             6/6
     #
-    # It is still a restriction, not an opt-out: `all` is scoped to TCP 443 and
-    # every other port stays denied, as does all ingress except from the gateway.
-    # Narrow it again if a future Cilium classifies these VIPs usefully.
+    # Cilium logged no drop for any of the failures, so there is no verdict to
+    # read -- only A/B measurement finds this.
+    #
+    # What still constrains this pod: ingress only from the gateway, egress to
+    # kube-dns under L7 DNS inspection, and egress to headlamp on 4466. It holds
+    # no cloud credentials and no kubeconfig; its ServiceAccount is the default.
+    #
+    # The narrow fix is to stop traversing the public VIP at all -- ZITADEL's own
+    # Service is ClusterIP :8080, so that needs the issuer URL to keep :443,
+    # which means split-horizon DNS (the repo already has the idea as
+    # IDP_RESOLVE in scripts/zitadel-*.sh). Worth doing when something else needs
+    # it too; not worth it for one pod.
     - toEntities:
         - all
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
 
     # The upstream it proxies to.
     - toEndpoints:


### PR DESCRIPTION
fix(gcp): a port-scoped egress rule cannot reach our own Gateway

The oauth2-proxy from #1888 ran only when it happened to land on the node hosting
the zitadel pod. Anywhere else it crashlooped on OIDC discovery with a TLS reset,
so Headlamp SSO survived on luck.

WHY, AND WHY IT LOOKED LIKE A NODE PROBLEM

Cilium's Gateway API Service has no real backend. Its EndpointSlice is the
sentinel 192.192.192.192:9999 -- "the L7 proxy handles this". Socket
load-balancing rewrites the destination BEFORE policy is evaluated, to an Envoy
listener whose port is allocated at runtime, so a rule naming a port cannot match
no matter which entity it names. A pod co-located with the backend takes a
different path and succeeds, which is what made this present as node affinity.

Measured from a pod pinned to a node that does NOT run zitadel, 6-10 attempts
each:

  world / cluster / host / remote-node / ingress, port 443     0
  all, port 443                                                0
  all, ports 443 + 9999 (the sentinel port)                    0
  toServices: cilium-gateway-zitadel                           0
  all, NO toPorts                                              6/6
  no policy at all                                             6/6

Cilium logged NO drop for any failure, so there is no verdict to read; this is
findable only by A/B measurement. Two earlier readings in this branch were wrong
because of that: "it is not the policy" (retested before Cilium reprogrammed the
endpoint -- both directions need ~35s) and "it is the node" (true but incidental).

WHAT IS STILL ENFORCED

Egress loses its port scope on that one rule. Ingress still admits only the
gateway; egress to kube-dns keeps L7 DNS inspection; egress to headlamp stays
pinned to 4466. The pod holds no cloud credentials and no kubeconfig.

The narrow fix is to stop traversing the public VIP: ZITADEL's own Service is
ClusterIP :8080, so keeping the issuer URL on :443 needs split-horizon DNS -- the
idea already exists in this repo as IDP_RESOLVE in scripts/zitadel-*.sh. Worth
building when a second consumer needs it; not for one pod.

Evidence:
  validate-manifests.sh   2093 resources, Valid: 2093, Invalid: 0, Skipped: 0
  live A/B                the table above
