### PR TITLE
fix(gcp): let oauth2-proxy's first install retry, because it WILL time out

### DIFF
--- a/tooling/gcp-0/headlamp/oauth2-proxy.yaml
+++ b/tooling/gcp-0/headlamp/oauth2-proxy.yaml
@@ -15,6 +15,26 @@ spec:
         kind: HelmRepository
         name: oauth2-proxy
       interval: 12h
+
+  # THE FIRST INSTALL WILL TIME OUT AT BOOTSTRAP, and without this it stays dead.
+  #
+  # oauth2-proxy cannot start until `headlamp-oauth2-proxy` exists in the secret
+  # store AND External Secrets has been granted access to it -- both of which
+  # happen after this HelmRelease first reconciles, by
+  # zitadel-oidc-clients.sh and `secret-store.sh grant`. So the Deployment sits
+  # in CreateContainerConfigError, Helm times out, and Flux records
+  #     Stalled=True RetriesExceeded: Failed to install after 1 attempt(s)
+  # and never tries again -- the exact state this hit on 2026-08-28, which needed
+  # a manual `flux reconcile --force` to clear.
+  #
+  # retries: 3 is the same shape cert-manager, kyverno and crossplane use here.
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+
   values:
     # Without this the chart names everything <release>-<chart>, i.e.
     # `headlamp-oauth2-proxy-oauth2-proxy`, and the HTTPRoute beside this file


### PR DESCRIPTION
fix(gcp): let oauth2-proxy's first install retry, because it WILL time out

At bootstrap oauth2-proxy cannot start until two things that happen AFTER this
HelmRelease first reconciles: `headlamp-oauth2-proxy` exists in the secret store
(zitadel-oidc-clients.sh) and External Secrets has been granted access to it
(secret-store.sh grant). Until then the Deployment sits in
CreateContainerConfigError and Helm times out waiting for it.

Without remediation Flux gives up permanently:

    Stalled=True  RetriesExceeded: Failed to install after 1 attempt(s)

and nothing retries it -- not the interval, not a git change. That is the exact
state gcp-0 was left in on 2026-08-28: pod healthy, secret synced, HelmRelease
still False, cleared only by a manual `flux reconcile helmrelease --force`.

retries: 3 on install and upgrade, the same shape cert-manager, kyverno and
crossplane already use in this repo. The ordering stays what it is; this just
stops a predictable first-run timeout from being permanent.

Evidence:
  validate-manifests.sh  2093 resources, Valid: 2093, Invalid: 0, Skipped: 0
  live                   HelmRelease headlamp-oauth2-proxy Ready=True after the
                         forced retry, pod 1/1 Running
