### PR TITLE
fix: count objects, not base backups, when deciding if a WAL archive is empty

### DIFF
--- a/scripts/cnpg-prepare-restore.sh
+++ b/scripts/cnpg-prepare-restore.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# Clear a CloudNativePG cluster's live WAL archive, so a restore can bootstrap.
+# Clear a CloudNativePG cluster's live WAL archive, so a new cluster can start.
 #
 # WHY THIS STEP EXISTS AT ALL
 #
-# CloudNativePG refuses to start a restored cluster whose DESTINATION archive is
-# non-empty -- a restore opens a new timeline that would collide with the WALs
+# CloudNativePG refuses to start a cluster whose DESTINATION archive is not
+# empty -- a new cluster opens a new timeline that would collide with the WALs
 # already there:
 #
 #   barman-cloud-check-wal-archive: WAL archive check failed for server
@@ -13,24 +13,49 @@
 #
 # And the backup buckets here outlive their clusters ON PURPOSE, so the
 # destination is never empty on a rebuild. Clearing it is therefore a normal part
-# of restoring, not an incident -- it is what an operator already does by hand
-# before an aws-0 rebuild.
+# of rebuilding, not an incident -- it is what an operator already does by hand
+# before an aws-0 rebuild, for every `*-cnpg-cluster/` prefix.
+#
+# This applies to a cluster that bootstraps EMPTY (initdb) just as much as to one
+# that restores: the check is about the destination, not about where the data
+# comes from. On aws-0 that is three clusters, only two of which restore.
 #
 # This script is that step, with the check that makes it safe to run.
 #
-# THE CHECK, WHICH IS THE WHOLE POINT
+# TWO DIFFERENT QUESTIONS, TWO DIFFERENT PREDICATES
 #
-# It refuses unless the dated seed exists AND contains at least one base backup.
+# The seed and the live archive are counted differently, and conflating them is
+# the bug this script had on its first day:
+#
+#   SEED  "is there something to restore from?"  -> count BASE BACKUPS.
+#         A seed with WALs but no base/ is unusable; a restore reads base/.
+#
+#   LIVE  "will barman's check refuse?"          -> count ANY OBJECT.
+#         The check is about the WAL archive. A live prefix holding six WALs and
+#         no base/ still refuses -- and a base-backup count calls it "empty".
+#
+# Found on 2026-08-29 preparing an aws-0 rebuild: xplane-zitadel-cnpg-cluster/
+# held wals/ and nothing else, and this script reported "already empty; nothing
+# to clear" for an archive that would have failed the bootstrap.
+#
+# THE GUARD, WHICH IS THE WHOLE POINT
+#
+# With --seed, it refuses unless that seed contains at least one base backup.
 # Clearing the live prefix while the seed is absent or half-copied destroys the
 # only copy of the database with nothing to restore from -- the one way this
 # operation can go badly, and the reason it should not be a bare `rm -r` typed
 # from memory.
+#
+# A cluster that bootstraps empty has no seed and therefore no such protection:
+# clearing its archive discards its only backup. That case needs
+# --accept-data-loss, spelled out, rather than an omitted flag.
 #
 # It never touches the seed, only the live cluster prefix.
 #
 # Usage:
 #   cnpg-prepare-restore.sh --cloud gcp --bucket B --cluster C --seed zitadel-20260828 [--project ID] [--apply]
 #   cnpg-prepare-restore.sh --cloud aws --bucket B --cluster C --seed zitadel-20260719 [--region R] [--profile P] [--apply]
+#   cnpg-prepare-restore.sh --cloud aws --bucket B --cluster C --accept-data-loss [--apply]   # bootstraps empty
 #
 # Dry-run unless --apply.
 
@@ -41,41 +66,47 @@ set -o pipefail
 CLOUD="" BUCKET="" CLUSTER="" SEED="" PROJECT="" PROFILE=""
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
 APPLY="false"
