### PR TITLE
docs: put SSO setup in the deploy flow, and correct the LLM platform's status

### DIFF
--- a/clusters/gcp-0-llm-platform/README.md
+++ b/clusters/gcp-0-llm-platform/README.md
@@ -33,11 +33,32 @@ for why the weights path differs from `aws-0`.
   `runtimeClassName` at all (see the header comment in `infrastructure/gcp-0/computeclass/gpu-l4.yaml`)
   — there is nothing this child would even be gating.
 
-## Status: the blocker is closed, but this has never actually run
+## Status: it HAS run now, and the run found four blockers
 
-Two things once stopped this platform from serving correctly on `gcp-0`. **Both are now closed.**
-What remains is not a gap but an absence of evidence: no part of this has been exercised on a live
-GKE cluster. Resuming is a validation run, not a routine enable.
+This section used to say two blockers were closed and only an absence of evidence remained.
+The umbrella was resumed for the first time on **2026-08-28**, and that resume found **four more**
+— three in the Composition, one outside Kubernetes entirely. Three are fixed; the fourth is not
+ours to fix.
+
+| Found on the first resume | Status |
+|---|---|
+| Pods carried no `gke-gcsfuse/volumes` annotation, so GKE injected no FUSE sidecar | fixed in `crossplane-configuration` **v0.4.4** |
+| The CiliumNetworkPolicy was AWS-shaped: no egress to the GKE metadata server, so the sidecar could never authenticate | fixed in **v0.4.5** |
+| `runtimeClassName: nvidia` (Bottlerocket-only, and *rejected* by GKE) plus a Karpenter nodeSelector and a missing Cilium toleration | fixed in **v0.4.6** |
+| `GPUS_ALL_REGIONS` quota is **0** on the project | **open** — a Google quota request, nothing in this repo can route around it |
+
+**How far it got.** Steps 1 and 2 of the failure order below both pass: the per-claim
+`GCPWorkloadIdentity` reached `Ready`, the FUSE mount worked, and the preload Job **completed with
+the weights written to GCS**. Step 3 was never reached: the serving pod is created and accepted by
+node auto-provisioning, and then `TriggeredScaleUp` fails with `GCE quota exceeded`.
+
+Worth noting for anyone repeating this: all three Composition defects were already documented in
+this repository *before* the Composition was written — `infrastructure/gcp-0/computeclass/gpu-l4.yaml`
+states the ComputeClass selector, the absent RuntimeClass and both required tolerations. The
+knowledge existed; the code did not read it. A render-time check comparing Composition output against
+that file would have caught all three at once.
+
+### The two original blockers, both still closed
 
 - ~~**Serving pods cannot read the weights bucket.**~~ **CLOSED at the pinned version.**
   The constraint itself is real and unchanged: the Cloud Storage FUSE CSI driver authenticates as
@@ -78,17 +99,26 @@ GKE cluster. Resuming is a validation run, not a routine enable.
   everything downstream, including resources that do not use it. Worth revisiting when the umbrella
   is actually resumed.
 
-It still ships suspended, because four L4s and a multi-gigabyte HuggingFace preload should be a
-deliberate act rather than a default. But the reason is now cost, not breakage.
+It still ships suspended, because an L4 and a multi-gigabyte HuggingFace preload should be a
+deliberate act rather than a default.
 
-**What to watch on the first resume**, in the order it can fail:
+The reason is **cost and an open quota** — not breakage in this repository. Everything the platform
+controls now works up to the GPU; `GPUS_ALL_REGIONS: 0` is what stops it, and until that is raised a
+resume will reach `Pending` on the serving pod and stay there. Nothing bills in that state: the pod
+is rejected before a GPU node is ever provisioned, which is why the failed run cost nothing.
+
+**What to watch on a resume**, in the order it can fail. Steps 1 and 2 are now evidenced on a live
+cluster; step 3 is still unproven:
 
 1. The `GCPWorkloadIdentity` per claim reaches `Synced=True Ready=True` — the binding exists.
 2. The serving pod actually mounts the bucket. A failure here is the FUSE identity path, and it
    surfaces as the pod stuck mounting, not as anything naming Workload Identity.
 3. vLLM reads the weights and reports the model ready.
 
-A first resume that gets past (2) is the thing this README could not previously promise.
+Getting past (2) is the thing this README could not previously promise. It can now: the
+2026-08-28 resume completed the preload and left the weights in
+`gs://<project>-ogenki-llm-models/xplane-qwen3-8b/`. (3) remains unproven, and will stay that way
+until the GPU quota is raised.
 
 ## Enable
 

