### PR TITLE
fix(aws): sweep the volumes still detaching at destroy, and script the restore step

### DIFF
--- a/opentofu/aws/eks/init/workflows.tm.hcl
+++ b/opentofu/aws/eks/init/workflows.tm.hcl
@@ -142,4 +142,36 @@ script "destroy" {
       [global.provisioner, "destroy", "-auto-approve", "-var-file=variables.tfvars"],
     ]
   }
+
+  # A SECOND sweep, and the moment is the whole point.
+  #
+  # prepare-destroy already sweeps orphaned volumes, but it runs BEFORE the
+  # destroy, moments after deleting the PVCs -- so it only catches what has
+  # finished detaching by then. Its own warning admits the rest ("may still be
+  # detaching -- the next run retries"), and the next run is a whole rebuild
+  # away, so a volume that detached one second late bills until then. That is
+  # how 62 volumes (~518 GiB) accumulated by 2026-07: each teardown leaving a
+  # few for the next one to find.
+  #
+  # Here every node is already terminated, so every volume of this cluster is
+  # unambiguously detached and there is no in-flight state to race. Same three
+  # filters as the earlier sweep -- available + this cluster's tag + the CSI
+  # driver's PVC tag -- so it cannot touch a live cluster or a hand-made volume.
+  job {
+    name        = "stage3-sweep-orphaned-volumes"
+    description = "Delete EBS volumes that were still detaching when the pre-destroy sweep ran"
+    commands = [
+      [
+        "bash",
+        "${terramate.root.path.fs.absolute}/scripts/aws-sweep-orphaned-volumes.sh",
+        "--cluster-name",
+        global.eks_cluster_name,
+        "--region",
+        global.region,
+        "--profile",
+        global.profile,
+        "--apply",
+      ],
+    ]
+  }
 }

