### PR TITLE
fix(aws-0): the approle ExternalSecret asked for a key nothing creates

### DIFF
--- a/security/aws-0/openbao/openbao-approle-externalsecret.yaml
+++ b/security/aws-0/openbao/openbao-approle-externalsecret.yaml
@@ -6,8 +6,23 @@ metadata:
 spec:
   dataFrom:
     - extract:
+        # SLASHES, not hyphens. This key must equal what OpenTofu actually
+        # writes: `cert_manager_approle_secret_name` in opentofu/config.tm.hcl,
+        # stored by opentofu/aws/openbao/management/secrets.tf.
+        #
+        # It was hyphenated when this overlay was split out (#1886), applying
+        # gcp-0's naming convention to the AWS lane. GCP needs hyphens because
+        # Secret Manager forbids `/` in a secret name; AWS Secrets Manager does
+        # not, and nothing on this side creates the hyphenated name. External
+        # Secrets then reports `Secret does not exist`, which reads like a
+        # missing secret rather than a wrong key -- and because cert-manager's
+        # ClusterIssuer waits on it, the whole `security-openbao` Kustomization
+        # stalls and every Kustomization downstream of it reports only
+        # "dependency not ready". Cost a from-scratch bootstrap on 2026-08-29.
+        #
+        # Its sibling openbao-ca-externalsecret.yaml uses slashes too.
         conversionStrategy: Default
-        key: openbao-cloud-native-ref-approles-cert-manager
+        key: openbao/cloud-native-ref/approles/cert-manager
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore


### PR DESCRIPTION
A from-scratch `aws-0` bootstrap stalled at **16 of 29** Kustomizations Ready, with every remaining one reporting only `dependency 'flux-system/security-openbao' is not ready`. The real error was one event deep:

```
UpdateFailed externalsecret/cert-manager-bao-approle
error processing spec.dataFrom[0].extract, err: Secret does not exist
```

The secret does exist. The **key** was wrong:

| | name |
|---|---|
| asked for | `openbao-cloud-native-ref-approles-cert-manager` (hyphens) |
| written by OpenTofu | `openbao/cloud-native-ref/approles/cert-manager` (slashes) |

`cert_manager_approle_secret_name` in `opentofu/config.tm.hcl` is slashed, and `opentofu/aws/openbao/management/secrets.tf` stores it under exactly that name — verified present in Secrets Manager, updated 10:47 today by this very deploy.

The hyphenated form arrived when this overlay was split out of the shared base (#1886) and `gcp-0`'s naming convention came with it. GCP needs hyphens because Secret Manager forbids `/` in a secret name; **AWS Secrets Manager does not** — which is why the sibling `openbao-ca-externalsecret.yaml` uses slashes on this side and syncs fine. Two ExternalSecrets in one directory disagreed, and only one was right.

### Why it was expensive to find

Nothing failed loudly. External Secrets says *"Secret does not exist"*, which reads as a missing secret rather than a wrong key. cert-manager's ClusterIssuer waits on the Secret, `security-openbao` never goes Ready, and a dozen downstream Kustomizations report a dependency problem that isn't theirs. The one true error is invisible unless you read events in the `security` namespace.

The comment now in the file records which side owns the name, so the next portability pass doesn't rename it again.

Verified: `./scripts/validate-manifests.sh` → `Valid: 2126, Invalid: 0, Skipped: 0`, all gates passed.