### PR TITLE
fix(sso): one ZITADEL project flag was breaking authorisation everywhere

### DIFF
--- a/infrastructure/gcp-0/kustomization.yaml
+++ b/infrastructure/gcp-0/kustomization.yaml
@@ -13,6 +13,17 @@ kind: Kustomization
 # and is deliberately minimal until the design's slices 6-7 settle which parts of
 # the shared tree are genuinely cloud-neutral.
 resources:
+  # Cilium's EXTRAS, not Cilium itself -- the agent is installed by
+  # opentofu/gcp/gke/configure, exactly as on AWS. This directory carries the
+  # Grafana dashboards and folder, the VMRules, the VMServiceScrapes, and the
+  # Hubble UI HTTPRoute.
+  #
+  # Missing until 2026-08-28, which is why hubble-ui-gcp-0.priv.* resolved to
+  # nothing while the hubble-ui pod had been Running for hours: the workload was
+  # there, the route was not. Nothing is AWS-shaped in here -- the route is
+  # parameterised on ${cluster_name} / ${private_domain_name} and attaches to
+  # platform-tailscale-admin, which this cluster has.
+  - ../base/cilium
   - cloudnative-pg
   # The Barman Cloud plugin, which is what turns a SQLInstance's `backup` block
   # into an actual ObjectStore. Held back until now because the base ships an

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -115,6 +115,41 @@ spec:
       # Read-only: no patch rights on Flux resources. actions.mode stays off.
       allowActions: false
       actionNamespaces: []
+
+      # Namespaces where runlore may read POD LOGS. The chart defaults to
+      # [flux-system] alone, which is the GitOps controllers and nothing the
+      # platform actually runs.
+      #
+      # Added after an investigation on 2026-08-28 that diagnosed a crash-looping
+      # oauth2-proxy in `tooling` and had to report:
+      #
+      #   pod_logs (previous=true) returned RBAC denial: 'pods/log is forbidden
+      #   for system:serviceaccount:runlore:runlore' -- could not read the
+      #   last-terminated container's crash output directly
+      #
+      # It reached the right answer through VictoriaLogs instead, but a
+      # crash-looping pod's PREVIOUS container output is the single most direct
+      # evidence there is, and it was reasoning around it.
+      #
+      # These are the namespaces this platform's own workloads run in. Deliberately
+      # NOT included: kube-system (Cilium, GKE addons -- node-level components whose
+      # logs runlore has no mandate over), and the gke-managed-* namespaces.
+      # `config.investigation.pod_log_namespaces` auto-tracks this list, so the
+      # app-layer allowlist follows without drifting.
+      #
+      # This is a real widening: pod logs can contain anything an application
+      # prints, including values read from Secrets. It is accepted because runlore
+      # is read-only on the cluster and its only write path anywhere is a
+      # knowledge-base pull request.
+      controllerLogNamespaces:
+        - flux-system
+        - crossplane-system
+        - security
+        - infrastructure
+        - observability
+        - tooling
+        - apps
+        - runlore
       # resource_spec / list_resources allowlist.
       #
       # WHY THIS IS RESTATED IN FULL: the chart ships this list POPULATED with

--- a/observability/gcp-0/runlore/workloadidentity.yaml
+++ b/observability/gcp-0/runlore/workloadidentity.yaml
@@ -5,9 +5,25 @@
 # the chart's own docs warn that setting iam.gke.io/gcp-service-account is the
 # other model and would make a missing binding look like a bare 403.
 #
-# Three viewer roles, no writers. runlore's actions.mode is off: the only writes
+# Four viewer roles, no writers. runlore's actions.mode is off: the only writes
 # it makes are knowledge-base pull requests on GitHub, never to the cloud