--- a/scripts/aws-sweep-orphaned-volumes.sh
+++ b/scripts/aws-sweep-orphaned-volumes.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Delete EBS volumes this cluster's CSI driver created and nothing is using,
+# AFTER the cluster has been destroyed.
+#
+# WHY A SECOND SWEEP, WHEN eks-prepare-destroy.sh ALREADY SWEEPS
+#
+# It does, and this does not replace it. The difference is WHEN.
+#
+# eks-prepare-destroy.sh runs BEFORE `tofu destroy`, right after it deletes the
+# PVCs -- so it only sees volumes that have finished detaching by that moment.
+# Its own failure message admits the rest: "may still be detaching -- the next
+# run retries". The next run is the next TEARDOWN, which is a rebuild away. A
+# volume that was one second late to detach therefore bills from now until the
+# cluster is next built and destroyed again, and forever if it never is. That is
+# how 62 volumes (~518 GiB) accumulated by 2026-07, with 12 more (~138 GiB) from
+# the single 2026-07-21 rebuild -- each teardown leaving a few behind for the
+# following one to find.
+#
+# This sweep runs after `tofu destroy` returns, when every node is terminated
+# and so every volume of this cluster is unambiguously detached. There is no
+# in-flight state left to race, which is exactly what makes the late moment the
+# reliable one. GCP's equivalent (gcp-sweep-orphaned-disks.sh) had to be written
+# from scratch because GKE had no sweep at all; here the moment is the fix.
+#
+# WHAT IT MATCHES, AND WHY IT IS SAFE
+#
+# The same three conditions as the pre-destroy sweep, deliberately identical:
+#
+#   1. status=available -- attached to nothing. An in-use volume is invisible to
+#      this script, so it cannot detach or delete a running cluster's storage.
+#   2. tagged `kubernetes.io/cluster/<name>=owned`, so a second cluster's
+#      volumes in the same region are never candidates.
+#   3. tagged `kubernetes.io/created-for/pvc/name`, which the EBS CSI driver
+#      writes alongside the PVC's namespace. A hand-made or root volume carries
+#      no such tag.
+#
+# Dropping condition 2 would sweep the whole region and could catch another
+# live cluster's volume during a reschedule. Keep all three.
+#
+# Usage:
+#   aws-sweep-orphaned-volumes.sh --cluster-name N --region R [--profile P] [--apply]
+#
+# Dry-run unless --apply, and it lists exactly what it would delete.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CLUSTER_NAME=""
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+PROFILE=""
+APPLY="false"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --cluster-name) CLUSTER_NAME="$2"; shift 2 ;;
+        --region)       REGION="$2"; shift 2 ;;
+        --profile)      PROFILE="$2"; shift 2 ;;
+        --apply)        APPLY="true"; shift ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+[ -n "$CLUSTER_NAME" ] || { echo "--cluster-name is required" >&2; exit 2; }
+[ -n "$REGION" ] || { echo "--region is required (or set AWS_REGION)" >&2; exit 2; }
+
+AWS=(aws --region "$REGION")
+[ -n "$PROFILE" ] && AWS+=(--profile "$PROFILE")
+
+# All three conditions are filters, so nothing else is even returned.
+rows=$("${AWS[@]}" ec2 describe-volumes \
+    --filters "Name=status,Values=available" \
+              "Name=tag:kubernetes.io/cluster/${CLUSTER_NAME},Values=owned" \
+              "Name=tag-key,Values=kubernetes.io/created-for/pvc/name" \
+    --query 'Volumes[].[VolumeId,Size,Tags[?Key==`kubernetes.io/created-for/pvc/namespace`]|[0].Value,Tags[?Key==`kubernetes.io/created-for/pvc/name`]|[0].Value]' \
+    --output text 2>/dev/null || true)
+
+if [ -z "$rows" ]; then
+    echo "No orphaned CSI volumes left by ${CLUSTER_NAME} in ${REGION}."
+    exit 0
+fi
+
+swept=0 failed=0 gib=0
+while read -r vol size ns pvc; do
+    [ -n "$vol" ] || continue
+    gib=$((gib + size))
+    if [ "$APPLY" != "true" ]; then
+        echo "[dry-run] would delete ${vol} (${size}GiB) — was ${ns}/${pvc}"
+        swept=$((swept + 1))
+        continue
+    fi
+    if "${AWS[@]}" ec2 delete-volume --volume-id "$vol" >/dev/null 2>&1; then
+        echo "[deleted] ${vol} (${size}GiB) — was ${ns}/${pvc}"
+        swept=$((swept + 1))
+    else
+        echo "[FAILED ] ${vol} (${size}GiB) — was ${ns}/${pvc}" >&2
+        failed=$((failed + 1))
+    fi
+done <<< "$rows"
+
+echo
+echo "swept: ${swept} (${gib} GiB), failed: ${failed}"
+
+# Never fail the teardown: a volume that cannot be deleted right now is a cost to
+# chase, not a reason to abort a destroy that has already removed the cluster.
+exit 0

