### PR TITLE
fix(observability): drop seven dashboards for operating systems we do not run

### DIFF
--- a/observability/base/victoria-metrics-k8s-stack/helmrelease-vmsingle.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/helmrelease-vmsingle.yaml
@@ -51,20 +51,3 @@ spec:
               storage: 10Gi
         extraArgs:
           maxLabelsPerTimeseries: "50"
-    # Todo authentication with Zitadel. Currently using admin user
-    # grafana:
-    #   grafana.ini:
-    #     server:
-    #       root_url: "https://grafana.${private_domain_name}"
-    #       domain: "grafana.${private_domain_name}"
-    #     auth.generic_auth:
-    #       enabled: true
-    #       name: "Zitadel"
-    #       allow_sign_up: true
-    #       client_id: "293437355073802541"
-    #       client_secret: "3XPQdOtQedxEnAjaTbxsnQ2Fc0WT15rKU5nsgSWYzgktdPHm82whbzfu01J0c0ba"
-    #       scopes: "openid profile email"
-    #       auth_url: "https://auth.${public_domain_name}/oauth/v2/authorize"
-    #       token_url: "https://auth.${public_domain_name}/oauth/v2/token"
-    #       api_url: "https://auth.${public_domain_name}/oidc/v1/userinfo"
-    #       # role_attribute_path: "contains(groups[*], 'admin-group') && 'Admin' || 'Viewer'"

--- a/observability/base/victoria-metrics-k8s-stack/vm-common-helm-values-configmap.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vm-common-helm-values-configmap.yaml
@@ -144,15 +144,47 @@ data:
             # Place VictoriaMetrics dashboards in "observability" folder
             folder: "observability"
       dashboards:
-        # Disable duplicate Kubernetes dashboards (already managed manually in infrastructure namespace)
-        k8s-views-global:
+        # THE KEY IS THE RENDERED NAME'S SUFFIX, and getting it wrong fails
+        # SILENTLY. Each dashboard becomes
+        # `victoria-metrics-k8s-stack-dashboard-<key>`, so read the key off a live
+        # object: `kubectl get grafanadashboard -n observability`. A key matching
+        # no dashboard is accepted, written into the sync-job ConfigMap, and does
+        # nothing -- there is no error and no warning.
+        #
+        # That is not hypothetical. Four entries here were `k8s-views-*` while the
+        # chart's keys are `kubernetes-views-*`, so the block below did NOTHING for
+        # as long as it existed, and its own comment ("already managed manually in
+        # infrastructure namespace") described a de-duplication that never
+        # happened: both copies shipped, fighting over one Grafana UID.
+        # Resolved on 2026-08-28 the other way round -- the hand-maintained copies
+        # in observability/base/grafana-operator were dropped and the chart's
+        # vendored ones kept -- so those four entries are gone rather than
+        # corrected.
+        #
+        # Operating systems this platform does not run. Every node on both clusters
+        # is Linux (Bottlerocket on aws-0, Container-Optimized OS on gcp-0), so
+        # these seven drew empty panels and made up 7 of 63 dashboards.
+        #
+        # Disabled HERE and not via a HelmRelease postRenderer: these are created
+        # at RUNTIME by the chart's sync-job (labelled `managed-by: sync-job`, owned
+        # by its ServiceAccount), not rendered by `helm template`. A postRenderer
+        # sees nothing to delete -- tried, and it was a silent no-op.
+        k8s-resources-windows-cluster:
           enabled: false
-        k8s-views-namespaces:
+        k8s-resources-windows-namespace:
           enabled: false
-        k8s-views-nodes:
+        k8s-resources-windows-pod:
           enabled: false
-        k8s-views-pods:
+        k8s-windows-cluster-rsrc-use:
           enabled: false
+        k8s-windows-node-rsrc-use:
+          enabled: false
+        nodes-aix:
+          enabled: false
+        nodes-darwin:
+          enabled: false
+        # Ours, from observability/base/grafana-operator, is the only
+        # node-exporter-full deployed -- this key is correct and effective.
         node-exporter-full:
           enabled: false
         # Enable VictoriaMetrics-specific dashboards


### PR DESCRIPTION
fix(observability): drop seven dashboards for operating systems we do not run

Windows, AIX and Darwin. Every node on both clusters is Linux -- Bottlerocket on
aws-0, Container-Optimized OS on gcp-0 -- so these seven drew empty panels and
made up 7 of the 63 dashboards.

AND A LATENT BUG FOUND WHILE DOING IT

The `dashboards:` key is the rendered name's suffix: each becomes
`victoria-metrics-k8s-stack-dashboard-<key>`. A key matching no dashboard is
ACCEPTED, written into the sync-job ConfigMap, and does nothing. No error, no
warning.

Four entries here were `k8s-views-*` while the chart's keys are
`kubernetes-views-*`. So that block did nothing for as long as it existed, and
its own comment -- "Disable duplicate Kubernetes dashboards (already managed
manually in infrastructure namespace)" -- described a de-duplication that never
happened. Both copies shipped, with the same Grafana UIDs, overwriting each other
on every reconcile. #1895 resolved that the other way round (the hand-maintained
copies were dropped, the chart's vendored ones kept), so those four entries are
removed rather than corrected.

WHY NOT A postRenderer

I tried one first and it was a silent no-op. These dashboards are not rendered by
`helm template`: the chart's SYNC-JOB creates them at runtime, which the live
objects say plainly -- `managed-by: sync-job`, ownerReference on
victoria-metrics-k8s-stack-sync-job's ServiceAccount. There is nothing in the
rendered output to delete, so the values map is the only real lever. Reverted.

Also removes a stale commented-out Grafana OIDC block from helmrelease-vmsingle
that carried a PLAINTEXT client secret in git. The live config has been in
vm-common-helm-values-configmap for a long time; the comment was only a leak.
That secret belongs to an aws-0 ZITADEL client and should be treated as exposed
and rotated -- flagged separately, since aws-0 is currently torn down.

Evidence:
  validate-manifests.sh   2126 resources, Valid: 2126, Invalid: 0, Skipped: 0
  live sync-job ConfigMap  18 keys, confirming the naming and the wrong ones
  live dashboard labels    managed-by: sync-job (not Helm-rendered)
