### PR TITLE
fix(gcp): drop the metrics-server that GKE already provides

### DIFF
--- a/clusters/gcp-0/observability/observability.yaml
+++ b/clusters/gcp-0/observability/observability.yaml
@@ -1,13 +1,15 @@
 # Observability on gcp-0. Same four Kustomizations as aws-0, same order, same
 # shared base — only the overlay path and the vars ConfigMap differ.
 #
-# The remaining components: kubernetes-event-exporter, VictoriaLogs, loggen and
-# metrics-server. runlore is excluded — it is the one observability component
-# that is not cloud-neutral. The reasoning is in
+# The remaining components: kubernetes-event-exporter, VictoriaLogs and loggen.
+# NOT metrics-server — GKE ships its own as a managed addon, and ours only fought
+# it. runlore comes from the overlay rather than the base, being the one
+# observability component that is not cloud-neutral. Both reasons are in
 # observability/gcp-0/kustomization.yaml.
 #
 # No SQLInstance healthCheckExpr, unlike aws-0's: that one gates on runlore's
-# database, and runlore does not run here.
+# database, and runlore has none here. It DOES run on gcp-0 (runlore-0/-1 in the
+# runlore namespace) -- it is the database that is absent, not the workload.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/observability/gcp-0/kustomization.yaml
+++ b/observability/gcp-0/kustomization.yaml
@@ -11,11 +11,30 @@ resources:
   - ../base/victoria-logs
   # Log generator for demo purposes
   - ../base/loggen
-  - ../base/metrics-server
   # ./runlore, not ../base/runlore: the overlay patches the three things that
   # genuinely differ by cloud — the provider block, the network policy that
   # reaches the metadata server, and the identity. See the directory.
   - ./runlore
+
+# ../base/metrics-server is deliberately NOT listed. GKE SHIPS ONE.
+#
+# It was listed until 2026-08-28, and it did nothing except fight the addon.
+# GKE runs `metrics-server-v1.35.1` as a managed addon, and the Service our chart
+# installs is the SAME OBJECT: it carries GKE's `addonmanager.kubernetes.io/mode:
+# Reconcile` and `kubernetes.io/cluster-service: true` labels alongside Helm's,
+# because the release adopted the one the addon manager had already created.
+#
+# So the two wrote over each other forever. The HelmRelease sat permanently at
+#     Ready=Unknown  correcting cluster drift
+#     DriftDetected: ClusterRole/system:metrics-server changed
+# with DriftDetected/DriftCorrected events repeating every few minutes.
+#
+# And our copy served nothing the whole time. The Service selects
+# `k8s-app: metrics-server`; our Deployment's pods are labelled
+# `app.kubernetes.io/name: metrics-server`, so the only endpoint behind
+# v1beta1.metrics.k8s.io was always GKE's pod. Two replicas, zero traffic.
+#
+# aws-0 still lists it, correctly -- EKS ships no metrics-server.
 
 # ../base/victoria-traces is deliberately NOT listed.
 # clusters/gcp-0/observability/observability-victoria-traces.yaml applies that


### PR DESCRIPTION
fix(gcp): drop the metrics-server that GKE already provides

gcp-0 ran two metrics-servers. Ours served nothing and fought the other one
permanently.

GKE ships `metrics-server-v1.35.1` as a managed addon. The Service our chart
installs is THE SAME OBJECT the addon manager created -- it carries GKE's
`addonmanager.kubernetes.io/mode: Reconcile` and `kubernetes.io/cluster-service:
true` labels alongside Helm's, because the release adopted it. So the two rewrote
each other forever, and the HelmRelease sat at:

    Ready=Unknown   correcting cluster drift
    DriftDetected:  ClusterRole/system:metrics-server changed (0 additions, 1 changes, 0 removals)

with DriftDetected/DriftCorrected events repeating every few minutes for the life
of the cluster.

REMOVING IT CHANGES NOTHING THAT WORKS, and that was checked rather than assumed:

  Service metrics-server selector    k8s-app: metrics-server
  our Deployment's pod labels        app.kubernetes.io/name: metrics-server
  actual endpoint behind the Service metrics-server-v1.35.1-5cb66fbbcc-zg8n8

The only endpoint behind `v1beta1.metrics.k8s.io` was always GKE's pod. Our two
replicas took traffic from nobody. Anything the addon manager still owns it
restores on its own -- that is what `mode: Reconcile` means.

aws-0 keeps it, correctly: EKS ships no metrics-server.

Also corrected two stale claims in clusters/gcp-0/observability/observability.yaml
while editing it: it listed metrics-server as a component, and said "runlore does
not run here". runlore DOES run on gcp-0 (runlore-0/-1); what it lacks is a
SQLInstance, which is the actual reason there is no healthCheckExpr.

Evidence:
  validate-manifests.sh   2082 resources, Valid: 2082, Invalid: 0, Skipped: 0
                          (2093 before -- the 11 objects of the removed chart)
  validate-doc-claims.sh  7 claims, 12 page checks
  validate-links.sh       all relative links resolve