--- a/scripts/cnpg-prepare-restore.sh
+++ b/scripts/cnpg-prepare-restore.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Clear a CloudNativePG cluster's live WAL archive, so a restore can bootstrap.
+#
+# WHY THIS STEP EXISTS AT ALL
+#
+# CloudNativePG refuses to start a restored cluster whose DESTINATION archive is
+# non-empty -- a restore opens a new timeline that would collide with the WALs
+# already there:
+#
+#   barman-cloud-check-wal-archive: WAL archive check failed for server
+#   <cluster>: Expected empty archive
+#
+# And the backup buckets here outlive their clusters ON PURPOSE, so the
+# destination is never empty on a rebuild. Clearing it is therefore a normal part
+# of restoring, not an incident -- it is what an operator already does by hand
+# before an aws-0 rebuild.
+#
+# This script is that step, with the check that makes it safe to run.
+#
+# THE CHECK, WHICH IS THE WHOLE POINT
+#
+# It refuses unless the dated seed exists AND contains at least one base backup.
+# Clearing the live prefix while the seed is absent or half-copied destroys the
+# only copy of the database with nothing to restore from -- the one way this
+# operation can go badly, and the reason it should not be a bare `rm -r` typed
+# from memory.
+#
+# It never touches the seed, only the live cluster prefix.
+#
+# Usage:
+#   cnpg-prepare-restore.sh --cloud gcp --bucket B --cluster C --seed zitadel-20260828 [--project ID] [--apply]
+#   cnpg-prepare-restore.sh --cloud aws --bucket B --cluster C --seed zitadel-20260719 [--region R] [--profile P] [--apply]
+#
+# Dry-run unless --apply.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CLOUD="" BUCKET="" CLUSTER="" SEED="" PROJECT="" PROFILE=""
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+APPLY="false"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --cloud)   CLOUD="$2"; shift 2 ;;
+        --bucket)  BUCKET="$2"; shift 2 ;;
+        --cluster) CLUSTER="$2"; shift 2 ;;
+        --seed)    SEED="$2"; shift 2 ;;
+        --project) PROJECT="$2"; shift 2 ;;
+        --region)  REGION="$2"; shift 2 ;;
+        --profile) PROFILE="$2"; shift 2 ;;
+        --apply)   APPLY="true"; shift ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+for v in CLOUD BUCKET CLUSTER SEED; do
+    [ -n "${!v}" ] || { echo "--${v,,} is required" >&2; exit 2; }
+done
+case "$CLOUD" in aws|gcp) ;; *) echo "--cloud must be aws or gcp" >&2; exit 2 ;; esac
+
+# Count base backups under a prefix. The base/ directory is what a restore
+# actually reads, so an empty one means the seed is unusable even if WALs happen
+# to be present.
+#
+# "COULD NOT CHECK" IS NOT "EMPTY", and conflating them is dangerous in exactly
+# one direction. An expired auth token makes the listing fail; if that is read as
+# "no backups" the script either refuses a restore that would have been fine, or
+# -- far worse in a variant that trusted the live count -- clears an archive
+# believing a seed exists. So the CLI's own exit status decides, stderr is kept,
+# and a failure is reported as a failure. Hit for real while testing this: a
+# stale gcloud token produced "the seed has no base backup" for a seed holding
+# three.
+#
+# Echoes either a count, or the literal string `ERROR` followed by the CLI's
+# message on stderr.
+count_bases() {
+    local prefix="$1" out rc
+    case "$CLOUD" in
+        gcp)
+            out=$(gcloud storage ls "gs://${BUCKET}/${prefix}/base/" ${PROJECT:+--project "$PROJECT"} 2>&1)
+            rc=$?
+            # `ls` on a missing prefix is a legitimate "zero", not a failure.
+            if [ "$rc" -ne 0 ]; then
+                if grep -qi "matched no objects\|not found" <<< "$out"; then echo 0; return 0; fi
+                echo "ERROR"; echo "$out" >&2; return 0
+            fi
+            grep -c '/$' <<< "$out" || true
+            ;;
+        aws)
+            local aws_args=(--region "$REGION")
+            [ -n "$PROFILE" ] && aws_args+=(--profile "$PROFILE")
+            out=$(aws "${aws_args[@]}" s3 ls "s3://${BUCKET}/${prefix}/base/" 2>&1)
+            rc=$?
+            # `s3 ls` exits 1 on an empty or missing prefix with no output.
+            if [ "$rc" -ne 0 ] && [ -n "$out" ]; then
+                echo "ERROR"; echo "$out" >&2; return 0
+            fi
+            grep -c 'PRE' <<< "$out" || true
+            ;;
+    esac
+}
+
+echo "cloud:   ${CLOUD}"
+echo "bucket:  ${BUCKET}"
+echo "seed:    ${SEED}"
+echo "cluster: ${CLUSTER}"
+echo
+
+seed_bases=$(count_bases "$SEED")
+if [ "$seed_bases" = "ERROR" ]; then
+    echo "[REFUSED] could not list the seed -- the error above is why." >&2
+    echo "          This is NOT the same as an empty seed, and nothing was" >&2
+    echo "          deleted. A stale credential is the usual cause." >&2
+    exit 1
+fi
+seed_bases=${seed_bases:-0}
+if [ "$seed_bases" -lt 1 ]; then
+    echo "[REFUSED] the seed '${SEED}' has no base backup under ${SEED}/base/." >&2
+    echo "          Clearing the live archive now would leave nothing to restore" >&2
+    echo "          from. Take a one-shot Backup and copy the cluster prefix to" >&2
+    echo "          ${SEED}/ first -- see docs/guides/restore-a-database." >&2
+    exit 1
+fi
+echo "[ok     ] seed holds ${seed_bases} base backup(s)"
+
+live_bases=$(count_bases "$CLUSTER")
+if [ "$live_bases" = "ERROR" ]; then
+    echo "[REFUSED] could not list the live archive -- see the error above." >&2
+    exit 1
+fi
+live_bases=${live_bases:-0}
+if [ "$live_bases" -lt 1 ]; then
+    echo "[skip   ] live archive ${CLUSTER}/ is already empty; nothing to clear"
+    exit 0
+fi
+
+if [ "$APPLY" != "true" ]; then
+    echo "[dry-run] would delete the live archive ${CLUSTER}/ (${live_bases} base backup(s) + WALs)"
+    echo
+    echo "This was a DRY RUN. Re-run with --apply."
+    exit 0
+fi
+
+case "$CLOUD" in
+    gcp) gcloud storage rm --recursive "gs://${BUCKET}/${CLUSTER}/" ${PROJECT:+--project "$PROJECT"} >/dev/null ;;
+    aws)
+        aws_args=(--region "$REGION")
+        [ -n "$PROFILE" ] && aws_args+=(--profile "$PROFILE")
+        aws "${aws_args[@]}" s3 rm "s3://${BUCKET}/${CLUSTER}/" --recursive >/dev/null
+        ;;
+esac
+echo "[cleared] ${CLUSTER}/ — the restore can now bootstrap from ${SEED}"

