### PR TITLE
docs: explain the authentication stack, and how to restore a database

### DIFF
--- a/website/content/docs/guides/restore-a-database.md
+++ b/website/content/docs/guides/restore-a-database.md
@@ -1,0 +1,161 @@
+---
+title: Restore a database from object storage
+weight: 40
+description: How a CloudNativePG cluster bootstraps from a frozen backup, the check that will refuse it, and how to verify the restore actually worked.
+lastVerified: 2026-08-29
+---
+
+A `SQLInstance` claim can bootstrap a brand-new database from a backup in object
+storage instead of starting empty. `security/gcp-0/zitadel` does exactly that, and
+this page is how it was proven to work.
+
+{{< callout type="info" >}}
+Performed end to end on `gcp-0` on 2026-08-29 — the first restore ever run in this
+repository, on either cloud. It works, and it needs one step that is not obvious.
+{{< /callout >}}
+
+## Why bother
+
+A ZITADEL that bootstraps **empty** loses, on every rebuild, everything the
+setup scripts cannot recreate:
+
+- the Google IdP's **user links**, and
+- **any human user at all** — which exists only after a first interactive login,
+  and therefore cannot be seeded by a script that runs at bootstrap.
+
+`scripts/zitadel-oidc-clients.sh` and `scripts/zitadel-idp.sh` can rebuild the
+provider, the clients, the project, its roles and the login policy. They cannot
+rebuild the fact that a person logged in once. Restoring is the difference
+between *the platform comes back* and *the platform is rebuilt and everyone logs
+in again to re-earn their grants*.
+
+## 1. Freeze a seed
+
+Recovery points at a **frozen, dated prefix**, never at the live cluster's own
+archive — a live prefix keeps changing under you, and the whole point is a known
+state you can return to.
+
+```bash
+# a) one-shot backup, so the seed contains the current configuration
+kubectl apply -n security -f - <<'EOF'
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: zitadel-restore-seed
+  namespace: security
+spec:
+  cluster:
+    name: xplane-zitadel-cnpg-cluster
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+EOF
+
+kubectl get backup -n security zitadel-restore-seed -w   # wait for phase=completed
+
+# b) copy the cluster prefix to a dated one
+gcloud storage cp --recursive \
+  gs://<project>-ogenki-cnpg-backups/xplane-zitadel-cnpg-cluster/* \
+  gs://<project>-ogenki-cnpg-backups/zitadel-$(date +%Y%m%d)/
+```
+
+On AWS the same two steps use `aws s3 cp --recursive` against
+`s3://<region>-ogenki-cnpg-backups/`.
+
+Then point the claim at it — `security/gcp-0/zitadel/kustomization.yaml`:
+
+```yaml
+- op: replace
+  path: /spec/objectStoreRecovery/path
+  value: zitadel-20260828
+```
+
+## 2. The check that will refuse the restore
+
+{{< callout type="warning" >}}
+**Clear the live archive first, or the restore will not start.**
+{{< /callout >}}
+
+CloudNativePG refuses to start a restored cluster whose **destination** WAL
+archive is non-empty — a restore opens a new timeline that would collide with the
+WALs already there:
+
+```
+barman-cloud-check-wal-archive: WAL archive check failed for server
+xplane-zitadel-cnpg-cluster: Expected empty archive
+```
+
+This is not an edge case. The backup bucket **outlives the cluster on purpose**
+(`infrastructure/gcp-0/cloudnative-pg/gcs-bucket.yaml`: *"backups outlive any
+individual cluster"*), so on every rebuild the destination still holds the
+previous cluster's archive and the bootstrap refuses.
+
+Having confirmed the dated seed is complete:
+
+```bash
+gcloud storage rm --recursive \
+  gs://<project>-ogenki-cnpg-backups/xplane-zitadel-cnpg-cluster/
+```
+
+The durable fix is a per-generation `serverName` in the `SQLInstance`
+Composition, which would remove this step on both clouds. Until then it is
+manual, and **`aws-0` carries the identical exposure** — it restores from
+`zitadel-20260719` into a bucket that also survives its cluster, so its next
+rebuild will refuse in exactly the same way.
+
+## 3. Force the bootstrap
+
+`bootstrap` is **immutable on an existing CloudNativePG cluster**. An existing
+database will never re-bootstrap, no matter what the claim says, so recovery only
+happens on creation:
+
+```bash
+kubectl delete cluster.postgresql.cnpg.io -n security xplane-zitadel-cnpg-cluster
+kubectl delete pvc -n security xplane-zitadel-cnpg-cluster-1
+```
+
+Delete the **PVC as well**. A surviving volume means CloudNativePG reuses it and
+skips the restore entirely — which looks like success and is not.
+
+Crossplane then recreates the cluster, and this is what proves the wiring:
+
+```bash
+kubectl get cluster.postgresql.cnpg.io -n security \
+  xplane-zitadel-cnpg-cluster -o jsonpath='{.spec.bootstrap}'
+# {"recovery":{"database":"app","owner":"app","source":"zitadel-20260828"}}
+```
+
+## 4. Verify against a baseline, not against a feeling
+
+A cluster reporting *"in healthy state"* only means Postgres started. Capture the
+application's own state **before** deleting anything, and compare after:
+
+```bash
+# before
+./scripts/zitadel-oidc-clients.sh ...   # or the ZITADEL API directly
+```
+
+The `gcp-0` run compared users, OIDC apps, project roles, user grants and
+identity providers. All five matched exactly:
+
+| | before | after |
+|---|---|---|
+| users | 3 | 3 |
+| OIDC apps | grafana, headlamp, flux-ui, headlamp-proxy, harbor | identical |
+| project roles | admin, backend, frontend, data | identical |
+| grants | one admin grant | identical |
+| identity providers | Google Workspace | identical |
+
+## Rotating the seed
+
+Refresh it when the database changes meaningfully — new OAuth apps, a schema
+migration, significant user growth. Repeat step 1 with a new date and update
+`path`. The old prefix costs a few tens of megabytes; keep it until the new one
+has been restored from at least once.
+
+## Related
+
+- [Teardown]({{< relref "/docs/get-started/gcp/teardown.md" >}}) — the backup
+  bucket must **survive** a teardown, or the next build has nothing to restore from
+- [ADR-0024]({{< relref "/docs/decisions/0024-identity-provider-per-cloud.md" >}}) —
+  why each cloud runs its own ZITADEL, and why that makes restore matter

--- a/website/content/docs/platform/security/authentication.md
+++ b/website/content/docs/platform/security/authentication.md
@@ -1,0 +1,158 @@
+---
+title: Authentication
+weight: 15
+description: One Google Workspace identity, brokered by ZITADEL, reaching Grafana, Harbor, the Flux UI, Headlamp and Kubernetes RBAC — and where each cloud differs.
+lastVerified: 2026-08-29
+---
+
+Every human-facing service on this platform is behind the same identity. You log
+in with a Google Workspace account and never see a per-application password.
+
+This page is the chain that makes that true, in the order a login travels it.
+
+## The intent
+
+Three properties, in priority order:
+
+1. **One identity, one place to revoke it.** Removing someone from Google
+   Workspace removes their access to every service — there is no second user
+   directory to remember.
+2. **Authorisation from group membership, not per-app configuration.** A single
+   ZITADEL role decides what you can do in Grafana, in the Flux UI, in Harbor and
+   in Kubernetes itself.
+3. **No shared credentials.** No service accounts handed round, no application
+   passwords in a vault that people copy out of.
+
+Everything below is machinery in service of those three.
+
+## The chain
+
+```
+Google Workspace          the source of truth for who you are
+        │  OIDC
+        ▼
+ZITADEL                   the broker: user, project roles, claims
+        │  OIDC + a `groups` / `roles` claim
+        ├──────────────► Grafana        (direct OIDC)
+        ├──────────────► Flux UI        (direct OIDC + impersonation)
+        ├──────────────► Harbor         (direct OIDC, DB-configured)
+        └──────────────► Headlamp       (differs by cloud — see below)
+```
+
+### Google Workspace → ZITADEL
+
+ZITADEL holds a Google identity provider at **instance level**, so every
+organisation inherits it. It is created by `scripts/zitadel-idp.sh` from
+credentials in the secret store, never by hand in a console.
+
+`isAutoCreation` is on: a Workspace user logging in for the first time gets a
+ZITADEL user built from their Google profile. **This is the only way a human user
+ever comes into existence** — which is why no bootstrap script can seed one, and
+why [restoring the database]({{< relref "/docs/guides/restore-a-database.md" >}})
+matters more than it first appears.
+
+{{< callout type="warning" >}}
+**Creating the provider does not enable it.** The IdP template and the login
+policy are separate objects. With the template present and the policy empty,
+ZITADEL renders no Google button and resolves a typed email as a *local*
+username — producing `User not found` on a correct configuration. `zitadel-idp.sh`
+adds it to the login policy for exactly this reason.
+{{< /callout >}}
+
+### ZITADEL → a groups claim
+
+ZITADEL has **no groups**. It has *project roles*, emitted as a nested object
+keyed by role and then by organisation. Every consumer here wants a flat array of
+strings instead.
+
+`scripts/zitadel-actions/groups-from-roles.js` bridges that: an Action on the
+token flow flattens the user's role grants and sets two claims — `groups`
+(Headlamp, Flux UI) and `roles` (Grafana). Two names, one list, because the
+consumers disagree and both are already deployed.
+
+The roles themselves live on the `platform` project: `admin`, `backend`,
+`frontend`, `data`. They are created by `zitadel-oidc-clients.sh`; granting one
+to a *user* is deliberately manual, since a user exists only after a first login.
+
+{{< callout type="warning" >}}
+**`projectRoleAssertion` must be true on the project**, and ZITADEL defaults it to
+false. With it off, no token carries roles **and** `ctx.v1.user.grants` is empty
+inside the Action — so it returns early and sets no claim at all, while still
+logging `action run succeeded`. One flag produces three unrelated-looking
+failures: `no such key: groups` in the Flux UI, `unauthorized` in Headlamp, and
+every Grafana user silently landing on `Viewer`.
+{{< /callout >}}
+
+## What each consumer does with it
+
+| Service | How it authenticates | What decides authorisation |
+|---|---|---|
+| **Grafana** | direct OIDC | `role_attribute_path` matching `roles[*]` → Admin / Editor / Viewer |
+| **Flux UI** | direct OIDC | impersonates `claims.email` with `claims.groups`, so Kubernetes RBAC decides |
+| **Harbor** | direct OIDC | `oidc_auth` mode, auto-onboard on first login |
+| **Headlamp** | **differs by cloud** | see below |
+
+Harbor is worth one note: its authentication is **not chart configuration**.
+`auth_mode`, the endpoint, the client and the scopes live in Harbor's *database*
+and are written through its API at runtime, so no manifest can express them —
+`scripts/harbor-oidc.sh` applies them.
+
+## Reaching the Kubernetes API
+
+This is where the two clouds genuinely diverge, and it is the most important
+thing on this page to understand before changing anything.
+
+### aws-0 — the API server trusts ZITADEL
+
+EKS accepts an OIDC identity provider directly:
+
+```hcl
+identity_providers = {
+  zitadel = {
+    issuer_url     = "https://auth.cloud.ogenki.io"
+    username_claim = "email"
+    groups_claim   = "groups"
+  }
+}
+```
+
+So a token issued by ZITADEL *is* a Kubernetes identity. The `groups` claim
+becomes real Kubernetes groups, and `security/base/rbac/admin.yaml` binds the
+`admin` group to `cluster-admin`. Headlamp simply forwards the user's token.
+
+### gcp-0 — it does not, and cannot
+
+GKE's managed control plane accepts no equivalent flag, and Identity Service for
+GKE — which used to provide one — is deprecated as of 2026-07-01 and unsupported
+in GKE 1.37+. Workforce Identity Federation, its replacement, authenticates a
+client *to Google* through a token exchange and cannot take a ZITADEL `id_token`.
+
+So on GCP, Headlamp sits behind **oauth2-proxy**: the proxy authenticates the
+human against ZITADEL and Headlamp talks to the API server as its **own
+ServiceAccount**. The trade is explicit — per-user Kubernetes RBAC is lost, and
+authorisation moves entirely to `--allowed-group=admin` on the proxy. See
+[ADR-0026]({{< relref "/docs/decisions/0026-headlamp-auth-proxy-on-gke.md" >}})
+for the alternatives weighed, including Pinniped.
+
+{{< callout type="warning" >}}
+Two properties hold that design up, and it fails open without either: the
+HTTPRoute **strips every inbound `X-Forwarded-*` header** before oauth2-proxy sets
+its own, and a CiliumNetworkPolicy allows ingress to Headlamp **only from the
+proxy**. Without the second, any pod in the cluster could call Headlamp claiming
+to be anyone.
+{{< /callout >}}
+
+Note also that oauth2-proxy emits `X-Forwarded-Groups` (**plural**) while
+Headlamp defaults to the singular `X-Forwarded-Group`. Left at defaults the login
+succeeds, the user has no groups, and nothing logs an error.
+
+## Setting it up
+
+The five ordered bootstrap steps — and why the order is load-bearing — are in
+[Verify the cluster]({{< relref "/docs/get-started/gcp/verify.md" >}}).
+
+## Related
+
+- [ADR-0024]({{< relref "/docs/decisions/0024-identity-provider-per-cloud.md" >}}) — why each cloud runs its own ZITADEL
+- [ADR-0026]({{< relref "/docs/decisions/0026-headlamp-auth-proxy-on-gke.md" >}}) — why Headlamp is proxied on GKE
+- [Restore a database]({{< relref "/docs/guides/restore-a-database.md" >}}) — why an empty ZITADEL costs more than it looks


### PR DESCRIPTION
docs: explain the authentication stack, and how to restore a database

Two pages the site never had. Both describe machinery that exists and works, and
was documented only in YAML comments and commit messages.

## platform/security/authentication.md

`platform/security/` covered OpenBao, PKI and policies. ZITADEL appeared in
passing on five pages and was explained on none of them — there was no page that
answered "how does logging in actually work here".

It follows a login along the chain: Google Workspace as the source of truth,
ZITADEL as the broker, the Action that turns project roles into a flat `groups`
claim because ZITADEL has no groups, then what each consumer does with it —
Grafana's role_attribute_path, the Flux UI's impersonation, Harbor's
database-stored auth_mode, and Headlamp.

It states the intent first, because the machinery only makes sense against it:
one identity with one place to revoke it, authorisation from group membership
rather than per-app config, and no shared credentials.

The section that matters most is how a token reaches the KUBERNETES API, because
the clouds genuinely diverge: EKS trusts ZITADEL directly through
identity_providers, so a ZITADEL token IS a Kubernetes identity and RBAC binds
the `admin` group. GKE cannot, so Headlamp sits behind oauth2-proxy and gives up
per-user RBAC. Both are stated as the trade they are, pointing at ADR-0026.

Three traps are called out where they will be read rather than in a commit
message: creating an IdP does not enable it (the login policy is a separate
object, and the symptom is `User not found` on a correct configuration);
`projectRoleAssertion` defaults to false and silently empties every claim; and
oauth2-proxy emits X-Forwarded-GroupS while Headlamp expects the singular.

## guides/restore-a-database.md

Restoring was documented only inside a kustomization.yaml comment. The site had
nothing — `postgresql.md` is observability, not recovery.

Written from the run that proved it on 2026-08-29: freeze a dated seed, clear the
live archive (CNPG refuses to start a restored cluster whose destination WAL
archive is non-empty, and this repo's buckets outlive clusters ON PURPOSE), delete
the Cluster AND its PVC because bootstrap is immutable and a surviving volume
silently skips the restore, then compare against a baseline captured beforehand.

It says plainly why this is worth the trouble: an empty ZITADEL loses the IdP's
user links and every human user, which exists only after a first interactive
login and therefore cannot be seeded by any script.

NOTE: the local Hugo is 0.139.0 while the site requires >= 0.146.0
(mise reports hugo-extended@0.165.0 missing), so these were not rendered locally.
CI's docs build is the gate.

Evidence:
  validate-links.sh       all relative links resolve
  validate-doc-claims.sh  7 claims, 12 page checks
