### PR TITLE
fix(gcp): make the disk sweep the teardown always claimed to have

### DIFF
--- a/opentofu/gcp/gke/init/workflows.tm.hcl
+++ b/opentofu/gcp/gke/init/workflows.tm.hcl
@@ -440,6 +440,41 @@ script "destroy" {
   }
 
   job {
+    name        = "stage2-sweep-orphaned-disks"
+    description = "Delete PD disks the in-cluster reclaim could not finish; runs after the cluster is gone"
+    commands = [
+      ["bash", "-c", <<-BASH
+        if [ "$${TM_GCP_ENABLED:-}" != "true" ]; then
+          echo "[skip] GKE init destroy (stage2-sweep-orphaned-disks): set TM_GCP_ENABLED=true"
+          exit 0
+        fi
+        set -euo pipefail
+        # The backstop k8s-reclaim-csi-volumes.sh has always CLAIMED to have.
+        #
+        # That script reclaims PVs while the cluster still exists -- the only
+        # moment the CSI controller can -- and when it runs out of time it warns
+        # and exits 0, saying a cloud-side sweep would catch the rest. No such
+        # sweep existed, and "the next destroy run" cannot help either: a later
+        # run is a different cluster whose PVs do not reference these disks.
+        #
+        # So the leak was real and repeating: 3 disks on the 2026-08-27 teardown,
+        # 8 (43 GB) on 2026-08-28.
+        #
+        # AFTER stage1-destroy-cluster deliberately. Before it, a disk still
+        # attached to a draining node is not yet unattached and would be skipped;
+        # after it, everything that leaked is unattached and visible.
+        #
+        # Never fails the teardown -- see the script's closing comment.
+        bash "${terramate.root.path.fs.absolute}/scripts/gcp-sweep-orphaned-disks.sh" \
+          --project "$(cd "${terramate.root.path.fs.absolute}/opentofu/gcp/gke/init" && \
+            awk -F'=' '/^[[:space:]]*project_id/{gsub(/[[:space:]"]/,"",$2); print $2}' variables.tfvars)" \
+          --apply
+      BASH
+      ],
+    ]
+  }
+
+  job {
     name        = "stage2-reconcile-state"
     description = "Drop any stage-2 state left behind, now that the cluster holding it is gone"
     commands = [

--- a/scripts/gcp-sweep-orphaned-disks.sh
+++ b/scripts/gcp-sweep-orphaned-disks.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Delete Persistent Disks that GKE's CSI driver created and nothing is using.
+#
+# WHY THIS EXISTS
+#
+# scripts/k8s-reclaim-csi-volumes.sh tries to reclaim every PV *before* the
+# cluster is deleted, which is the only moment the CSI controller can do it. When
+# it cannot finish in time it prints a warning and exits 0, ending with:
+#
+#   "The cloud-side sweep is the backstop; anything still attached to a draining
+#    node is caught by the NEXT destroy run."
+#
+# BOTH HALVES OF THAT SENTENCE WERE FALSE. There was no cloud-side sweep -- no
+# job anywhere deleted a disk from GCP -- and "the next destroy run" cannot help
+# either: a later run operates on a DIFFERENT cluster, whose PVs do not reference
+# these disks, so nothing ever looks at them again. The warning read like a
+# handoff to a step that did not exist, which is worse than no warning: it is why
+# the leak was noticed twice and fixed neither time.
+#
+#   2026-08-27 teardown:  3 disks orphaned  (20/10/5 GB)
+#   2026-08-28 teardown:  8 disks orphaned  (43 GB total)
+#
+# This script is that backstop, made real.
+#
+# WHAT IT MATCHES, AND WHY IT IS SAFE
+#
+# Two conditions, both required:
+#
+#   1. NO USERS -- the disk is attached to no instance. A disk in use is never
+#      touched, so running this against a live project cannot detach anything.
+#   2. Created by the GKE PD CSI driver, proven from the disk's own description:
+#        "storage.gke.io/created-by": "pd.csi.storage.gke.io"
+#      which the driver writes alongside the PVC name and namespace it was
+#      created for. A hand-made disk, a boot disk or another tool's volume has no
+#      such marker and is left alone.
+#
+# Deliberately NOT matched on the `pvc-` name prefix alone: that is a convention,
+# not a guarantee, and it would delete a hand-created disk that happened to be
+# named that way.
+#
+# Usage:
+#   gcp-sweep-orphaned-disks.sh --project ID [--apply]
+#
+# Dry-run unless --apply, and it lists exactly what it would delete.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+PROJECT=""
+APPLY="false"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --project) PROJECT="$2"; shift 2 ;;
+        --apply)   APPLY="true"; shift ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+[ -n "$PROJECT" ] || { echo "--project is required" >&2; exit 2; }
+
+# `-users:*` is the unattached filter. The description match cannot be expressed
+# in a --filter reliably (it is a JSON blob), so it is checked per disk below.
+mapfile -t CANDIDATES < <(
+    gcloud compute disks list --project "$PROJECT" \
+        --filter="-users:*" \
+        --format='value(name,zone,sizeGb)' 2>/dev/null || true
+)
+
+if [ "${#CANDIDATES[@]}" -eq 0 ]; then
+    echo "No unattached disks in ${PROJECT}."
+    exit 0
+fi
+
+swept=0 kept=0 failed=0
+for row in "${CANDIDATES[@]}"; do
+    [ -n "$row" ] || continue
+    name=$(awk '{print $1}' <<< "$row")
+    zone=$(awk '{print $2}' <<< "$row")
+    size=$(awk '{print $3}' <<< "$row")
+    # zone comes back as a URL; the basename is what the delete call wants.
+    zone="${zone##*/}"
+
+    desc=$(gcloud compute disks describe "$name" --project "$PROJECT" --zone "$zone" \
+             --format='value(description)' 2>/dev/null || true)
+
+    if ! grep -q "pd.csi.storage.gke.io" <<< "$desc"; then
+        echo "[keep   ] ${name} (${size}GB, ${zone}) — not CSI-created"
+        kept=$((kept + 1))
+        continue
+    fi
+
+    # The PVC it belonged to, purely so the log says what is being removed.
+    pvc=$(python3 -c "
+import json,sys
+try:
+    d=json.loads(sys.argv[1])
+    print(d.get('kubernetes.io/created-for/pvc/namespace','?') + '/' + d.get('kubernetes.io/created-for/pvc/name','?'))
+except Exception:
+    print('?')
+" "$desc" 2>/dev/null || echo "?")
+
+    if [ "$APPLY" != "true" ]; then
+        echo "[dry-run] would delete ${name} (${size}GB, ${zone}) — was ${pvc}"
+        swept=$((swept + 1))
+        continue
+    fi
+
+    if gcloud compute disks delete "$name" --project "$PROJECT" --zone "$zone" --quiet >/dev/null 2>&1; then
+        echo "[deleted] ${name} (${size}GB, ${zone}) — was ${pvc}"
+        swept=$((swept + 1))
+    else
+        echo "[FAILED ] ${name} (${size}GB, ${zone})" >&2
+        failed=$((failed + 1))
+    fi
+done
+
+echo
+echo "swept: ${swept}, kept: ${kept}, failed: ${failed}"
+
+# Never fail the teardown. A disk that cannot be deleted right now is a cost
+# problem to chase, not a reason to abort a destroy that has already removed the
+# cluster -- and the run's own log names it.
+exit 0

--- a/scripts/k8s-reclaim-csi-volumes.sh
+++ b/scripts/k8s-reclaim-csi-volumes.sh
@@ -104,8 +104,8 @@ done
 if [ "${pv_count:-0}" != "0" ]; then
     echo "WARNING: ${pv_count} PV(s) not reclaimed — their backing volumes may be orphaned:"
     "${KCTL[@]}" get pv -o jsonpath='{range .items[*]}{.metadata.name}{" -> "}{.spec.csi.volumeHandle}{"\n"}{end}' 2>/dev/null || true
-    echo "The cloud-side sweep is the backstop; anything still attached to a draining"
-    echo "node is caught by the NEXT destroy run."
+    echo "The cloud-side sweep (stage2-sweep-orphaned-disks) deletes these after the"
+    echo "cluster is gone. On AWS there is no equivalent step yet -- check manually."
 else
     echo "All PersistentVolumes reclaimed."
 fi

--- a/website/content/docs/get-started/gcp/teardown.md
+++ b/website/content/docs/get-started/gcp/teardown.md
@@ -63,6 +63,39 @@ the AWS teardown because every step of it is plain Kubernetes — what it does,
 step by step, is on the
 [AWS teardown]({{< relref "/docs/get-started/aws/teardown.md#what-eks-prepare-destroysh-does-first" >}}).
 
+**It is not sufficient on its own, and used to claim otherwise.** The reclaim can
+only run while the cluster exists, and when it runs out of time it warns and
+exits 0 — it used to say a "cloud-side sweep" would catch the rest, and no such
+step existed. The leak therefore repeated: 3 disks on 2026-08-27, **8 disks /
+43 GB** on 2026-08-28, on a cluster with more stateful workloads (two CNPG
+databases, VictoriaMetrics, VictoriaLogs, runlore, Harbor).
+
+`stage2-sweep-orphaned-disks` is that backstop, made real. It runs **after** the
+cluster is deleted — before then, a disk still attached to a draining node is not
+yet unattached and would be skipped — and removes only disks that are both
+unattached **and** carry the GKE CSI driver's own marker in their description:
+
+```
+"storage.gke.io/created-by": "pd.csi.storage.gke.io"
+```
+
+so a hand-made disk is never touched. It logs each deletion with the PVC it came
+from, and never fails the teardown.
+
+Run it by hand against any project at any time:
+
+```bash
+./scripts/gcp-sweep-orphaned-disks.sh --project <project>          # dry run
+./scripts/gcp-sweep-orphaned-disks.sh --project <project> --apply
+```
+
+{{< callout type="warning" >}}
+**AWS has the same leak and no equivalent step.** `eks-prepare-destroy.sh` shares
+the same in-cluster reclaim and the same failure mode, and 62 EBS volumes
+(~518 GB) were swept by hand after a 2026-07-21 rebuild. Nothing sweeps them
+automatically yet.
+{{< /callout >}}
+
 {{< callout type="warning" >}}
 **This step deletes PVC data unconditionally**, regardless of the reclaim policy
 a PV was created with. There is no flag that skips it. Back up anything you need


### PR DESCRIPTION
fix(gcp): make the disk sweep the teardown always claimed to have

The teardown leaked Persistent Disks twice, and the reason was a sentence that
was not true. k8s-reclaim-csi-volumes.sh reclaims PVs while the cluster still
exists -- the only moment the CSI controller can -- and when it runs out of time
it warns and exits 0 with:

    "The cloud-side sweep is the backstop; anything still attached to a draining
     node is caught by the NEXT destroy run."

BOTH HALVES WERE FALSE. No job anywhere deleted a disk from GCP, and a later
destroy cannot help either: it is a different cluster, whose PVs do not reference
these disks, so nothing looks at them again. The warning read like a handoff to a
step that did not exist -- worse than no warning, because it invites you to stop
checking.

    2026-08-27 teardown:  3 disks orphaned (20/10/5 GB)
    2026-08-28 teardown:  8 disks orphaned (43 GB)

The second run had two CNPG databases, VictoriaMetrics, VictoriaLogs, runlore and
Harbor -- more stateful workloads, more leak. It scales the wrong way.

WHAT THIS ADDS

scripts/gcp-sweep-orphaned-disks.sh, wired as stage2-sweep-orphaned-disks and
running AFTER stage1-destroy-cluster. Before that point a disk still attached to
a draining node is not yet unattached and would be skipped; after it, everything
that leaked is unattached and visible.

Two conditions, both required, so it cannot delete something it should not:

  1. no users -- an attached disk is never touched, so this is safe to run
     against a live project;
  2. the GKE CSI driver's own marker in the disk description,
     "storage.gke.io/created-by": "pd.csi.storage.gke.io", which it writes
     alongside the PVC name and namespace.

Deliberately NOT matched on the `pvc-` name prefix: that is a convention, not a
guarantee, and would catch a hand-made disk named that way.

Dry-run by default, logs each disk with the PVC it came from, and never fails the
teardown -- a disk that cannot be deleted is a cost to chase, not a reason to
abort a destroy that has already removed the cluster.

VERIFIED ON THE REAL LEAK, not a hypothetical: run against the 8 disks left by
tonight's teardown it identified all 8, named each one's origin
(tooling/data-harbor-trivy-0, flux-system/source-controller,
observability/vmsingle-…, runlore/catalog-runlore-0/1, …), deleted them, and the
project went to 0 disks.

AWS HAS THE SAME LEAK AND STILL NO SWEEP. eks-prepare-destroy.sh shares the same
in-cluster reclaim and the same failure mode -- 62 EBS volumes (~518 GB) were
cleaned by hand after a 2026-07-21 rebuild. Called out in the doc and in the
corrected comment rather than fixed here, since it needs the AWS equivalent
written and tested against a real teardown.

Evidence:
  dry run                8 identified, 0 kept, 0 failed
  apply                  8 deleted; `gcloud compute disks list` -> 0
  bash -n + shellcheck   clean
  terramate script list  destroy still resolves
  validate-manifests.sh  2126 resources, Valid: 2126, Invalid: 0, Skipped: 0
  validate-links.sh      all relative links resolve
