### PR TITLE
docs(gcp): the SSO bootstrap is five steps, and we documented one

### DIFF
--- a/scripts/zitadel-oidc-clients.sh
+++ b/scripts/zitadel-oidc-clients.sh
@@ -71,6 +71,17 @@ ZITADEL_PROJECT_NAME="platform"
 # and nothing anywhere said so -- login worked, authorisation silently did not.
 ZITADEL_PROJECT_ROLES=(admin backend frontend data)
 
+# --grant-admin <email>: give an EXISTING user the `admin` project role.
+#
+# Separate from role creation because the two cannot happen at the same time. A
+# human user does not exist in ZITADEL until their FIRST LOGIN -- the Google IdP
+# auto-creates them -- so there is nobody to grant to at bootstrap. The sequence
+# is unavoidably: register clients -> configure the IdP -> log in once -> grant.
+#
+# It is here rather than in a console because a role granted by hand is a role
+# nobody can reproduce, which is how gcp-0 ended up with no groups claim at all.
+GRANT_ADMIN=""
+
 while [ $# -gt 0 ]; do
     case "$1" in
         --cluster) CLUSTER="$2"; shift 2 ;;
@@ -78,6 +89,7 @@ while [ $# -gt 0 ]; do
         --region)  REGION="$2"; shift 2 ;;
         --project) GCP_PROJECT="$2"; shift 2 ;;
         --apply)   APPLY="true"; shift ;;
+        --grant-admin) GRANT_ADMIN="$2"; shift 2 ;;
         *) echo "unknown argument: $1" >&2; exit 2 ;;
     esac
 done
