### PR TITLE
chore(crossplane): pin v0.4.5, the second half of making the GCS mount work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ differences:
 > **Both known blockers are closed; the umbrella stays suspended on cost, not breakage.**
 > Serving pods need a per-claim read-only identity because the FUSE mount authenticates as the
 > mounting pod's own ServiceAccount. That identity **is** rendered by the `InferenceService`
-> composition as of `crossplane-configuration` v0.4.4 — the version already pinned here — which
+> composition as of `crossplane-configuration` v0.4.5 — the version already pinned here — which
 > emits a per-claim ServiceAccount, a Deployment running as it, and a `GCPWorkloadIdentity` granting
 > `roles/storage.objectViewer` scoped to the weights bucket. No pin bump needed. (The second gap,
 > KEDA on `gcp-0`, is also closed — `infrastructure/gcp-0` pulls the shared `base/keda`.)

--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -219,7 +219,7 @@ spec:
         - clone
         - --depth=1
         - --single-branch
-        - --branch=v0.4.4
+        - --branch=v0.4.5
         - https://github.com/Smana/crossplane-configuration.git
         - /repo/crossplane-configuration
       securityContext:

--- a/clusters/gcp-0-llm-platform/README.md
+++ b/clusters/gcp-0-llm-platform/README.md
@@ -45,7 +45,7 @@ GKE cluster. Resuming is a validation run, not a routine enable.
   the node's default identity. So each `InferenceService` claim's serving ServiceAccount needs its
   own read-only `GCPWorkloadIdentity` — the role AWS's per-claim read-only EPI plays. This README
   previously said the composition had no GCP support for that. It does, in
-  `crossplane-configuration` **v0.4.4, the version already pinned** in
+  `crossplane-configuration` **v0.4.5, the version already pinned** in
   `infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml`. Read back from
   that tag's own golden fixture (`tests/golden/inferenceservice-gcp.yaml`), a claim renders:
 

--- a/infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml
@@ -12,4 +12,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-aws
 spec:
-  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.4
+  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.5

--- a/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
@@ -13,4 +13,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-gcp
 spec:
-  package: ghcr.io/smana/crossplane-configuration-gcp:v0.4.4
+  package: ghcr.io/smana/crossplane-configuration-gcp:v0.4.5

--- a/website/content/docs/platform/ai-platform/_index.md
+++ b/website/content/docs/platform/ai-platform/_index.md
@@ -29,7 +29,7 @@ plain Flux reconciliation both leave the cluster LLM-free.
 | **Autoscaling** | KEDA, three vLLM saturation triggers OR-combined, `min=1` (always warm) |
 | **Weights** | Amazon S3 Files (POSIX over S3), RWX PVC shared by a preload Job and the serving pod |
 | **GPUs** | Karpenter `gpu-l4` NodePool — single-GPU `g6` spot instances, Bottlerocket NVIDIA AMI, capped at 4 GPUs |
-| **Composition** | `crossplane-inference-service` KCL module `0.9.0`, pinned inside `crossplane-configuration-aws:v0.4.4` |
+| **Composition** | `crossplane-inference-service` KCL module `0.9.0`, pinned inside `crossplane-configuration-aws:v0.4.5` |
 
 ## Why self-host at all
 

--- a/website/content/docs/platform/developer-platform/_index.md
+++ b/website/content/docs/platform/developer-platform/_index.md
@@ -14,11 +14,11 @@ a version:
 ```yaml
 # infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml
 spec:
-  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.4
+  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.5
 ```
 
 `gcp-0` serves the same claims from its own package,
-`ghcr.io/smana/crossplane-configuration-gcp:v0.4.4`, pinned in
+`ghcr.io/smana/crossplane-configuration-gcp:v0.4.5`, pinned in
 `infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml`
 — both clusters currently pin the same release.
 

--- a/website/content/docs/platform/developer-platform/app-field-reference.md
+++ b/website/content/docs/platform/developer-platform/app-field-reference.md
@@ -17,11 +17,11 @@ they live in
 [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration),
 which this repo pins as a `Configuration` package
 (`infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml`,
-currently `ghcr.io/smana/crossplane-configuration-aws:v0.4.4`). This table was
+currently `ghcr.io/smana/crossplane-configuration-aws:v0.4.5`). This table was
 reconciled by hand against that repository's `apis/app/definition.yaml` (the
 CRD schema — types, enums, CEL rules) and `apis/app/kcl/main.k` (composition
 defaults that never appear in the schema, such as resource requests/limits or
-the gateway/route fallback names) at the commit tagged `v0.4.4`.
+the gateway/route fallback names) at the commit tagged `v0.4.5`.
 
 **To regenerate:** check out `Smana/crossplane-configuration` at the tag
 currently pinned above, and read `apis/app/definition.yaml` +

--- a/website/content/docs/platform/developer-platform/app-wizard.md
+++ b/website/content/docs/platform/developer-platform/app-wizard.md
@@ -29,7 +29,7 @@ The wizard clones **two** repositories at startup: this one (for the `App`
 schema, stacks, and its own config) and
 [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration)
 at the tag pinned in `apps/platform/app-wizard/app.yaml`'s
-`fetch-crossplane-configuration` init container — currently `v0.4.4`, the
+`fetch-crossplane-configuration` init container — currently `v0.4.5`, the
 same tag pinned in
 `infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml`.
 This is a deliberate coupling, not an accident: if the wizard's clone drifts


### PR DESCRIPTION
chore(crossplane): pin v0.4.5, the second half of making the GCS mount work

v0.4.4 got GKE's FUSE sidecar injected. v0.4.5
(Smana/crossplane-configuration#18) lets it authenticate: the sidecar exchanges
the pod's ServiceAccount token at 169.254.169.254 before it can touch the bucket,
and the CiliumNetworkPolicy this Composition renders did not allow that.

It did not, because the policy was AWS-shaped on BOTH clouds -- S3 and Secrets
Manager FQDNs plus `toEntities: host` on port 80, which is the EKS Pod Identity
Agent. A GKE preload could reach HuggingFace and then never authenticate to the
bucket it was downloading into. The pod reported PodInitializing with nothing
about networking in its status; the reason was only visible in the sidecar's own
log.

Note the inversion, which this repo has now hit from both sides: on EKS the Pod
Identity Agent is host-network so Cilium calls it the `host` entity and `toCIDR`
silently fails; on GKE the metadata server is NOT `host`, so it needs exactly the
address form. runlore already shipped this same rule for GKE (#563).

AWS is byte-identical -- 17 of 18 golden fixtures unchanged, and the preload's
existing rule ORDER was preserved deliberately after a first attempt reordered
them and moved three AWS goldens for no semantic reason.

Evidence:
  ghcr manifest           crossplane-configuration-gcp:v0.4.5 present
  upstream task check     exit 0, 18/18 golden fixtures match
  validate-manifests.sh   2126 resources, Valid: 2126, Invalid: 0, Skipped: 0
  validate-links.sh       all relative links resolve