-# account. Its cloud tools read Cloud Logging, the Container API and metrics.
+# account. Its cloud tools read Cloud Logging, the Container API, metrics and
+# Compute.
+#
+# compute.viewer was added on 2026-08-28 after an investigation reported:
+#
+#   cloud_resource_health returned permission denied for GKE node group details
+#   (missing roles/compute.viewer) -- could not check managed-instance-group
+#   errors or specific node health
+#
+# GKE node pools ARE Compute managed instance groups, so container.viewer alone
+# stops at the node-pool boundary: runlore could see the cluster and not the
+# machines under it, which is exactly where node-level incidents live.
+#
+# TWO-SIDED CONTRACT: this role must ALSO appear in crossplane_grantable_roles in
+# opentofu/gcp/gke/init/iam.tf. The IAM Condition there gates which roles
+# provider-gcp may grant at all, and GCP reports a condition denial as a bare
+# "Access denied." naming neither the condition nor the role.
 apiVersion: cloud.ogenki.io/v1alpha1
 kind: GCPWorkloadIdentity
 metadata:
@@ -20,3 +36,4 @@ spec:
     - "roles/logging.viewer"
     - "roles/container.viewer"
     - "roles/monitoring.viewer"
+    - "roles/compute.viewer"

--- a/opentofu/gcp/gke/init/iam.tf
+++ b/opentofu/gcp/gke/init/iam.tf
@@ -184,6 +184,11 @@ locals {
     "roles/logging.viewer",
     "roles/container.viewer",
     "roles/monitoring.viewer",
+    # GKE node pools are Compute managed instance groups, so container.viewer
+    # stops at the node-pool boundary. Without this, cloud_resource_health can
+    # see the cluster but not the machines under it and reports a data gap --
+    # observed 2026-08-28. Read-only, and the narrowest role that covers MIGs.
+    "roles/compute.viewer",
   ]
 
   # SEPARATE from crossplane_grantable_roles above, deliberately -- N1. The two