--- a/website/content/docs/get-started/gcp/_index.md
+++ b/website/content/docs/get-started/gcp/_index.md
@@ -201,6 +201,16 @@ TM_GCP_ENABLED=true TF_VAR_flux_git_ref='refs/heads/my-branch' \
   terramate script run --no-tags=aws deploy
 ```
 
+## Single sign-on
+
+The deploy leaves ZITADEL running with **nothing configured in it** — no identity
+provider, no OIDC clients, no roles. Five ordered commands turn that into a
+working Google login for Grafana, Harbor, the Flux UI and Headlamp:
+[Set up single sign-on]({{< relref "sso.md" >}}).
+
+Skipping this is not obvious from the cluster: every workload is healthy and
+every service simply asks for a password nobody has.
+
 ## Verify
 
 The control plane has a **private endpoint**, so the tailnet must be up first.

--- a/website/content/docs/get-started/gcp/sso.md
+++ b/website/content/docs/get-started/gcp/sso.md
@@ -1,0 +1,73 @@
+---
+title: Set up single sign-on
+weight: 20
+description: The five ordered commands that give a fresh cluster working SSO, and the one step no script can do for you.
+lastVerified: 2026-08-29
+---
+
+A freshly deployed cluster has ZITADEL running and **nothing configured in it**.
+These are the steps that turn that into a working Google login for Grafana,
+Harbor, the Flux UI and Headlamp.
+
+They used to live at the bottom of [Verify the cluster]({{< relref "verify.md" >}}),
+which is the wrong place: this is setup, and nobody bootstrapping a cluster looks
+under "verify". For what the resulting stack actually does — and why ZITADEL is in
+the middle of it — see
+[Authentication]({{< relref "/docs/platform/security/authentication.md" >}}).
+
+SSO needs **five** steps, and the order is load-bearing: each one creates what
+the next reads. Running only the first — which is all this page used to say —
+leaves you with OIDC clients and no way to log in through Google.
+
+Every step is idempotent: re-running prints `[skip …]` and changes nothing.
+
+```bash
+# 1. Register the OIDC clients, the project, its roles, and
+#    projectRoleAssertion. That last one is not optional: with it off ZITADEL
+#    puts NO roles in any token AND leaves ctx.v1.user.grants empty inside the
+#    groups action, so every consumer authenticates and then has no groups.
+./scripts/zitadel-oidc-clients.sh sync --cluster gcp-0 --cloud gcp \
+  --project ogenki-435905 --apply
+
+# 2. Let External Secrets read what step 1 just created. Those secrets did not
+#    exist when the OpenTofu stack applied, so nothing granted access to them —
+#    this reads the cluster's ExternalSecrets and grants what exists.
+./scripts/secret-store.sh grant --cloud gcp --project ogenki-435905 --apply
+
+# 3. The Google identity provider, the LOGIN POLICY entry that actually enables
+#    it, and the action that flattens project roles into a `groups` claim.
+#    Creating the provider without the policy entry gives "User not found".
+IDP_URL=https://auth.gcp.cloud.ogenki.io \
+  ./scripts/zitadel-idp.sh sync --cluster gcp-0 --cloud gcp \
+  --project ogenki-435905 --apply
+
+# 4. Harbor's auth mode. Harbor stores this in its DATABASE, not in the chart,
+#    so no manifest can express it and a fresh cluster has no SSO button.
+PRIVATE_DOMAIN=priv.gcp.ogenki.io \
+  ./scripts/harbor-oidc.sh sync --cluster gcp-0 --cloud gcp \
+  --project ogenki-435905 --apply
+```
+
+**Then log in once through Google**, at any consumer. That first login is what
+CREATES your ZITADEL user — the IdP auto-registers it — so there is nobody to
+authorise before it. Afterwards:
+
+```bash
+# 5. Give yourself the admin role. Group-based RBAC (cluster-admin via the
+#    `admin` group) does nothing until a user actually holds it.
+./scripts/zitadel-oidc-clients.sh sync --cluster gcp-0 --cloud gcp \
+  --project ogenki-435905 --grant-admin you@example.com --apply
+```
+
+The **only** thing left in a console is Google-side: the OAuth client's
+authorized redirect URI must list
+`https://auth.<public domain>/ui/login/login/externalidp/callback`. Google
+accepts many, so one client serves every cluster; `zitadel-idp.sh` prints the
+exact URI on every run and cannot add it for you.
+
+## Then check it worked
+
+Open Grafana, Harbor, the Flux UI or Headlamp. You should be offered a Google
+button rather than a username field, and after logging in your ZITADEL user
+exists — [Verify the cluster]({{< relref "verify.md" >}}) covers the rest of the
+post-deploy checks.

--- a/website/content/docs/get-started/gcp/verify.md
+++ b/website/content/docs/get-started/gcp/verify.md
@@ -157,57 +157,14 @@ gcloud secrets versions access latest \
 ZITADEL's first admin is in `zitadel-envvars`
 (`ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME` / `…_PASSWORD`). Prefer SSO.
 
-### Single sign-on, in this order
+### Single sign-on
 
-SSO needs **five** steps, and the order is load-bearing: each one creates what
-the next reads. Running only the first — which is all this page used to say —
-leaves you with OIDC clients and no way to log in through Google.
+Setting SSO up is a **deploy** step, not a verification one — it is five ordered
+commands and it has its own page:
+[Set up single sign-on]({{< relref "sso.md" >}}).
 