+ACCEPT_LOSS="false"
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --cloud)   CLOUD="$2"; shift 2 ;;
-        --bucket)  BUCKET="$2"; shift 2 ;;
-        --cluster) CLUSTER="$2"; shift 2 ;;
-        --seed)    SEED="$2"; shift 2 ;;
-        --project) PROJECT="$2"; shift 2 ;;
-        --region)  REGION="$2"; shift 2 ;;
-        --profile) PROFILE="$2"; shift 2 ;;
-        --apply)   APPLY="true"; shift ;;
+        --cloud)             CLOUD="$2"; shift 2 ;;
+        --bucket)            BUCKET="$2"; shift 2 ;;
+        --cluster)           CLUSTER="$2"; shift 2 ;;
+        --seed)              SEED="$2"; shift 2 ;;
+        --project)           PROJECT="$2"; shift 2 ;;
+        --region)            REGION="$2"; shift 2 ;;
+        --profile)           PROFILE="$2"; shift 2 ;;
+        --apply)             APPLY="true"; shift ;;
+        --accept-data-loss)  ACCEPT_LOSS="true"; shift ;;
         *) echo "unknown argument: $1" >&2; exit 2 ;;
     esac
 done
 
-for v in CLOUD BUCKET CLUSTER SEED; do
+for v in CLOUD BUCKET CLUSTER; do
     [ -n "${!v}" ] || { echo "--${v,,} is required" >&2; exit 2; }
 done
 case "$CLOUD" in aws|gcp) ;; *) echo "--cloud must be aws or gcp" >&2; exit 2 ;; esac
 
-# Count base backups under a prefix. The base/ directory is what a restore
-# actually reads, so an empty one means the seed is unusable even if WALs happen
-# to be present.
-#
+if [ -z "$SEED" ] && [ "$ACCEPT_LOSS" != "true" ]; then
+    echo "--seed is required, or --accept-data-loss if this cluster bootstraps" >&2
+    echo "empty. Without a seed there is nothing to restore from, so clearing the" >&2
+    echo "archive discards this database's only backup -- say so explicitly." >&2
+    exit 2
+fi
+
 # "COULD NOT CHECK" IS NOT "EMPTY", and conflating them is dangerous in exactly
-# one direction. An expired auth token makes the listing fail; if that is read as
+# one direction. An expired auth token makes a listing fail; if that is read as
 # "no backups" the script either refuses a restore that would have been fine, or
-# -- far worse in a variant that trusted the live count -- clears an archive
-# believing a seed exists. So the CLI's own exit status decides, stderr is kept,
-# and a failure is reported as a failure. Hit for real while testing this: a
-# stale gcloud token produced "the seed has no base backup" for a seed holding
-# three.
+# -- far worse -- clears an archive believing a seed exists. So the CLI's own
+# exit status decides, stderr is kept, and a failure is reported as a failure.
+# Hit for real while testing this: a stale gcloud token produced "the seed has no
+# base backup" for a seed holding three.
 #
-# Echoes either a count, or the literal string `ERROR` followed by the CLI's
+# Both counters echo either a number, or the literal `ERROR` with the CLI's
 # message on stderr.
+
+# SEED predicate: base backups, which is what a restore actually reads.
 count_bases() {
     local prefix="$1" out rc
     case "$CLOUD" in
@@ -103,42 +134,74 @@ count_bases() {
     esac
 }
 
+# LIVE predicate: any object at all, because barman's check is about the WAL
+# archive. Counting base backups here would call a wals/-only prefix empty.
+count_objects() {
+    local prefix="$1" out rc
+    case "$CLOUD" in
+        gcp)
+            out=$(gcloud storage ls "gs://${BUCKET}/${prefix}/**" ${PROJECT:+--project "$PROJECT"} 2>&1)
+            rc=$?
+            if [ "$rc" -ne 0 ]; then
+                if grep -qi "matched no objects\|not found" <<< "$out"; then echo 0; return 0; fi
+                echo "ERROR"; echo "$out" >&2; return 0
+            fi
+            grep -c '^gs://' <<< "$out" || true
+            ;;
+        aws)
+            local aws_args=(--region "$REGION")
+            [ -n "$PROFILE" ] && aws_args+=(--profile "$PROFILE")
+            out=$(aws "${aws_args[@]}" s3 ls --recursive "s3://${BUCKET}/${prefix}/" 2>&1)
+            rc=$?
+            if [ "$rc" -ne 0 ] && [ -n "$out" ]; then
+                echo "ERROR"; echo "$out" >&2; return 0
+            fi
+            grep -c . <<< "$out" || true
+            ;;
+    esac
+}
+
 echo "cloud:   ${CLOUD}"
 echo "bucket:  ${BUCKET}"
