### PR TITLE
docs(db): record how a restore actually behaves, having finally run one

### DIFF
--- a/security/base/zitadel/sqlinstance.yaml
+++ b/security/base/zitadel/sqlinstance.yaml
@@ -42,6 +42,27 @@ spec:
   # S3 (root cause unknown — suspect cluster destroy raced backup
   # finalize). Add a Flux pre-flight check that fails closed if the
   # configured recovery prefix is empty.
+  # UNTESTED ON THIS CLOUD, and it will not work as written on a rebuild.
+  #
+  # gcp-0 exercised the equivalent path on 2026-08-28 -- the first time a restore
+  # from object storage has actually been performed anywhere in this repository.
+  # It works, and it needs one step nobody had written down: CNPG refuses to
+  # start a restored cluster whose DESTINATION WAL archive is non-empty --
+  #
+  #   barman-cloud-check-wal-archive: WAL archive check failed for server
+  #   xplane-zitadel-cnpg-cluster: Expected empty archive
+  #
+  # -- because a restore opens a new timeline that would collide with the WALs
+  # already there. This bucket outlives the cluster by design, so on every
+  # aws-0 rebuild `xplane-zitadel-cnpg-cluster/` still holds the LAST cluster's
+  # archive and the bootstrap will refuse, exactly as it did on GCP.
+  #
+  # aws-0 has not hit it only because nothing has rebuilt since zitadel-20260719
+  # was frozen. Before the next rebuild, either clear the live prefix --
+  #   aws s3 rm --recursive \
+  #     s3://<region>-ogenki-cnpg-backups/xplane-zitadel-cnpg-cluster/
+  # -- having first confirmed the dated seed is complete, or fix it properly with
+  # a per-generation serverName in the SQLInstance Composition.
   objectStoreRecovery:
     bucketName: "${region}-ogenki-cnpg-backups"
     path: "zitadel-20260719"

--- a/security/gcp-0/zitadel/kustomization.yaml
+++ b/security/gcp-0/zitadel/kustomization.yaml
@@ -47,6 +47,36 @@ patches:
   #      Rotate the seed the way base documents for aws-0: take a one-shot
   #      Backup, copy the cluster prefix to a new dated one, update `path` here.
   #
+  #      ── RESTORING REQUIRES CLEARING THE LIVE ARCHIVE FIRST ──────────────
+  #
+  #      VALIDATED end to end on 2026-08-28 by deleting the CNPG Cluster AND its
+  #      PVC and letting Crossplane rebuild: the restored instance came back with
+  #      the same 3 users, 5 OIDC apps, 4 roles, admin grant and Google IdP.
+  #
+  #      It failed three times first, and the reason is structural rather than
+  #      incidental. CNPG refuses to start a restored cluster whose DESTINATION
+  #      WAL archive is non-empty -- a restore opens a new timeline and would
+  #      collide with the existing WALs:
+  #
+  #        barman-cloud-check-wal-archive: WAL archive check failed for server
+  #        xplane-zitadel-cnpg-cluster: Expected empty archive
+  #
+  #      The bucket is deliberately durable (infrastructure/gcp-0/cloudnative-pg/
+  #      gcs-bucket.yaml: "backups outlive any individual cluster"), so on EVERY
+  #      rebuild the destination still holds the previous cluster's archive and
+  #      the restore refuses. Before a restore-bootstrap, clear it:
+  #
+  #        gcloud storage rm --recursive \
+  #          gs://<project>-ogenki-cnpg-backups/xplane-zitadel-cnpg-cluster/
+  #
+  #      Safe only because the seed under zitadel-<date>/ is a full copy -- take
+  #      and freeze the seed BEFORE clearing anything.
+  #
+  #      The durable fix is a per-generation `serverName` in the SQLInstance
+  #      Composition, which would remove this step on both clouds. Until then the
+  #      manual step is required, and aws-0 carries the same exposure -- see the
+  #      note in security/base/zitadel/sqlinstance.yaml.
+  #
   #   3. backup.bucketName points at a `${project_id}-` bucket rather than
   #      base's `${region}-` one. GCS bucket names are globally unique, so the
   #      region is not what makes one unique. The bucket itself is provisioned


### PR DESCRIPTION
docs(db): record how a restore actually behaves, having finally run one

The restore path in this repository had never been executed -- on either cloud.
gcp-0 ran it on 2026-08-28 by deleting the CNPG Cluster AND its PVC and letting
Crossplane rebuild. It works: the restored instance came back with the same 3
users, 5 OIDC apps (grafana, headlamp, flux-ui, headlamp-proxy, harbor), 4
project roles, the admin grant and the Google Workspace IdP -- compared against a
baseline captured before the delete.

IT FAILED THREE TIMES FIRST, for a reason that is structural rather than
incidental:

    barman-cloud-check-wal-archive: WAL archive check failed for server
    xplane-zitadel-cnpg-cluster: Expected empty archive

CNPG refuses to start a restored cluster whose DESTINATION WAL archive is
non-empty, because a restore opens a new timeline that would collide with the
WALs already there. And the bucket is durable ON PURPOSE -- gcs-bucket.yaml says
"backups outlive any individual cluster" -- so on EVERY rebuild the destination
still holds the previous cluster's archive and the bootstrap refuses.

So a restore needs a step nobody had written down: clear the live cluster prefix
first, having confirmed the dated seed is a complete copy.

AWS-0 CARRIES THE SAME EXPOSURE, which is the more useful half of this commit.
Its claim restores from zitadel-20260719 into a bucket that also outlives its
cluster, so its next rebuild will refuse in exactly the same way. It has not
happened only because nothing has rebuilt since that seed was frozen. The base
now says so where someone reading objectStoreRecovery will see it.

The durable fix -- a per-generation serverName in the SQLInstance Composition --
would remove the manual step on both clouds. Recorded as the recommendation
rather than done here, since it is a Composition change and a release.

Evidence:
  restore                 Cluster "in healthy state", zitadel 1/1 Running
  data compared           users/apps/roles/grants/idps identical to baseline
  validate-manifests.sh   2126 resources, Valid: 2126, Invalid: 0, Skipped: 0