--- a/scripts/k8s-reclaim-csi-volumes.sh
+++ b/scripts/k8s-reclaim-csi-volumes.sh
@@ -11,8 +11,16 @@
 #   AWS  62 EBS volumes (~518Gi) accumulated across rebuilds by 2026-07, and 12
 #        more (~138Gi) from a single 2026-07-21 rebuild.
 #   GCP  3 orphaned PD disks (35Gi) survived the 2026-08-27 gcp-0 teardown --
-#        Harbor's registry, its CNPG cluster and trivy. GKE had no equivalent of
-#        this step at all; it was AWS-only because that is where it first hurt.
+#        Harbor's registry, its CNPG cluster and trivy, then 8 more (43GB) the
+#        next day. GKE had no equivalent of this step at all; it was AWS-only
+#        because that is where it first hurt.
+#
+# The cloud-side sweep this script defers to now runs on both clouds AFTER the
+# cluster is destroyed -- scripts/gcp-sweep-orphaned-disks.sh and
+# scripts/aws-sweep-orphaned-volumes.sh, each wired into its own `destroy`.
+# GCP had no sweep at all before that. AWS had one, but only in prepare-destroy,
+# before the destroy -- so it missed whatever was still detaching, and left it
+# for a teardown a rebuild away.
 #
 # Extracted from scripts/eks-prepare-destroy.sh rather than copied: every step
 # below is plain Kubernetes, and a second copy is a second thing to forget.
@@ -104,8 +112,10 @@ done
 if [ "${pv_count:-0}" != "0" ]; then
     echo "WARNING: ${pv_count} PV(s) not reclaimed — their backing volumes may be orphaned:"
     "${KCTL[@]}" get pv -o jsonpath='{range .items[*]}{.metadata.name}{" -> "}{.spec.csi.volumeHandle}{"\n"}{end}' 2>/dev/null || true
