### PR TITLE
chore(crossplane): pin v0.4.6, so a GPU pod can actually be scheduled on GKE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ differences:
 > **Both known blockers are closed; the umbrella stays suspended on cost, not breakage.**
 > Serving pods need a per-claim read-only identity because the FUSE mount authenticates as the
 > mounting pod's own ServiceAccount. That identity **is** rendered by the `InferenceService`
-> composition as of `crossplane-configuration` v0.4.5 — the version already pinned here — which
+> composition as of `crossplane-configuration` v0.4.6 — the version already pinned here — which
 > emits a per-claim ServiceAccount, a Deployment running as it, and a `GCPWorkloadIdentity` granting
 > `roles/storage.objectViewer` scoped to the weights bucket. No pin bump needed. (The second gap,
 > KEDA on `gcp-0`, is also closed — `infrastructure/gcp-0` pulls the shared `base/keda`.)

--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -219,7 +219,7 @@ spec:
         - clone
         - --depth=1
         - --single-branch
-        - --branch=v0.4.5
+        - --branch=v0.4.6
         - https://github.com/Smana/crossplane-configuration.git
         - /repo/crossplane-configuration
       securityContext:

--- a/clusters/gcp-0-llm-platform/README.md
+++ b/clusters/gcp-0-llm-platform/README.md
@@ -45,7 +45,7 @@ GKE cluster. Resuming is a validation run, not a routine enable.
   the node's default identity. So each `InferenceService` claim's serving ServiceAccount needs its
   own read-only `GCPWorkloadIdentity` — the role AWS's per-claim read-only EPI plays. This README
   previously said the composition had no GCP support for that. It does, in
-  `crossplane-configuration` **v0.4.5, the version already pinned** in
+  `crossplane-configuration` **v0.4.6, the version already pinned** in
   `infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml`. Read back from
   that tag's own golden fixture (`tests/golden/inferenceservice-gcp.yaml`), a claim renders:
 

--- a/infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml
@@ -12,4 +12,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-aws
 spec:
-  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.5
+  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.6

--- a/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
@@ -13,4 +13,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-gcp
 spec:
-  package: ghcr.io/smana/crossplane-configuration-gcp:v0.4.5
+  package: ghcr.io/smana/crossplane-configuration-gcp:v0.4.6

--- a/website/content/docs/platform/ai-platform/_index.md
+++ b/website/content/docs/platform/ai-platform/_index.md
@@ -29,7 +29,7 @@ plain Flux reconciliation both leave the cluster LLM-free.
 | **Autoscaling** | KEDA, three vLLM saturation triggers OR-combined, `min=1` (always warm) |
 | **Weights** | Amazon S3 Files (POSIX over S3), RWX PVC shared by a preload Job and the serving pod |
 | **GPUs** | Karpenter `gpu-l4` NodePool — single-GPU `g6` spot instances, Bottlerocket NVIDIA AMI, capped at 4 GPUs |
-| **Composition** | `crossplane-inference-service` KCL module `0.9.0`, pinned inside `crossplane-configuration-aws:v0.4.5` |
+| **Composition** | `crossplane-inference-service` KCL module `0.9.0`, pinned inside `crossplane-configuration-aws:v0.4.6` |
 
 ## Why self-host at all
 

--- a/website/content/docs/platform/developer-platform/_index.md
+++ b/website/content/docs/platform/developer-platform/_index.md
@@ -14,11 +14,11 @@ a version:
 ```yaml
 # infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml
 spec:
-  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.5
+  package: ghcr.io/smana/crossplane-configuration-aws:v0.4.6
 ```
 
 `gcp-0` serves the same claims from its own package,
-`ghcr.io/smana/crossplane-configuration-gcp:v0.4.5`, pinned in
+`ghcr.io/smana/crossplane-configuration-gcp:v0.4.6`, pinned in
 `infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml`
 — both clusters currently pin the same release.
 

--- a/website/content/docs/platform/developer-platform/app-field-reference.md
+++ b/website/content/docs/platform/developer-platform/app-field-reference.md
@@ -17,11 +17,11 @@ they live in
 [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration),
 which this repo pins as a `Configuration` package
 (`infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml`,
-currently `ghcr.io/smana/crossplane-configuration-aws:v0.4.5`). This table was
+currently `ghcr.io/smana/crossplane-configuration-aws:v0.4.6`). This table was
 reconciled by hand against that repository's `apis/app/definition.yaml` (the
 CRD schema — types, enums, CEL rules) and `apis/app/kcl/main.k` (composition
 defaults that never appear in the schema, such as resource requests/limits or
-the gateway/route fallback names) at the commit tagged `v0.4.5`.
+the gateway/route fallback names) at the commit tagged `v0.4.6`.
 
 **To regenerate:** check out `Smana/crossplane-configuration` at the tag
 currently pinned above, and read `apis/app/definition.yaml` +

--- a/website/content/docs/platform/developer-platform/app-wizard.md
+++ b/website/content/docs/platform/developer-platform/app-wizard.md
@@ -29,7 +29,7 @@ The wizard clones **two** repositories at startup: this one (for the `App`
 schema, stacks, and its own config) and
 [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration)
 at the tag pinned in `apps/platform/app-wizard/app.yaml`'s
-`fetch-crossplane-configuration` init container — currently `v0.4.5`, the
+`fetch-crossplane-configuration` init container — currently `v0.4.6`, the
 same tag pinned in
 `infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml`.
 This is a deliberate coupling, not an accident: if the wizard's clone drifts


### PR DESCRIPTION
chore(crossplane): pin v0.4.6, so a GPU pod can actually be scheduled on GKE

Third and final GCP fix in the chain that started when gcp-0's LLM umbrella was
resumed for the first time. v0.4.4 got the FUSE sidecar injected, v0.4.5 let it
authenticate, and the weights are now in the bucket -- but the serving Deployment
still could not create a pod:

    pods "xplane-qwen3-8b-..." is forbidden: pod rejected:
    RuntimeClass "nvidia" not found

v0.4.6 (Smana/crossplane-configuration#19) fixes three AWS-shaped assumptions in
one pod spec: `runtimeClassName: nvidia` (Bottlerocket-only, and REJECTED by the
API server on GKE rather than ignored), `nodeSelector: karpenter.sh/nodepool`
(there is no Karpenter on GKE -- a ComputeClass is selected through
`cloud.google.com/compute-class`), and a missing toleration for
node.cilium.io/agent-not-ready, without which the class never scales up and
`whenUnsatisfiable: DoNotScaleUp` means nothing says why.

Worth noting for the record: all three were already documented in THIS repository,
in infrastructure/gcp-0/computeclass/gpu-l4.yaml, before the Composition was
written. The knowledge existed; the code did not read it. Every one of these three
releases was found by running the platform rather than inspecting it, which is
exactly what clusters/gcp-0-llm-platform/README.md said a first resume was for.

AWS unchanged -- 17 of 18 golden fixtures byte-identical across the upstream
change.

NEXT is real GPU capacity: an L4 on spot will be provisioned the moment this
schedules, which is the first billable thing in the whole sequence.

Evidence:
  ghcr manifest           crossplane-configuration-gcp:v0.4.6 present
  upstream task check     exit 0, 18/18 golden fixtures match
  validate-manifests.sh   2126 resources, Valid: 2126, Invalid: 0, Skipped: 0