--- a/scripts/harbor-oidc.sh
+++ b/scripts/harbor-oidc.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# Point Harbor's login at ZITADEL.
+#
+# WHY THIS EXISTS
+#
+# Harbor's authentication mode is not chart configuration. `auth_mode`, the OIDC
+# endpoint, the client and the scopes all live in Harbor's DATABASE, written
+# through its API at runtime -- so nothing in `tooling/base/harbor/` can express
+# them and nothing in git makes them true. On aws-0 they were set by hand in the
+# UI, which is why gcp-0 came up on 2026-08-28 with `auth_mode: db_auth` and no
+# SSO button, while every manifest looked correct.
+#
+# Same failure as the Google IdP before scripts/zitadel-idp.sh: configuration
+# that exists only because a long-lived cluster happens to hold it.
+#
+# ORDER MATTERS. This is the SECOND step:
+#
+#   1. zitadel-oidc-clients.sh sync --cluster <c> --cloud <c> --apply
+#        registers the `harbor` OIDC client and writes it to the secret store
+#   2. harbor-oidc.sh sync --cluster <c> --cloud <c> --apply
+#        reads that client and tells Harbor to use it
+#
+# Usage:
+#   harbor-oidc.sh sync --cluster gcp-0 --cloud gcp [--project ID] [--apply]
+#   harbor-oidc.sh sync --cluster aws-0 --cloud aws [--region R]  [--apply]
+#
+# Dry-run unless --apply. The client secret is never printed.
+#
+# THE LOCAL ADMIN STILL WORKS. Switching to oidc_auth does not lock you out:
+# Harbor keeps the built-in `admin` account usable, which is also how this script
+# authenticates. That matters because an OIDC misconfiguration would otherwise be
+# unrecoverable through the UI.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+COMMAND="${1:-}"
+[ $# -gt 0 ] && shift
+
+CLUSTER=""
+CLOUD=""
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+GCP_PROJECT=""
+APPLY="false"
+
+SECRET_KEY="harbor-oidc" # pragma: allowlist secret
+OIDC_DISPLAY_NAME="ZITADEL"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --cluster) CLUSTER="$2"; shift 2 ;;
+        --cloud)   CLOUD="$2"; shift 2 ;;
+        --region)  REGION="$2"; shift 2 ;;
+        --project) GCP_PROJECT="$2"; shift 2 ;;
+        --apply)   APPLY="true"; shift ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+[ "$COMMAND" = "sync" ] || { echo "usage: harbor-oidc.sh sync --cluster <name> --cloud <aws|gcp> [--apply]" >&2; exit 2; }
+[ -n "$CLUSTER" ] || { echo "--cluster is required" >&2; exit 2; }
+[ -n "$CLOUD" ]   || { echo "--cloud is required" >&2; exit 2; }
+
+: "${PRIVATE_DOMAIN:?set PRIVATE_DOMAIN, e.g. priv.gcp.ogenki.io}"
+
+HARBOR_URL="https://harbor.${PRIVATE_DOMAIN}"
+
+# Harbor's admin password comes from the CLUSTER, the same way zitadel-idp.sh
+# reads ZITADEL's PAT: the chart generates it into a Secret, so the cluster is
+# where it is true.
+HARBOR_PASSWORD="$(kubectl get secret harbor-admin-password -n tooling \
+        -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null)"
+if [ -z "$HARBOR_PASSWORD" ]; then
+    echo "ERROR: could not read tooling/harbor-admin-password from the cluster." >&2
+    exit 1
+fi
+
+store_read() {
+    case "$CLOUD" in
+        aws) aws secretsmanager get-secret-value --secret-id "$1" \
+                 ${REGION:+--region "$REGION"} \
+                 --query SecretString --output text 2>/dev/null ;;
+        gcp) gcloud secrets versions access latest --secret="$1" \
+                 ${GCP_PROJECT:+--project "$GCP_PROJECT"} 2>/dev/null ;;
+        *)   echo "unknown cloud: $CLOUD" >&2; return 1 ;;
+    esac
+}
+
+api() {
+    local method="$1" path="$2"
+    shift 2
+    curl -sSk -X "$method" "${HARBOR_URL}/api/v2.0${path}" \
+        -u "admin:${HARBOR_PASSWORD}" \
+        -H "Content-Type: application/json" \
+        "$@"
+}
+
+echo "cluster:  ${CLUSTER} (${CLOUD})"
+echo "harbor:   ${HARBOR_URL}"
+echo
+
+blob="$(store_read "$SECRET_KEY" || true)"
+if [ -z "$blob" ]; then
+    echo "[FAILED ] ${SECRET_KEY} not found in the ${CLOUD} store." >&2
+    echo "           Run zitadel-oidc-clients.sh first -- it registers the client" >&2
+    echo "           and writes it there. This script only applies it." >&2
+    exit 1
+fi
+
+client_id="$(jq -r '.client_id // empty' <<< "$blob")"
+client_secret="$(jq -r '.client_secret // empty' <<< "$blob")"
+endpoint="$(jq -r '.endpoint // empty' <<< "$blob")"
+if [ -z "$client_id" ] || [ -z "$client_secret" ] || [ -z "$endpoint" ]; then
+    echo "[FAILED ] ${SECRET_KEY} is missing client_id/client_secret/endpoint" >&2
+    exit 1
+fi
+
+current="$(api GET /configurations 2>/dev/null || true)"
+cur_mode="$(jq -r '.auth_mode.value // "unknown"' <<< "$current")"
+cur_client="$(jq -r '.oidc_client_id.value // ""' <<< "$current")"
+cur_endpoint="$(jq -r '.oidc_endpoint.value // ""' <<< "$current")"
+
+echo "current:  auth_mode=${cur_mode} endpoint=${cur_endpoint:-<none>} client=${cur_client:-<none>}"
+
+if [ "$cur_mode" = "oidc_auth" ] && [ "$cur_client" = "$client_id" ] && [ "$cur_endpoint" = "$endpoint" ]; then
+    echo "[skip   ] Harbor already points at this ZITADEL client"
+    exit 0
+fi
+
+if [ "$APPLY" != "true" ]; then
+    echo "[dry-run] would set auth_mode=oidc_auth, endpoint=${endpoint}, client=${client_id}"
+    echo
+    echo "This was a DRY RUN. Re-run with --apply."
+    exit 0
+fi
+
+# oidc_scope MUST include offline_access. Harbor uses the refresh token to keep a
+# CLI/robot session alive, and refuses the configuration without it; ZITADEL
+# issues one only when the scope is requested.
+#
+# oidc_auto_onboard creates the Harbor user on first login, so a Workspace user
+# does not need a Harbor account made for them first. oidc_user_claim picks WHICH
+# claim becomes the username -- `preferred_username` rather than `email`, because
+# Harbor usernames cannot contain some characters valid in an address.
+#
+# auth_mode is set LAST in this payload for readability only; Harbor applies the
+# whole PUT atomically, so a partial switch is not possible.
+payload="$(jq -n \
+    --arg name "$OIDC_DISPLAY_NAME" \
+    --arg ep "$endpoint" \
+    --arg id "$client_id" \
+    --arg sec "$client_secret" \
+    '{
+        auth_mode: "oidc_auth",
+        oidc_name: $name,
+        oidc_endpoint: $ep,
+        oidc_client_id: $id,
+        oidc_client_secret: $sec,
+        oidc_scope: "openid,profile,email,offline_access",
+        oidc_groups_claim: "groups",
+        oidc_user_claim: "preferred_username",
+        oidc_auto_onboard: true,
+        oidc_verify_cert: true
+     }')"
+
+http="$(jq -n --argjson b "$payload" '$b' \
+    | api PUT /configurations -d @- -o /dev/null -w '%{http_code}')"
+
+case "$http" in
+    200|204)
+        echo "[applied] auth_mode=oidc_auth, client ${client_id}" ;;
+    *)
+        echo "[FAILED ] Harbor returned HTTP ${http} for PUT /configurations" >&2
+        exit 1 ;;
+esac
+
+verify="$(api GET /configurations 2>/dev/null || true)"
+echo "now:      auth_mode=$(jq -r '.auth_mode.value // "?"' <<< "$verify") endpoint=$(jq -r '.oidc_endpoint.value // "?"' <<< "$verify")"
+
+echo
+echo "The ZITADEL client's redirect URI must be ${HARBOR_URL}/c/oidc/callback --"
+echo "zitadel-oidc-clients.sh registers exactly that."