-echo "seed:    ${SEED}"
+echo "seed:    ${SEED:-<none — cluster bootstraps empty>}"
 echo "cluster: ${CLUSTER}"
 echo
 
-seed_bases=$(count_bases "$SEED")
-if [ "$seed_bases" = "ERROR" ]; then
-    echo "[REFUSED] could not list the seed -- the error above is why." >&2
-    echo "          This is NOT the same as an empty seed, and nothing was" >&2
-    echo "          deleted. A stale credential is the usual cause." >&2
-    exit 1
+if [ -n "$SEED" ]; then
+    seed_bases=$(count_bases "$SEED")
+    if [ "$seed_bases" = "ERROR" ]; then
+        echo "[REFUSED] could not list the seed -- the error above is why." >&2
+        echo "          This is NOT the same as an empty seed, and nothing was" >&2
+        echo "          deleted. A stale credential is the usual cause." >&2
+        exit 1
+    fi
+    seed_bases=${seed_bases:-0}
+    if [ "$seed_bases" -lt 1 ]; then
+        echo "[REFUSED] the seed '${SEED}' has no base backup under ${SEED}/base/." >&2
+        echo "          Clearing the live archive now would leave nothing to restore" >&2
+        echo "          from. Take a one-shot Backup and copy the cluster prefix to" >&2
+        echo "          ${SEED}/ first -- see docs/guides/restore-a-database." >&2
+        exit 1
+    fi
+    echo "[ok     ] seed holds ${seed_bases} base backup(s)"
+else
+    echo "[warn   ] no seed: this cluster bootstraps empty, so clearing its archive"
+    echo "          discards its only backup. Proceeding on --accept-data-loss."
 fi
-seed_bases=${seed_bases:-0}
-if [ "$seed_bases" -lt 1 ]; then
-    echo "[REFUSED] the seed '${SEED}' has no base backup under ${SEED}/base/." >&2
-    echo "          Clearing the live archive now would leave nothing to restore" >&2
-    echo "          from. Take a one-shot Backup and copy the cluster prefix to" >&2
-    echo "          ${SEED}/ first -- see docs/guides/restore-a-database." >&2
-    exit 1
-fi
-echo "[ok     ] seed holds ${seed_bases} base backup(s)"
 
-live_bases=$(count_bases "$CLUSTER")
-if [ "$live_bases" = "ERROR" ]; then
+live_objects=$(count_objects "$CLUSTER")
+if [ "$live_objects" = "ERROR" ]; then
     echo "[REFUSED] could not list the live archive -- see the error above." >&2
     exit 1
 fi
-live_bases=${live_bases:-0}
-if [ "$live_bases" -lt 1 ]; then
-    echo "[skip   ] live archive ${CLUSTER}/ is already empty; nothing to clear"
+live_objects=${live_objects:-0}
+if [ "$live_objects" -lt 1 ]; then
+    echo "[skip   ] live archive ${CLUSTER}/ holds no objects; nothing to clear"
     exit 0
 fi
 
 if [ "$APPLY" != "true" ]; then
-    echo "[dry-run] would delete the live archive ${CLUSTER}/ (${live_bases} base backup(s) + WALs)"
+    echo "[dry-run] would delete the live archive ${CLUSTER}/ (${live_objects} object(s))"
     echo
     echo "This was a DRY RUN. Re-run with --apply."
     exit 0
@@ -152,4 +215,4 @@ case "$CLOUD" in
         aws "${aws_args[@]}" s3 rm "s3://${BUCKET}/${CLUSTER}/" --recursive >/dev/null
         ;;
 esac
-echo "[cleared] ${CLUSTER}/ — the restore can now bootstrap from ${SEED}"
+echo "[cleared] ${CLUSTER}/ (${live_objects} object(s)) — the bootstrap can now start"

--- a/website/content/docs/guides/restore-a-database.md
+++ b/website/content/docs/guides/restore-a-database.md
@@ -90,6 +90,20 @@ This is not an edge case. The backup bucket **outlives the cluster on purpose**
 individual cluster"*), so on every rebuild the destination still holds the
 previous cluster's archive and the bootstrap refuses.
 
