### PR TITLE
docs(gcp): the teardown leaves Crossplane's buckets behind, and one must survive

### DIFF
--- a/website/content/docs/get-started/gcp/teardown.md
+++ b/website/content/docs/get-started/gcp/teardown.md
@@ -112,6 +112,39 @@ The three hand-created bootstrap prerequisites — the state bucket, the Cloud K
 key ring, and the Tailscale OAuth client — are also left alone. Cloud KMS key
 rings cannot be deleted at all.
 
+### Everything Crossplane created
+
+`tofu destroy` does not remove these, and it cannot: Crossplane is *in* the
+cluster, so it dies with it. Anything it provisioned in GCP is simply orphaned.
+On the 2026-08-28 gcp-0 teardown that was **3 Buckets, 7 BucketIAMMembers and 5
+ProjectIAMMembers**.
+
+The buckets survive on purpose rather than by oversight — their
+`managementPolicies` are `[Observe, Create, Update, LateInitialize]` with **no
+`Delete`**, which is the constitution's "no deletion permissions for stateful
+services" applied to object storage. Deleting the claim does not delete the
+bucket; nothing does, except a human.
+
+```bash
+gcloud storage buckets list --project <project> --format='value(name)'
+```
+
+The IAM members cost nothing and reference principals that no longer exist, so
+they are noise rather than a leak. The buckets bill.
+
+{{< callout type="warning" >}}
+**Keep `<project>-ogenki-cnpg-backups`.** It holds the dated restore seed —
+`zitadel-<date>/` — that `security/gcp-0/zitadel` bootstraps the next cluster's
+ZITADEL from. Delete it and the rebuild starts with an EMPTY identity provider,
+losing what no script can recreate: the Google IdP's user links, and any human
+user, which exists only after a first interactive login. It is ~100 MB.
+{{< /callout >}}
+
+The other two are a judgement call. `<project>-ogenki-llm-models` held 18.1 GB of
+model weights after one preload — keeping it makes a later LLM run skip the
+HuggingFace download entirely; deleting it saves a few tens of cents a month.
+`<project>-ogenki-harbor` is empty unless images were pushed.
+
 ## Verifying nothing is left
 
 Teardown is not finished because a script said so. Check the project:
@@ -123,6 +156,11 @@ gcloud compute disks list --project <project>
 gcloud compute addresses list --project <project>
 gcloud dns managed-zones list --project <project>
 gcloud compute networks list --project <project>   # only `default` should remain
+
+# Expected to REMAIN, not to be empty: the Crossplane-created buckets and the
+# bootstrap prerequisites. Confirm the list matches what you meant to keep --
+# in particular that <project>-ogenki-cnpg-backups is still there.
+gcloud storage buckets list --project <project> --format='value(name)'
 ```
 
 ## Non-interactive


### PR DESCRIPTION
docs(gcp): the teardown leaves Crossplane's buckets behind, and one must survive

Two gaps found while preparing the 2026-08-28 gcp-0 teardown. The page covered
the PD-disk and Cloud-DNS leaks thoroughly and said nothing about the largest
category of surviving resource.

## `tofu destroy` cannot remove what Crossplane created

Crossplane runs IN the cluster, so it dies with it and everything it provisioned
in GCP is orphaned. On this teardown that is 3 Buckets, 7 BucketIAMMembers and 5
ProjectIAMMembers.

The buckets survive by DESIGN, not oversight: their managementPolicies are
[Observe, Create, Update, LateInitialize] with no `Delete` -- the constitution's
"no deletion permissions for stateful services" applied to object storage.
Deleting the claim does not delete the bucket. Nothing does, except a human.

The IAM members are noise: free, and pointing at principals that no longer exist.
The buckets bill.

## One of them must NOT be deleted

`<project>-ogenki-cnpg-backups` holds the dated restore seed that
security/gcp-0/zitadel bootstraps the next cluster's ZITADEL from. Deleting it
means the rebuild comes up with an EMPTY identity provider, losing precisely what
no script can recreate -- the Google IdP's user links, and any human user, which
exists only after a first interactive login. It is ~100 MB, and it is the whole
reason a restore seed was created in the first place.

Called out as a warning callout rather than a sentence, because the natural
instinct after a teardown is to empty every bucket that is left.

The other two are a judgement call and now say so: llm-models held 18.1 GB after
one preload (keeping it skips a later HuggingFace download), harbor is empty
unless images were pushed.

Also adds `gcloud storage buckets list` to the verification block, framed as
"expected to remain" rather than "should be empty" -- the rest of that list
checks for absence, and this one checks that the right things are still present.

NOT covered here: the AWS teardown page has the same Crossplane blind spot, since
aws-0's S3 buckets are provisioned the same way. Worth the same treatment.

Evidence:
  live cluster            3 Bucket / 7 BucketIAMMember / 5 ProjectIAMMember
  managementPolicies      no Delete on any of the three buckets
  validate-links.sh       all relative links resolve
  validate-doc-claims.sh  7 claims, 12 page checks