@@ -297,6 +309,41 @@ ensure_project() {
 # Set on an EXISTING project too, not only at creation -- gcp-0's was created
 # before this was understood, and a project that predates this function must be
 # repaired rather than left to a manual console click nobody remembers.
+grant_admin_role() {
+    local email="$1" project_id="$2" user_id existing
+    [ -n "$email" ] || return 0
+    [ -n "$project_id" ] || return 0
+    if [ "$project_id" = "DRYRUN-PROJECT" ]; then
+        echo "[dry-run] would grant 'admin' to ${email}"
+        return 0
+    fi
+
+    user_id="$(api POST /management/v1/users/_search -d '{"query":{"limit":200}}' 2>/dev/null \
+               | jq -r --arg e "$email" '.result[]? | select((.userName == $e) or (.human.email.email == $e)) | .id' | head -1)"
+    if [ -z "$user_id" ]; then
+        echo "[FAILED ] no ZITADEL user for ${email}." >&2
+        echo "           A human user exists only AFTER their first login through the" >&2
+        echo "           Google IdP (isAutoCreation). Log in once, then re-run this." >&2
+        return 1
+    fi
+
+    existing="$(api POST /management/v1/users/grants/_search -d '{"query":{"limit":200}}' 2>/dev/null \
+                | jq -r --arg u "$user_id" --arg p "$project_id" \
+                    '.result[]? | select(.userId == $u and .projectId == $p) | .roleKeys[]?' || true)"
+    if grep -qx "admin" <<< "$existing"; then
+        echo "[skip   ] ${email} already holds 'admin'"
+        return 0
+    fi
+    if [ "$APPLY" != "true" ]; then
+        echo "[dry-run] would grant 'admin' to ${email} (${user_id})"
+        return 0
+    fi
+
+    jq -n --arg p "$project_id" '{projectId: $p, roleKeys: ["admin"]}' \
+        | api POST "/management/v1/users/${user_id}/grants" -d @- >/dev/null
+    echo "[granted] 'admin' to ${email} (${user_id})"
+}
+
 ensure_project_role_assertion() {
     local project_id="$1" current
     [ -n "$project_id" ] || return 0
@@ -387,6 +434,7 @@ cmd_sync() {
 
     ensure_project_role_assertion "$project_id"
     ensure_project_roles "$project_id"
+    grant_admin_role "$GRANT_ADMIN" "$project_id"
 
     local created=0 skipped=0
     for entry in "${CONSUMERS[@]}"; do

--- a/website/content/docs/get-started/gcp/verify.md
+++ b/website/content/docs/get-started/gcp/verify.md
@@ -155,13 +155,59 @@ gcloud secrets versions access latest \
 ```
 
 ZITADEL's first admin is in `zitadel-envvars`
-(`ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME` / `…_PASSWORD`). Prefer SSO once the
-OIDC clients are registered:
+(`ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME` / `…_PASSWORD`). Prefer SSO.
+
+### Single sign-on, in this order
+
+SSO needs **five** steps, and the order is load-bearing: each one creates what
+the next reads. Running only the first — which is all this page used to say —
+leaves you with OIDC clients and no way to log in through Google.
+
+Every step is idempotent: re-running prints `[skip …]` and changes nothing.
 
 ```bash
+# 1. Register the OIDC clients, the project, its roles, and
+#    projectRoleAssertion. That last one is not optional: with it off ZITADEL
+#    puts NO roles in any token AND leaves ctx.v1.user.grants empty inside the
+#    groups action, so every consumer authenticates and then has no groups.
 ./scripts/zitadel-oidc-clients.sh sync --cluster gcp-0 --cloud gcp \
   --project ogenki-435905 --apply
+
+# 2. Let External Secrets read what step 1 just created. Those secrets did not
+#    exist when the OpenTofu stack applied, so nothing granted access to them —
+#    this reads the cluster's ExternalSecrets and grants what exists.
+./scripts/secret-store.sh grant --cloud gcp --project ogenki-435905 --apply
+
+# 3. The Google identity provider, the LOGIN POLICY entry that actually enables
+#    it, and the action that flattens project roles into a `groups` claim.
+#    Creating the provider without the policy entry gives "User not found".
+IDP_URL=https://auth.gcp.cloud.ogenki.io \
+  ./scripts/zitadel-idp.sh sync --cluster gcp-0 --cloud gcp \
+  --project ogenki-435905 --apply
+
+# 4. Harbor's auth mode. Harbor stores this in its DATABASE, not in the chart,
+#    so no manifest can express it and a fresh cluster has no SSO button.
+PRIVATE_DOMAIN=priv.gcp.ogenki.io \
+  ./scripts/harbor-oidc.sh sync --cluster gcp-0 --cloud gcp \
+  --project ogenki-435905 --apply
 ```
+
+**Then log in once through Google**, at any consumer. That first login is what
+CREATES your ZITADEL user — the IdP auto-registers it — so there is nobody to
+authorise before it. Afterwards:
+
+```bash
+# 5. Give yourself the admin role. Group-based RBAC (cluster-admin via the
+#    `admin` group) does nothing until a user actually holds it.
+./scripts/zitadel-oidc-clients.sh sync --cluster gcp-0 --cloud gcp \
+  --project ogenki-435905 --grant-admin you@example.com --apply
+```
+
+The **only** thing left in a console is Google-side: the OAuth client's
+authorized redirect URI must list
+`https://auth.<public domain>/ui/login/login/externalidp/callback`. Google
+accepts many, so one client serves every cluster; `zitadel-idp.sh` prints the
+exact URI on every run and cannot add it for you.
 
 ## 6. Observability actually receiving data
 


### PR DESCRIPTION
docs(gcp): the SSO bootstrap is five steps, and we documented one

Answers "are we sure the next bootstrap needs no ZITADEL/OIDC/Google clicking?"
The scripts all existed. The RUNBOOK did not: verify.md listed
zitadel-oidc-clients.sh alone, so anyone following it would end up with OIDC
clients registered and no way to log in through Google -- which is exactly the
state gcp-0 was found in on 2026-08-28.

The order is load-bearing; each step creates what the next reads:

  1. zitadel-oidc-clients.sh   clients, project, roles, projectRoleAssertion
  2. secret-store.sh grant     ESO access to the secrets step 1 just created
  3. zitadel-idp.sh            Google IdP + LOGIN POLICY entry + groups action
  4. harbor-oidc.sh            Harbor's auth_mode (its DB, not the chart)
  -- log in once through Google, which is what creates your user --
  5. --grant-admin             give that user the admin role

Step 2 is the one that is easy to leave out and hard to diagnose: those secrets
did not exist when the OpenTofu stack applied, so nothing granted access, and the
consumer sits in CreateContainerConfigError with "secret not found".

Step 5 is new here. A human user does not exist in ZITADEL until their FIRST
LOGIN -- the IdP auto-creates them -- so there is nobody to authorise at
bootstrap and the grant cannot be folded into step 1. `--grant-admin <email>`
makes it a command instead of a console click, which matters because a role
granted by hand is a role nobody can reproduce. It skips cleanly when the user
does not exist yet and says why.

WHAT IS STILL MANUAL, and it is one thing: the Google OAuth client's authorized
redirect URI. That is a Google-side setting no script here can write. Google
accepts many URIs so one client serves every cluster, and zitadel-idp.sh prints
the exact one on every run.

Verified against the live instance rather than written from the code:
  --grant-admin on an already-granted user -> "[skip] … already holds 'admin'"
  bash -n + shellcheck                     -> clean
  validate-links.sh                        -> all relative links resolve
  validate-doc-claims.sh                   -> 7 claims, 12 page checks