+{{< callout type="warning" >}}
+**It applies to clusters that bootstrap *empty* too.** The check is about the
+destination, not about where the data comes from — a brand-new `initdb` cluster
+refuses just as hard if its archive prefix is not empty. On `aws-0` that is
+three clusters, only two of which restore: `xplane-zitadel-cnpg-cluster`,
+`xplane-harbor-cnpg-cluster` and `xplane-image-gallery-cnpg-cluster`. Clear
+every `*-cnpg-cluster/` prefix before a rebuild, not only the ones with a seed.
+{{< /callout >}}
+
+And **"empty" means no objects, not no base backups.** A prefix holding only
+`wals/` still refuses. This bit us on 2026-08-29: preparing an `aws-0` rebuild,
+`xplane-zitadel-cnpg-cluster/` held six WAL objects and no `base/`, and a
+base-backup count called it empty.
+
 `scripts/cnpg-prepare-restore.sh` does this with the guard that makes it safe —
 it refuses unless the dated seed actually holds a base backup, so the live
 archive is never cleared when there would be nothing to restore from:
@@ -109,9 +123,20 @@ On `aws-0` this step has always been done by hand before a rebuild, which is why
 restores work there; the script is the same operation with the check attached:
 
 ```bash
-./scripts/cnpg-prepare-restore.sh --cloud aws --region <region> \
-  --bucket <region>-ogenki-cnpg-backups \
+B=eu-west-3-ogenki-cnpg-backups
+./scripts/cnpg-prepare-restore.sh --cloud aws --region eu-west-3 --bucket $B \
   --cluster xplane-zitadel-cnpg-cluster --seed zitadel-20260719
+./scripts/cnpg-prepare-restore.sh --cloud aws --region eu-west-3 --bucket $B \
+  --cluster xplane-harbor-cnpg-cluster  --seed harbor-20241111
+```
+
+The third one bootstraps empty, so there is no seed to protect it — clearing its
+archive discards that database's only backup. The script refuses to guess, and
+makes you say so:
+
+```bash
+./scripts/cnpg-prepare-restore.sh --cloud aws --region eu-west-3 --bucket $B \
+  --cluster xplane-image-gallery-cnpg-cluster --accept-data-loss
 ```
 
 The durable fix is a per-generation `serverName` in the `SQLInstance`


### PR DESCRIPTION
Found while running the preflight for today's `aws-0` rebuild — the script asked
the wrong question about the live archive.

## The bug

The seed and the destination need **different predicates**:

| side | question | correct predicate |
|---|---|---|
| seed | is there something to restore *from*? | **base backups** — a restore reads `base/` |
| live | will barman's check *refuse*? | **any object** — the check is about the WAL archive |

It used the seed's predicate for both. So `xplane-zitadel-cnpg-cluster/`, which
holds **six WAL objects and no `base/`**, came back as:

```
[skip   ] live archive xplane-zitadel-cnpg-cluster/ is already empty; nothing to clear
```

…for an archive that would have failed the bootstrap with exactly the error this
script exists to prevent. It now reports `6 object(s)` to delete.

## The second half

The check is about the **destination**, not about where the data comes from — so
a cluster that bootstraps *empty* (`initdb`) refuses just as hard. `aws-0` has
three archive prefixes and only two seeds:

| cluster | seed | live objects |
|---|---|---|
| `xplane-zitadel-cnpg-cluster` | `zitadel-20260719` (10 bases) | 6 |
| `xplane-harbor-cnpg-cluster` | `harbor-20241111` (4 bases) | 19 |
| `xplane-image-gallery-cnpg-cluster` | **none** | 16 |

Clearing an archive with no seed behind it discards that database's only backup,
so the script now refuses to guess — that case needs `--accept-data-loss`
spelled out rather than a flag left off.

## Verification

Against the real bucket `eu-west-3-ogenki-cnpg-backups`:

```
zitadel        seed 10 bases, live 6 objects   -> would delete   (was: "already empty")
harbor         seed  4 bases, live 19 objects  -> would delete
image-gallery  no seed                         -> refuses without the flag; 16 objects with it
bogus bucket                                   -> [REFUSED] could not list, exit 1, nothing deleted
```

`shellcheck -S warning` clean, `validate-links.sh` passes.