-    echo "The cloud-side sweep (stage2-sweep-orphaned-disks) deletes these after the"
-    echo "cluster is gone. On AWS there is no equivalent step yet -- check manually."
+    echo "The cloud-side sweep deletes these once the cluster is gone, and it now"
+    echo "exists on both clouds -- gcp: stage2-sweep-orphaned-disks, aws:"
+    echo "stage3-sweep-orphaned-volumes. Both run automatically in \`terramate"
+    echo "script run destroy\`; run the script by hand if you destroyed another way."
 else
     echo "All PersistentVolumes reclaimed."
 fi

--- a/security/base/zitadel/sqlinstance.yaml
+++ b/security/base/zitadel/sqlinstance.yaml
@@ -42,27 +42,30 @@ spec:
   # S3 (root cause unknown — suspect cluster destroy raced backup
   # finalize). Add a Flux pre-flight check that fails closed if the
   # configured recovery prefix is empty.
-  # UNTESTED ON THIS CLOUD, and it will not work as written on a rebuild.
+  # RESTORING REQUIRES CLEARING THE LIVE ARCHIVE FIRST, and on aws-0 that step is
+  # already part of how rebuilds are done by hand -- the `…-cnpg-cluster/` prefix
+  # is cleaned before the bootstrap, which is why it has always worked here.
   #
-  # gcp-0 exercised the equivalent path on 2026-08-28 -- the first time a restore
-  # from object storage has actually been performed anywhere in this repository.
-  # It works, and it needs one step nobody had written down: CNPG refuses to
+  # It is written down now because it was tribal knowledge, and gcp-0 rediscovered
+  # it the hard way on 2026-08-28 with three failed recovery Jobs. CNPG refuses to
   # start a restored cluster whose DESTINATION WAL archive is non-empty --
   #
   #   barman-cloud-check-wal-archive: WAL archive check failed for server
   #   xplane-zitadel-cnpg-cluster: Expected empty archive
   #
   # -- because a restore opens a new timeline that would collide with the WALs
-  # already there. This bucket outlives the cluster by design, so on every
-  # aws-0 rebuild `xplane-zitadel-cnpg-cluster/` still holds the LAST cluster's
-  # archive and the bootstrap will refuse, exactly as it did on GCP.
+  # already there. This bucket outlives the cluster by design, so the destination
+  # is never empty on a rebuild and the step is a normal part of restoring rather
+  # than an incident.
   #
-  # aws-0 has not hit it only because nothing has rebuilt since zitadel-20260719
-  # was frozen. Before the next rebuild, either clear the live prefix --
+  # `scripts/cnpg-prepare-restore.sh` is that step with a guard: it refuses unless
+  # the dated seed actually holds a base backup, so the live archive is never
+  # cleared when there would be nothing to restore from. The manual equivalent is
   #   aws s3 rm --recursive \
   #     s3://<region>-ogenki-cnpg-backups/xplane-zitadel-cnpg-cluster/
-  # -- having first confirmed the dated seed is complete, or fix it properly with
-  # a per-generation serverName in the SQLInstance Composition.
+  #
+  # The durable fix is a per-generation serverName in the SQLInstance Composition,
+  # which removes the step on both clouds. See docs/guides/restore-a-database.
   objectStoreRecovery:
     bucketName: "${region}-ogenki-cnpg-backups"
     path: "zitadel-20260719"