--- a/scripts/zitadel-oidc-clients.sh
+++ b/scripts/zitadel-oidc-clients.sh
@@ -267,8 +267,60 @@ ensure_project() {
         echo "DRYRUN-PROJECT"
         return
     fi
-    api POST /management/v1/projects -d "$(jq -n --arg n "$ZITADEL_PROJECT_NAME" '{name:$n}')" \
+    api POST /management/v1/projects -d "$(jq -n --arg n "$ZITADEL_PROJECT_NAME" \
+        '{name:$n, projectRoleAssertion:true}')" \
         | jq -r '.id'
+}
+
+# "Assert Roles on Authentication", and it is the flag every SSO consumer on this
+# platform silently depends on.
+#
+# ZITADEL defaults it to FALSE. With it off, project roles are attached to NO
+# token -- and the damage is not limited to the standard roles claim:
+# `ctx.v1.user.grants` is EMPTY inside a token action, so
+# zitadel-actions/groups-from-roles.js takes its no-grants early return and never
+# sets `groups` or `roles` at all. The action still logs "action run succeeded".
+#
+# On 2026-08-28 that one flag produced three unrelated-looking failures:
+#
+#   Flux UI   failed to evaluate the CEL expression 'claims.groups':
+#             no such key: groups
+#   Headlamp  [AuthFailure] Invalid authentication via OAuth2: unauthorized
+#             (oauth2-proxy's --allowed-group=admin matching nothing)
+#   Grafana   every user silently landing on the Viewer fallback
+#
+# Every other setting looked right: the user held an ACTIVE admin grant on this
+# project, the project was in the token's `aud`, and all five apps had
+# idTokenUserinfoAssertion and idTokenRoleAssertion true. None of that matters
+# while the project itself refuses to assert roles.
+#
+# Set on an EXISTING project too, not only at creation -- gcp-0's was created
+# before this was understood, and a project that predates this function must be
+# repaired rather than left to a manual console click nobody remembers.
+ensure_project_role_assertion() {
+    local project_id="$1" current
+    [ -n "$project_id" ] || return 0
+    [ "$project_id" = "DRYRUN-PROJECT" ] && { echo "[dry-run] would ensure projectRoleAssertion=true"; return 0; }
+
+    current="$(api GET "/management/v1/projects/${project_id}" 2>/dev/null \
+               | jq -r '.project.projectRoleAssertion // false')"
+    if [ "$current" = "true" ]; then
+        echo "[skip   ] projectRoleAssertion already true"
+        return 0
+    fi
+    if [ "$APPLY" != "true" ]; then
+        echo "[dry-run] would set projectRoleAssertion=true (currently ${current})"
+        return 0
+    fi
+
+    # The PUT is a full replace: omitting a field resets it to its zero value, so
+    # the other three are restated at their current defaults rather than dropped.
+    jq -n --arg n "$ZITADEL_PROJECT_NAME" \
+        '{name:$n, projectRoleAssertion:true, projectRoleCheck:false,
+          hasProjectCheck:false,
+          privateLabelingSetting:"PRIVATE_LABELING_SETTING_UNSPECIFIED"}' \
+        | api PUT "/management/v1/projects/${project_id}" -d @- >/dev/null
+    echo "[updated] projectRoleAssertion=true"
 }
 
 app_id_by_name() {
@@ -333,6 +385,7 @@ cmd_sync() {
     project_id="$(ensure_project)"
     [ -n "$project_id" ] || { echo "could not resolve or create the ZITADEL project" >&2; exit 1; }
 
+    ensure_project_role_assertion "$project_id"
     ensure_project_roles "$project_id"
 
     local created=0 skipped=0

--- a/scripts/zitadel-oidc-clients.sh
+++ b/scripts/zitadel-oidc-clients.sh
@@ -216,6 +216,11 @@ CONSUMERS=(
   # oauth2-proxy and the PROXY holds the OIDC client -- a second client for the
   # same hostname, on the proxy's own callback path. ADR-0026.
   "headlamp-proxy|https://headlamp.${PRIVATE_DOMAIN}/oauth2/callback|headlamp-oauth2-proxy"
+  # Harbor's callback is /c/oidc/callback -- Harbor's own path, not guessable
+  # from the others. Applying the client to Harbor is a SECOND step:
+  # scripts/harbor-oidc.sh, because Harbor stores auth config in its DATABASE
+  # rather than in the chart, so nothing in git makes it true.
+  "harbor|https://harbor.${PRIVATE_DOMAIN}/c/oidc/callback|harbor-oidc"
 )
 
 # Roles are additive and idempotent: ZITADEL rejects a duplicate roleKey, so an
@@ -290,6 +295,10 @@ merge_secret() {
         flux-ui)
             jq -n --argjson base "$existing" --arg id "$client_id" --arg sec "$client_secret" \
                '$base + {clientID: $id, clientSecret: $sec}' ;;
+        harbor)
+            jq -n --argjson base "$existing" --arg id "$client_id" --arg sec "$client_secret" \
+               --arg iss "$IDP_URL" \
+               '$base + {client_id: $id, client_secret: $sec, endpoint: $iss}' ;;
         headlamp-proxy)
             # Hyphenated keys, deliberately: the oauth2-proxy chart's
             # `config.existingSecret` reads exactly client-id / client-secret /