-Every step is idempotent: re-running prints `[skip …]` and changes nothing.
-
-```bash
-# 1. Register the OIDC clients, the project, its roles, and
-#    projectRoleAssertion. That last one is not optional: with it off ZITADEL
-#    puts NO roles in any token AND leaves ctx.v1.user.grants empty inside the
-#    groups action, so every consumer authenticates and then has no groups.
-./scripts/zitadel-oidc-clients.sh sync --cluster gcp-0 --cloud gcp \
-  --project ogenki-435905 --apply
-
-# 2. Let External Secrets read what step 1 just created. Those secrets did not
-#    exist when the OpenTofu stack applied, so nothing granted access to them —
-#    this reads the cluster's ExternalSecrets and grants what exists.
-./scripts/secret-store.sh grant --cloud gcp --project ogenki-435905 --apply
-
-# 3. The Google identity provider, the LOGIN POLICY entry that actually enables
-#    it, and the action that flattens project roles into a `groups` claim.
-#    Creating the provider without the policy entry gives "User not found".
-IDP_URL=https://auth.gcp.cloud.ogenki.io \
-  ./scripts/zitadel-idp.sh sync --cluster gcp-0 --cloud gcp \
-  --project ogenki-435905 --apply
-
-# 4. Harbor's auth mode. Harbor stores this in its DATABASE, not in the chart,
-#    so no manifest can express it and a fresh cluster has no SSO button.
-PRIVATE_DOMAIN=priv.gcp.ogenki.io \
-  ./scripts/harbor-oidc.sh sync --cluster gcp-0 --cloud gcp \
-  --project ogenki-435905 --apply
-```
-
-**Then log in once through Google**, at any consumer. That first login is what
-CREATES your ZITADEL user — the IdP auto-registers it — so there is nobody to
-authorise before it. Afterwards:
-
-```bash
-# 5. Give yourself the admin role. Group-based RBAC (cluster-admin via the
-#    `admin` group) does nothing until a user actually holds it.
-./scripts/zitadel-oidc-clients.sh sync --cluster gcp-0 --cloud gcp \
-  --project ogenki-435905 --grant-admin you@example.com --apply
-```
-
-The **only** thing left in a console is Google-side: the OAuth client's
-authorized redirect URI must list
-`https://auth.<public domain>/ui/login/login/externalidp/callback`. Google
-accepts many, so one client serves every cluster; `zitadel-idp.sh` prints the
-exact URI on every run and cannot add it for you.
+To check it is working, open any of the services above: you should be offered a
+Google button rather than a username field.
 
 ## 6. Observability actually receiving data
 


### PR DESCRIPTION
docs: put SSO setup in the deploy flow, and correct the LLM platform's status

Two follow-ups from the website audit. Both are cases where correct information
was in the wrong place or had gone stale.

## SSO setup was filed under "Verify the cluster"

The five ordered bootstrap commands shipped in #1896 and rendered fine — at the
bottom of a page titled *Verify the cluster*. Nobody bootstrapping a cluster looks
under "verify", and the deploy page never mentioned they existed. Published but
unfindable is functionally missing, which is exactly how it was reported.

Now `get-started/gcp/sso.md`, weight 20 so it sits before Verify, and linked from
the deploy page's own flow with the consequence spelled out:

    Skipping this is not obvious from the cluster: every workload is healthy and
    every service simply asks for a password nobody has.

`verify.md` keeps a short pointer plus the one thing that IS a verification —
whether you are offered a Google button or a username field. The new page links
on to platform/security/authentication for what the stack actually does.

## The LLM platform README claimed blockers that reopened

It said two blockers were closed and "the reason is now cost, not breakage". The
first resume, on 2026-08-28, found four more: three Composition defects (missing
FUSE annotation, AWS-shaped network policy, AWS-shaped GPU scheduling — fixed in
v0.4.4, v0.4.5 and v0.4.6) and the GPUS_ALL_REGIONS quota being 0, which is not
ours to fix.

Rewritten to say what the run actually established: steps 1 and 2 of its own
failure order now have evidence — the per-claim identity reached Ready, the FUSE
mount worked, and the preload COMPLETED with weights in GCS. Step 3 was never
reached. A resume today gets to `Pending` on the serving pod and stays there, and
bills nothing, because the pod is rejected before a GPU node is provisioned.

It also records the pattern, which is the more useful half: all three Composition
defects were already documented in this repository BEFORE the Composition was
written — gpu-l4.yaml states the ComputeClass selector, the absent RuntimeClass
and both required tolerations. The knowledge existed; the code did not read it.

Evidence:
  validate-manifests.sh   2126 resources, Valid: 2126, Invalid: 0, Skipped: 0
  validate-links.sh       all relative links resolve
  validate-doc-claims.sh  7 claims, 12 page checks