--- a/website/content/docs/get-started/aws/teardown.md
+++ b/website/content/docs/get-started/aws/teardown.md
@@ -18,11 +18,13 @@ cd opentofu/aws/eks/init
 terramate script run destroy
 ```
 
-Three steps, defined in `opentofu/aws/eks/init/workflows.tm.hcl`:
+Four steps, defined in `opentofu/aws/eks/init/workflows.tm.hcl`:
 
 1. **`prepare-destroy`** — runs `scripts/eks-prepare-destroy.sh` (see below).
 2. **`stage2-destroy-addons`** — destroys the `eks/configure` stack (Cilium, Flux).
 3. **`stage1-destroy-cluster`** — destroys the `eks/init` stack (the cluster itself).
+4. **`stage3-sweep-orphaned-volumes`** — deletes the EBS volumes that were still
+   detaching when step 1 swept ([why](#the-sweep-after-the-destroy)).
 
 ## Full teardown
 
@@ -77,6 +79,9 @@ Before OpenTofu deletes anything, the script:
   volumes in `available` state, tagged for this cluster, whose PV no longer
   exists. `EKS_DESTROY_KEEP_VOLUMES=true` skips only this sweep of
   already-orphaned volumes; it has no effect on the PV/PVC reclaim above.
+  This sweep runs *before* the destroy, so it can only see what has finished
+  detaching by then — see [the second sweep](#the-sweep-after-the-destroy) for
+  the rest.
 - Reclaims the IAM access keys Harbor's S3 registry storage uses — AWS caps
   `AccessKeysPerUser` at 2, so without this a second or third rebuild's
   Harbor can fail to start on a full quota.
@@ -86,6 +91,37 @@ Before OpenTofu deletes anything, the script:
   Pod Identity associations.
 - Strips finalizers from any Crossplane composite resource stuck terminating,
   so the namespace delete that follows doesn't hang forever.
+
+## The sweep after the destroy
+
+`terramate script run destroy` ends with `stage3-sweep-orphaned-volumes`, which
+runs `scripts/aws-sweep-orphaned-volumes.sh` once the cluster is gone.
+
+It exists because the pre-destroy sweep above runs at the wrong moment to be
+complete. It fires moments after the PVCs are deleted, so a volume still
+detaching is not yet `available` and is skipped — and the script says so:
+*"may still be detaching — the next run retries"*. The next **run** is the next
+teardown, which is a whole rebuild away, so a volume that detached a second too
+late bills for the entire gap, and forever if the cluster is never rebuilt.
+That is the shape of the accumulation: 62 volumes (~518 GiB) by 2026-07, each
+teardown leaving a few for the following one to find.
+
+After `tofu destroy` returns, every node is terminated, so every volume of this
+cluster is unambiguously detached and there is no in-flight state left to race.
+The same three filters apply — `available`, tagged
+`kubernetes.io/cluster/<name>=owned`, and tagged
+`kubernetes.io/created-for/pvc/name` — so it can neither touch a second live
+cluster's storage nor a hand-made volume.
+
+Run it by hand if you tore the cluster down some other way. It is a dry run
+unless you pass `--apply`:
+
+```bash
+./scripts/aws-sweep-orphaned-volumes.sh --cluster-name aws-0 --region eu-west-3
+```
+
+GCP has the same step as `stage2-sweep-orphaned-disks` — see the
+[GCP teardown]({{< relref "/docs/get-started/gcp/teardown.md" >}}).
 
 ## What is not deleted
 

--- a/website/content/docs/guides/restore-a-database.md
+++ b/website/content/docs/guides/restore-a-database.md
@@ -90,18 +90,34 @@ This is not an edge case. The backup bucket **outlives the cluster on purpose**
 individual cluster"*), so on every rebuild the destination still holds the
 previous cluster's archive and the bootstrap refuses.
 
-Having confirmed the dated seed is complete:
+`scripts/cnpg-prepare-restore.sh` does this with the guard that makes it safe —
+it refuses unless the dated seed actually holds a base backup, so the live
+archive is never cleared when there would be nothing to restore from:
 
 ```bash