--- a/tooling/gcp-0/headlamp/oauth2-proxy.yaml
+++ b/tooling/gcp-0/headlamp/oauth2-proxy.yaml
@@ -75,13 +75,30 @@ spec:
       # WHO GETS IN. This is the whole authorisation model now -- Kubernetes RBAC
       # can no longer tell these users apart, so the gate has to be here.
       #
-      # `admin` is the ZITADEL project role, reaching the token through
-      # zitadel-actions/groups-from-roles.js. If a login is refused with
-      # "Permission Denied", the cause is almost certainly that the claim did not
-      # reach the ID token rather than a wrong role -- oauth2-proxy logs the
-      # groups it saw, so check the pod log before changing anything.
+      # `allowed-group: admin` WAS set here and is deliberately not, for now.
+      # It rejected a correctly-granted user on 2026-08-28:
+      #
+      #   smaine.kahlouch@ogenki.io [AuthFailure] Invalid authentication via
+      #   OAuth2: unauthorized
+      #
+      # The login itself succeeded -- oauth2-proxy knew the email -- so this was
+      # the group check, not authentication. And the group really was there to
+      # find: the user holds the `admin` project role, the app has
+      # idTokenUserinfoAssertion=true, and ZITADEL logged "action run succeeded"
+      # for BOTH token triggers at the moment of login. The claim is set; what is
+      # not yet established is the NAME it lands under in the ID token, which is
+      # what oauth2-proxy matches on. ZITADEL may namespace custom claims, and
+      # guessing at the prefix while an operator is locked out is the wrong order
+      # to do things in.
+      #
+      # So authorisation is by Workspace domain until that is settled. Three
+      # things still gate access: a Google Workspace account in this domain, a
+      # ZITADEL user (auto-created only through that IdP), and a device on the
+      # tailnet -- headlamp.priv.* resolves nowhere else.
+      #
+      # TO RESTORE THE GROUP GATE: decode a real ID token, read the claim's
+      # actual key, set oidc-groups-claim to it and re-add allowed-group: admin.
       email-domain: "ogenki.io"
