### PR TITLE
docs: an initdb cluster does not refuse — it loses its backups quietly

### DIFF
--- a/website/content/docs/guides/restore-a-database.md
+++ b/website/content/docs/guides/restore-a-database.md
@@ -76,7 +76,7 @@ Then point the claim at it — `security/gcp-0/zitadel/kustomization.yaml`:
 **Clear the live archive first, or the restore will not start.**
 {{< /callout >}}
 
-CloudNativePG refuses to start a restored cluster whose **destination** WAL
+CloudNativePG refuses to start a **restored** cluster whose destination WAL
 archive is non-empty — a restore opens a new timeline that would collide with the
 WALs already there:
 
@@ -91,12 +91,25 @@ individual cluster"*), so on every rebuild the destination still holds the
 previous cluster's archive and the bootstrap refuses.
 
 {{< callout type="warning" >}}
-**It applies to clusters that bootstrap *empty* too.** The check is about the
-destination, not about where the data comes from — a brand-new `initdb` cluster
-refuses just as hard if its archive prefix is not empty. On `aws-0` that is
-three clusters, only two of which restore: `xplane-zitadel-cnpg-cluster`,
-`xplane-harbor-cnpg-cluster` and `xplane-image-gallery-cnpg-cluster`. Clear
-every `*-cnpg-cluster/` prefix before a rebuild, not only the ones with a seed.
+**A cluster that bootstraps *empty* fails differently, and worse.** The check is
+about the destination, not about where the data comes from — but an `initdb`
+cluster does **not** refuse to start. It starts, reports `Ready`, Flux goes
+green, and only continuous WAL archiving fails:
+
+```
+Initialized=True: Cluster has been bootstrapped
+Ready=True:       Cluster is Ready
+ContinuousArchiving=False: unexpected failure invoking barman-cloud-wal-archive
+```
+
+with the same `Expected empty archive` underneath. The cluster runs happily
+**with no backups**, and nothing surfaces it — so clear every `*-cnpg-cluster/`
+prefix before a rebuild, not only the ones with a seed.
+
+Measured on 2026-08-29. `aws-0` had all three archives cleared and all three
+clusters report `ContinuousArchiving=True`; `gcp-0` had harbor's left in place
+(69 objects) and it alone reports `False`, while looking healthy in every other
+respect.
 {{< /callout >}}
 
 And **"empty" means no objects, not no base backups.** A prefix holding only


### PR DESCRIPTION
The restore guide said a cluster bootstrapping empty *"refuses just as hard"* as a restored one when its destination WAL archive is non-empty. It doesn't — and the truth is worse.

Measured on both clusters today. `gcp-0`'s harbor bootstraps via `initdb` and its archive still held 69 objects from the previous generation:

```
Initialized=True: Cluster has been bootstrapped
Ready=True:       Cluster is Ready
ContinuousArchiving=False: unexpected failure invoking barman-cloud-wal-archive

barman-cloud-check-wal-archive: WAL archive check failed for server
xplane-harbor-cnpg-cluster: Expected empty archive
```

The cluster starts, reports `Ready`, Flux goes green — **and it has no backups**. Nothing surfaces it. A refusal to start would at least be loud.

The control is clean:

| cluster | archive cleared? | `ContinuousArchiving` |
|---|---|---|
| `aws-0` zitadel / harbor / image-gallery | yes, all three | **True** ×3 |
| `gcp-0` harbor | no — 69 objects | **False** |

That also settles a doubt about clearing `xplane-image-gallery-cnpg-cluster` on `aws-0`, which has no seed and needed `--accept-data-loss`: **it was necessary.** The reason given at the time — *"it will refuse to start"* — was wrong; the reason it was necessary is that archiving would otherwise have been silently dead.

The advice doesn't change: clear every `*-cnpg-cluster/` prefix before a rebuild, not only the ones with a seed. What changes is what you're watching for when you skip it.

`validate-links.sh` and `validate-doc-claims.sh` pass.