-gcloud storage rm --recursive \
-  gs://<project>-ogenki-cnpg-backups/xplane-zitadel-cnpg-cluster/
+./scripts/cnpg-prepare-restore.sh --cloud gcp --project <project> \
+  --bucket <project>-ogenki-cnpg-backups \
+  --cluster xplane-zitadel-cnpg-cluster --seed zitadel-20260828      # dry run
+# ... then --apply
+```
+
+It distinguishes *could not check* from *empty*: if the listing fails — a stale
+credential is the usual cause — it refuses and says so, rather than reporting an
+absent seed and inviting you to proceed.
+
+On `aws-0` this step has always been done by hand before a rebuild, which is why
+restores work there; the script is the same operation with the check attached:
+
+```bash
+./scripts/cnpg-prepare-restore.sh --cloud aws --region <region> \
+  --bucket <region>-ogenki-cnpg-backups \
+  --cluster xplane-zitadel-cnpg-cluster --seed zitadel-20260719
 ```
 
 The durable fix is a per-generation `serverName` in the `SQLInstance`
-Composition, which would remove this step on both clouds. Until then it is
-manual, and **`aws-0` carries the identical exposure** — it restores from
-`zitadel-20260719` into a bucket that also survives its cluster, so its next
-rebuild will refuse in exactly the same way.
+Composition, which would remove the step on both clouds. Until then it is a
+normal part of restoring — on `aws-0` it has always been done, just never
+written down.
 
 ## 3. Force the bootstrap
 


### PR DESCRIPTION
Two AWS teardown gaps, both surfaced while writing the GCP counterparts down.

## The volume leak is a timing bug, not a missing sweep

`eks-prepare-destroy.sh` has always swept orphaned EBS volumes — but it runs
**before** `tofu destroy`, moments after deleting the PVCs. A volume still
detaching is not yet `available`, so it is skipped. The script even says so:

> may still be detaching — the next run retries

The next *run* is the next **teardown**, a whole rebuild away. A volume a second
late to detach bills for that entire gap, and forever if the cluster is never
rebuilt. That is the shape of the accumulation: **62 volumes (~518 GiB) by
2026-07**, each teardown leaving a few for the following one to find.

`stage3-sweep-orphaned-volumes` runs *after* the destroy returns, when every node
is terminated and every volume of the cluster is unambiguously detached — no
in-flight state left to race. That late moment is the fix.

Safety is unchanged from the existing sweep — the same three filters, all
required:

| filter | prevents |
|---|---|
| `status=available` | detaching or deleting anything in use |
| `tag:kubernetes.io/cluster/<name>=owned` | touching a second live cluster in the region |
| `tag-key:kubernetes.io/created-for/pvc/name` | touching a hand-made or root volume |

## The restore step was tribal knowledge

CloudNativePG refuses to start a restored cluster whose **destination** WAL
archive is non-empty (`Expected empty archive`), and the backup buckets here
outlive their clusters *on purpose* — so the destination is never empty on a
rebuild. Clearing it is a normal part of restoring, not an incident: on `aws-0`
it has always been done by hand, which is why restores work there. `gcp-0`
rediscovered it the hard way with three failed recovery Jobs.

`scripts/cnpg-prepare-restore.sh` is that step with the check that makes it safe:
**it refuses unless the dated seed actually holds a base backup**, so the live
archive is never cleared when there would be nothing to restore from.

It also distinguishes *could not check* from *empty*. That is not hypothetical —
an expired `gcloud` token produced "the seed has no base backup" for a seed
holding three while this was being tested. A variant that trusted such a count
would clear an archive believing a seed existed.

## Correction

`security/base/zitadel/sqlinstance.yaml` claimed `aws-0` "will refuse" on its
next rebuild. It will not — the step is already part of how rebuilds are done
there. The comment now says what is actually true, and points at the script.

## Verification

| claim | evidence |
|---|---|
| sweep runs, CLI call well-formed | `aws-sweep-orphaned-volumes.sh --cluster-name aws-0 --region eu-west-3` → `No orphaned CSI volumes`. True negative: the region holds **0** volumes of any kind |
| wired into the right script | `terramate script info destroy` lists it as the last job of `eks/init` |
| manifests | `validate-manifests.sh` → `Valid: 2126, Invalid: 0, Skipped: 0`, all gates passed |
| docs | `validate-links.sh` and `validate-doc-claims.sh` both pass (7 claims / 12 page checks) |
| scripts | `shellcheck -S warning` clean on all three; `terramate fmt` clean |

**Deletion itself is unproven** — it needs a real teardown with volumes present
to exercise. The dry run only proves the query is well-formed against a clean
account.