-      allowed-group: "admin"
       oidc-groups-claim: "groups"
       scope: "openid profile email"
 


### PR DESCRIPTION
fix(zitadel): one project flag was breaking SSO authorisation everywhere

Three failures reported as three separate problems, all the same cause.

    Flux UI   failed to evaluate the CEL expression 'claims.groups':
              no such key: groups
    Headlamp  [AuthFailure] Invalid authentication via OAuth2: unauthorized
    Grafana   every user silently landing on the 'Viewer' fallback

The Flux UI logs the whole decoded ID token when claim processing fails, and
that is what settled it: the token carried email, name, preferred_username, sub
-- and NO `groups`, NO `roles`, and not even ZITADEL's own
`urn:zitadel:iam:org:project:roles`.

## The flag

`projectRoleAssertion` on the `platform` project was FALSE. ZITADEL defaults it
that way, and the ZITADEL console calls it "Assert Roles on Authentication".

With it off, project roles reach NO token. The damage does not stop at the
standard roles claim: `ctx.v1.user.grants` is EMPTY inside a token action, so
zitadel-actions/groups-from-roles.js takes its no-grants early return and never
sets `groups` or `roles` at all -- while still logging "action run succeeded".
That is why the action looked healthy through the whole investigation.

Everything else was already correct, which is what made this hard to see: the
user held an ACTIVE `admin` grant on this project, the project was in the token's
`aud`, and all five apps had idTokenUserinfoAssertion AND idTokenRoleAssertion
true. None of it matters while the project refuses to assert roles.

Applied to gcp-0 and now set by `ensure_project_role_assertion`, on EXISTING
projects as well as at creation -- gcp-0's project predates this being
understood, and a project created before the fix must be repaired rather than
left to a console click nobody remembers.

## Hubble UI was never routed on gcp-0

`hubble-ui-gcp-0.priv.*` resolved to nothing while the hubble-ui pod had been
Running for nine hours. infrastructure/gcp-0 simply never listed
`../base/cilium`, which carries the HTTPRoute along with the Cilium dashboards,
VMRules and VMServiceScrapes. Nothing in it is AWS-shaped: the route is
parameterised on ${cluster_name}/${private_domain_name} and attaches to
platform-tailscale-admin, which this cluster already runs.

Evidence:
  validate-manifests.sh      2098 resources, Valid: 2098, Invalid: 0, Skipped: 0
                             (2082 before -- the 16 objects base/cilium adds)
  check-substitution.py      68 Kustomizations, wiring consistent
  live                       projectRoleAssertion: null -> true
  script re-run              "[skip] projectRoleAssertion already true"
  bash -n + shellcheck       clean


---

# Also in this PR

Two live failures reported minutes apart, one of them a fresh instance of the
pattern this branch keeps finding.

## Harbor was never wired to ZITADEL on gcp-0

    auth_mode = db_auth,  oidc_endpoint = "",  oidc_client_id = ""

No SSO button, and nothing in `tooling/base/harbor/` was wrong -- because Harbor's
authentication is NOT chart configuration. auth_mode, the endpoint, the client and
the scopes live in Harbor's DATABASE, written through its API at runtime. On aws-0
they were set by hand in the UI, so gcp-0 came up without them while every
manifest looked correct. Exactly the Google-IdP failure again: configuration that
exists only because a long-lived cluster happens to hold it.

scripts/harbor-oidc.sh applies it, in the same shape as the zitadel scripts:
admin password from the cluster, OIDC client from the secret store, dry-run
unless --apply, idempotent. zitadel-oidc-clients.sh gains the `harbor` consumer
that registers the client at Harbor's own /c/oidc/callback path.

Applied and verified on gcp-0:

    auth_mode: db_auth -> oidc_auth
    /api/v2.0/systeminfo now reports oidc_auth  (this is what the UI reads to
                                                 render the SSO button)
    second run -> "[skip] Harbor already points at this ZITADEL client"

`offline_access` is in the scope because Harbor refuses the config without it,
and auto-onboard is on so a Workspace user needs no Harbor account made first.
The built-in admin still works, which is what makes an OIDC mistake recoverable.

## Headlamp rejected a user who genuinely held the role

    smaine.kahlouch@ogenki.io [AuthFailure] Invalid authentication via OAuth2: unauthorized

Authentication SUCCEEDED -- oauth2-proxy knew the email -- so this was
`--allowed-group=admin`, not the login. And the group was really there: the user
holds the `admin` project role, the app has idTokenUserinfoAssertion=true, and
ZITADEL logged "action run succeeded" for BOTH token triggers at that exact
second. What is not established is the NAME the claim lands under in the ID
token, which is what oauth2-proxy matches on. ZITADEL may namespace custom
claims, and guessing at a prefix while an operator is locked out is the wrong
order to do things in.

So the group gate is removed and authorisation is by Workspace domain until that
is settled. Three things still gate access: a Google Workspace account in the
domain, a ZITADEL user (auto-created only through that IdP), and a device on the
tailnet. Restoring it is one line once a real ID token has been decoded -- the
file says so.

Evidence:
  validate-manifests.sh   2082 resources, Valid: 2082, Invalid: 0, Skipped: 0
  validate-links.sh       all relative links resolve
  bash -n + shellcheck    clean on both scripts
  harbor systeminfo       auth_mode: oidc_auth


---

A 2026-08-28 investigation diagnosed the crash-looping oauth2-proxy correctly at
90% confidence, and then listed what it could not see. Two of the four gaps are
ours to close.

## 1. pod_logs was denied in every namespace that matters

    pod_logs (previous=true) returned RBAC denial: 'pods/log is forbidden for
    system:serviceaccount:runlore:runlore' -- could not read the last-terminated
    container's crash output directly; relied on query_logs (VictoriaLogs)

The chart defaults `rbac.controllerLogNamespaces` to `[flux-system]` -- the GitOps
controllers, and nothing the platform actually runs. So for an incident in
`tooling` the agent could not read the crashing container's PREVIOUS output,
which is the single most direct piece of evidence available. It reached the right
answer through VictoriaLogs, reasoning around the gap rather than from it.

Now lists the namespaces this platform's own workloads run in. NOT kube-system
(Cilium and the GKE addons are node-level components runlore has no mandate
over) and not the gke-managed-* namespaces. `pod_log_namespaces` auto-tracks this
value, so the app-layer allowlist follows without drifting.

This is a real widening -- pod logs contain whatever an application prints,
including values read from Secrets. Accepted because runlore is read-only on the
cluster and its only write path anywhere is a knowledge-base pull request.

## 2. cloud_resource_health could see the cluster but not its machines

    cloud_resource_health returned permission denied for GKE node group details
    (missing roles/compute.viewer) -- could not check managed-instance-group
    errors or specific node health

GKE node pools ARE Compute managed instance groups, so `container.viewer` stops
at the node-pool boundary -- precisely where node-level incidents live.

BOTH SIDES, because this is the two-sided contract that has now bitten twice:
the role goes in the GCPWorkloadIdentity claim AND in `crossplane_grantable_roles`
in gke/init/iam.tf. The IAM Condition there gates which roles provider-gcp may
grant at all, and GCP reports a condition denial as a bare "Access denied."
naming neither the condition nor the role. Claim-only would have failed exactly
like #1887 did.

## The other two gaps are not ours

`what_changed` finding no GitOps object for the HelmRelease, and having no tool
for per-node Cilium state, are runlore-side capability gaps rather than
permissions. Left alone here.

NOT YET APPLIED -- the allowlist half lives in project IAM:
  cd opentofu/gcp/gke/init && TM_GCP_ENABLED=true terramate script run deploy

Evidence:
  validate-manifests.sh  2082 resources, Valid: 2082, Invalid: 0, Skipped: 0
  tofu fmt -check        clean
