### PR TITLE
fix(gcp): every script that shells out to gcloud now uses ADC, from one place

### DIFF
--- a/scripts/cnpg-prepare-restore.sh
+++ b/scripts/cnpg-prepare-restore.sh
@@ -63,6 +63,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# gcloud must run as the identity OpenTofu uses, not the CLI account -- see
+# scripts/lib/gcloud-adc.sh. Without it this script reports "could not list the
+# live archive" for a bucket the deploy writes to happily.
+# shellcheck source=scripts/lib/gcloud-adc.sh
+. "$(dirname "$0")/lib/gcloud-adc.sh"
+
 CLOUD="" BUCKET="" CLUSTER="" SEED="" PROJECT="" PROFILE=""
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
 APPLY="false"
@@ -111,7 +117,7 @@ count_bases() {
     local prefix="$1" out rc
     case "$CLOUD" in
         gcp)
-            out=$(gcloud storage ls "gs://${BUCKET}/${prefix}/base/" ${PROJECT:+--project "$PROJECT"} 2>&1)
+            out=$(gcp_gcloud storage ls "gs://${BUCKET}/${prefix}/base/" ${PROJECT:+--project "$PROJECT"} 2>&1)
             rc=$?
             # `ls` on a missing prefix is a legitimate "zero", not a failure.
             if [ "$rc" -ne 0 ]; then
@@ -140,7 +146,7 @@ count_objects() {
     local prefix="$1" out rc
     case "$CLOUD" in
         gcp)
-            out=$(gcloud storage ls "gs://${BUCKET}/${prefix}/**" ${PROJECT:+--project "$PROJECT"} 2>&1)
+            out=$(gcp_gcloud storage ls "gs://${BUCKET}/${prefix}/**" ${PROJECT:+--project "$PROJECT"} 2>&1)
             rc=$?
             if [ "$rc" -ne 0 ]; then
                 if grep -qi "matched no objects\|not found" <<< "$out"; then echo 0; return 0; fi
@@ -208,7 +214,7 @@ if [ "$APPLY" != "true" ]; then
 fi
 
 case "$CLOUD" in
-    gcp) gcloud storage rm --recursive "gs://${BUCKET}/${CLUSTER}/" ${PROJECT:+--project "$PROJECT"} >/dev/null ;;
+    gcp) gcp_gcloud storage rm --recursive "gs://${BUCKET}/${CLUSTER}/" ${PROJECT:+--project "$PROJECT"} >/dev/null ;;
     aws)
         aws_args=(--region "$REGION")
         [ -n "$PROFILE" ] && aws_args+=(--profile "$PROFILE")

--- a/scripts/gcp-purge-dns-records.sh
+++ b/scripts/gcp-purge-dns-records.sh
@@ -33,6 +33,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# gcloud must run as the identity OpenTofu uses, not the CLI account.
+# shellcheck source=scripts/lib/gcloud-adc.sh
+. "$(dirname "$0")/lib/gcloud-adc.sh"
+
 ZONE="${1:-}"
 PROJECT="${2:-}"
 
@@ -41,13 +45,13 @@ if [ -z "$ZONE" ] || [ -z "$PROJECT" ]; then
     exit 2
 fi
 
-if ! gcloud dns managed-zones describe "$ZONE" --project "$PROJECT" >/dev/null 2>&1; then
+if ! gcp_gcloud dns managed-zones describe "$ZONE" --project "$PROJECT" >/dev/null 2>&1; then
     echo "Cloud DNS zone '${ZONE}' does not exist — nothing to purge."
     exit 0
 fi
 
 # name<TAB>type, apex NS/SOA excluded.
-records=$(gcloud dns record-sets list \
+records=$(gcp_gcloud dns record-sets list \
     --zone "$ZONE" --project "$PROJECT" \
     --format='value[separator="	"](name,type)' 2>/dev/null \
     | awk -F'\t' '$2 != "NS" && $2 != "SOA"')
@@ -63,7 +67,7 @@ echo "Purging ${count} record set(s) from '${ZONE}' so the zone can be destroyed
 failed=0
 while IFS=$'\t' read -r name type; do
     [ -z "$name" ] && continue
-    if gcloud dns record-sets delete "$name" --type "$type" \
+    if gcp_gcloud dns record-sets delete "$name" --type "$type" \
          --zone "$ZONE" --project "$PROJECT" >/dev/null 2>&1; then
         echo "  deleted  ${type} ${name}"
     else

--- a/scripts/gcp-sweep-orphaned-disks.sh
+++ b/scripts/gcp-sweep-orphaned-disks.sh
@@ -48,6 +48,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# gcloud must run as the identity OpenTofu uses, not the CLI account.
+# shellcheck source=scripts/lib/gcloud-adc.sh
+. "$(dirname "$0")/lib/gcloud-adc.sh"
+
 PROJECT=""
 APPLY="false"
 
@@ -64,7 +68,7 @@ done
 # `-users:*` is the unattached filter. The description match cannot be expressed
 # in a --filter reliably (it is a JSON blob), so it is checked per disk below.
 mapfile -t CANDIDATES < <(
-    gcloud compute disks list --project "$PROJECT" \
+    gcp_gcloud compute disks list --project "$PROJECT" \
         --filter="-users:*" \
         --format='value(name,zone,sizeGb)' 2>/dev/null || true
 )
@@ -83,7 +87,7 @@ for row in "${CANDIDATES[@]}"; do
     # zone comes back as a URL; the basename is what the delete call wants.
     zone="${zone##*/}"
 
-    desc=$(gcloud compute disks describe "$name" --project "$PROJECT" --zone "$zone" \
+    desc=$(gcp_gcloud compute disks describe "$name" --project "$PROJECT" --zone "$zone" \
              --format='value(description)' 2>/dev/null || true)
 
     if ! grep -q "pd.csi.storage.gke.io" <<< "$desc"; then
@@ -108,7 +112,7 @@ except Exception:
         continue
     fi
 
-    if gcloud compute disks delete "$name" --project "$PROJECT" --zone "$zone" --quiet >/dev/null 2>&1; then
+    if gcp_gcloud compute disks delete "$name" --project "$PROJECT" --zone "$zone" --quiet >/dev/null 2>&1; then
         echo "[deleted] ${name} (${size}GB, ${zone}) — was ${pvc}"
         swept=$((swept + 1))
     else

--- a/scripts/harbor-oidc.sh
+++ b/scripts/harbor-oidc.sh
@@ -36,6 +36,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# gcloud must run as the identity OpenTofu uses, not the CLI account.
+# shellcheck source=scripts/lib/gcloud-adc.sh
+. "$(dirname "$0")/lib/gcloud-adc.sh"
+
 COMMAND="${1:-}"
 [ $# -gt 0 ] && shift
 
@@ -82,7 +86,7 @@ store_read() {
         aws) aws secretsmanager get-secret-value --secret-id "$1" \
                  ${REGION:+--region "$REGION"} \
                  --query SecretString --output text 2>/dev/null ;;
-        gcp) gcloud secrets versions access latest --secret="$1" \
+        gcp) gcp_gcloud secrets versions access latest --secret="$1" \
                  ${GCP_PROJECT:+--project "$GCP_PROJECT"} 2>/dev/null ;;
         *)   echo "unknown cloud: $CLOUD" >&2; return 1 ;;
     esac

--- a/scripts/lib/gcloud-adc.sh
+++ b/scripts/lib/gcloud-adc.sh
@@ -1,0 +1,66 @@
+# shellcheck shell=bash
+#
+# Run gcloud as the SAME identity OpenTofu uses.
+#
+# Source this and call gcp_gcloud instead of gcloud:
+#
+#   . "$(dirname "$0")/lib/gcloud-adc.sh"
+#   gcp_gcloud storage ls "gs://${BUCKET}/"
+#
+# WHY THIS EXISTS
+#
+# Everything that builds this platform on GCP authenticates with Application
+# Default Credentials -- the google provider, the GCS state backend, the GKE
+# calls. Scripts that shell out to plain `gcloud` do not: they use the CLI
+# account from `gcloud config get-value account`. Two identities, one workflow,
+# and nothing says so until one of them is missing a grant.
+#
+# On 2026-08-29 that cost most of a day. A `gcloud auth login` had filed a
+# personal-account credential under a Workspace name, so every stored credential
+# resolved to an account with NO bindings on the project, while ADC was the
+# project Owner. Errors read
+#
+#   [smaine.kahlouch@ogenki.io] does not have permission ...
+#   smaine.kahlouch@gmail.com does not have storage.objects.list access
+#
+# -- gcloud printing the configured label while Google evaluated a different
+# token. It broke openbao-config.sh mid-deploy and cnpg-prepare-restore.sh after
+# it, both with permission errors that pointed at IAM rather than at the CLI.
+#
+# CLOUDSDK_AUTH_ACCESS_TOKEN makes gcloud use a token we hand it. When ADC is not
+# configured we fall back to the CLI account, which is the old behaviour and
+# still correct on a workstation that only ever runs `gcloud auth login`.
+#
+# Factored out rather than copied per script: this repository has already learned
+# what happens to a snippet duplicated across files -- the GCP opt-in gate became
+# fifteen hand-written copies and four scripts silently missed it.
+
+_gcloud_adc_token=""
+_gcloud_adc_resolved="false"
+
+gcp_gcloud() {
+    if [ "$_gcloud_adc_resolved" = "false" ]; then
+        _gcloud_adc_token=$(gcloud auth application-default print-access-token 2>/dev/null || true)
+        _gcloud_adc_resolved="true"
+    fi
+    if [ -n "$_gcloud_adc_token" ]; then
+        CLOUDSDK_AUTH_ACCESS_TOKEN="$_gcloud_adc_token" gcloud "$@"
+    else
+        gcloud "$@"
+    fi
+}
+
+# Say which identity is in play, ON STDERR.
+#
+# The redirect is load-bearing: callers capture gcp_gcloud's stdout as data --
+# a secret value, a bucket listing -- and a log line written to stdout lands
+# inside it. That put a timestamped line into .tls/ca.pem once already, where it
+# failed TLS verification in a way that pointed at the certificate rather than at
+# the logging.
+gcp_gcloud_identity() {
+    if [ -n "$_gcloud_adc_token" ]; then
+        echo "using Application Default Credentials (same identity as OpenTofu)" >&2
+    else
+        echo "no Application Default Credentials; using the gcloud CLI account" >&2
+    fi
+}

--- a/scripts/openbao-config.sh
+++ b/scripts/openbao-config.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# shellcheck source=scripts/lib/gcloud-adc.sh
+. "$(dirname "$0")/lib/gcloud-adc.sh"
+
 # This script is used to configure OpenBao. It supports two operations:
 # - init: Initialize the OpenBao cluster, then store the root token and the
 #         recovery keys in two SEPARATE secret store entries (AWS Secrets
@@ -217,46 +220,10 @@ check_openbao_status() {
     return 1
 }
 
-# Run gcloud as the SAME identity OpenTofu uses.
-#
-# Everything else in the GCP lane authenticates with Application Default
-# Credentials -- the google provider, the GCS state backend, the GKE calls. This
-# script was the one exception: it shelled out to plain `gcloud`, which uses the
-# *CLI account* (`gcloud config get-value account`) instead. Two identities, one
-# deploy, and nothing says so until one of them is missing a grant.
-#
-# That is exactly how it failed on 2026-08-29. A fresh `gcloud auth login` left
-# the CLI account without `secretmanager.versions.access` on ogenki-435905, so
-# `openbao-config.sh ca` died with PERMISSION_DENIED reading the CA chain --
-# while ADC could read the very same secret (HTTP 200). The deploy had already
-# created the network, the OpenBao VM and GKE using ADC, so "no permission" was
-# true and misleading at the same time.
-#
-# CLOUDSDK_AUTH_ACCESS_TOKEN makes gcloud use a token we hand it. If ADC is not
-# configured we fall back to the CLI account, which is the old behaviour and
-# still right on a workstation that only ever uses `gcloud auth login`.
-# The log lines below go to STDERR deliberately: gcp_gcloud is called from
-# secret_read, whose STDOUT *is* the secret value. Logging to stdout here put
-# a timestamped log line inside .tls/ca.pem, which then fails TLS verification
-# in a way that points at the certificate rather than at this function.
-_gcloud_adc_token=""
-_gcloud_adc_resolved="false"
-gcp_gcloud() {
-    if [ "$_gcloud_adc_resolved" = "false" ]; then
-        _gcloud_adc_token=$(gcloud auth application-default print-access-token 2>/dev/null || true)
-        _gcloud_adc_resolved="true"
-        if [ -n "$_gcloud_adc_token" ]; then
-            log_message "INFO" "Using Application Default Credentials for Secret Manager (same identity as OpenTofu)" >&2
-        else
-            log_message "INFO" "No Application Default Credentials; falling back to the gcloud CLI account" >&2
-        fi
-    fi
-    if [ -n "$_gcloud_adc_token" ]; then
-        CLOUDSDK_AUTH_ACCESS_TOKEN="$_gcloud_adc_token" gcloud "$@"
-    else
-        gcloud "$@"
-    fi
-}
+# gcloud runs as the identity OpenTofu uses -- see scripts/lib/gcloud-adc.sh
+# for why, and for the 2026-08-29 failure that made it necessary. This was a
+# private copy here first; it moved to lib/ once six more scripts turned out to
+# need exactly the same thing.
 
 # Write a secret value, creating the secret if it does not exist. Dispatches
 # on $CLOUD so init_openbao() and write_ca() don't need to know which backend

--- a/scripts/secret-store.sh
+++ b/scripts/secret-store.sh
@@ -57,6 +57,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# gcloud must run as the identity OpenTofu uses, not the CLI account.
+# shellcheck source=scripts/lib/gcloud-adc.sh
+. "$(dirname "$0")/lib/gcloud-adc.sh"
+
 CLOUD=""
 CONTEXT=""
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
@@ -85,7 +89,7 @@ aws_sm() {
 }
 
 gcp_sm() {
-    if [ -n "$PROJECT" ]; then gcloud secrets --project "$PROJECT" "$@"; else gcloud secrets "$@"; fi
+    if [ -n "$PROJECT" ]; then gcp_gcloud secrets --project "$PROJECT" "$@"; else gcp_gcloud secrets "$@"; fi
 }
 
 # Does one key exist in the store?
@@ -125,7 +129,7 @@ store_has() {
     echo >&2
     echo "Refusing to continue: an unreachable store is not an empty one." >&2
     [ "$CLOUD" = "aws" ] && echo "Hint: pass --region (aws configure get region is empty here)." >&2
-    [ "$CLOUD" = "gcp" ] && echo "Hint: pass --project, or set one with gcloud config set project." >&2
+    [ "$CLOUD" = "gcp" ] && echo "Hint: pass --project, or set one with gcp_gcloud config set project." >&2
     exit 1
 }
 
@@ -598,7 +602,7 @@ cmd_grant() {
     [ -n "$PROJECT" ] || { echo "--project is required" >&2; exit 2; }
 
     local number
-    number=$(gcloud projects describe "$PROJECT" --format='value(projectNumber)' 2>/dev/null)
+    number=$(gcp_gcloud projects describe "$PROJECT" --format='value(projectNumber)' 2>/dev/null)
     [ -n "$number" ] || { echo "could not read the project number for ${PROJECT}" >&2; exit 1; }
 
     local principal="principal://iam.googleapis.com/projects/${number}/locations/global/workloadIdentityPools/${PROJECT}.svc.id.goog/subject/ns/security/sa/external-secrets"
@@ -612,7 +616,7 @@ cmd_grant() {
     local granted=0 absent=0 failed=0
     while read -r key; do
         [ -z "$key" ] && continue
-        if ! gcloud secrets describe "$key" --project "$PROJECT" >/dev/null 2>&1; then
+        if ! gcp_gcloud secrets describe "$key" --project "$PROJECT" >/dev/null 2>&1; then
             # Not an error here: `check` is what reports missing secrets. A key
             # containing "/" cannot exist in GCP at all -- see ADR-0023.
             echo "[absent ] ${key}"
@@ -624,7 +628,7 @@ cmd_grant() {
             granted=$((granted + 1))
             continue
         fi
-        if gcloud secrets add-iam-policy-binding "$key" --project "$PROJECT" \
+        if gcp_gcloud secrets add-iam-policy-binding "$key" --project "$PROJECT" \
              --member "$principal" --role roles/secretmanager.secretAccessor >/dev/null 2>&1; then
             echo "[granted] ${key}"
             granted=$((granted + 1))

--- a/scripts/zitadel-idp.sh
+++ b/scripts/zitadel-idp.sh
@@ -54,6 +54,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# gcloud must run as the identity OpenTofu uses, not the CLI account.
+# shellcheck source=scripts/lib/gcloud-adc.sh
+. "$(dirname "$0")/lib/gcloud-adc.sh"
+
 COMMAND="${1:-}"
 [ $# -gt 0 ] && shift
 
@@ -104,7 +108,7 @@ store_read() {
         aws) aws secretsmanager get-secret-value \
                  ${REGION:+--region "$REGION"} \
                  --secret-id "$1" --query SecretString --output text 2>/dev/null ;;
-        gcp) gcloud secrets versions access latest \
+        gcp) gcp_gcloud secrets versions access latest \
                  ${GCP_PROJECT:+--project "$GCP_PROJECT"} \
                  --secret="$1" 2>/dev/null ;;
     esac

--- a/scripts/zitadel-oidc-clients.sh
+++ b/scripts/zitadel-oidc-clients.sh
@@ -42,6 +42,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# gcloud must run as the identity OpenTofu uses, not the CLI account.
+# shellcheck source=scripts/lib/gcloud-adc.sh
+. "$(dirname "$0")/lib/gcloud-adc.sh"
+
 COMMAND="${1:-}"
 [ $# -gt 0 ] && shift
 
@@ -104,7 +108,7 @@ store_read() {
         aws) aws secretsmanager get-secret-value \
                  ${REGION:+--region "$REGION"} \
                  --secret-id "$1" --query SecretString --output text 2>/dev/null ;;
-        gcp) gcloud secrets versions access latest \
+        gcp) gcp_gcloud secrets versions access latest \
                  ${GCP_PROJECT:+--project "$GCP_PROJECT"} \
                  --secret="$1" 2>/dev/null ;;
     esac
@@ -114,7 +118,7 @@ store_exists() {
     case "$CLOUD" in
         aws) aws secretsmanager describe-secret ${REGION:+--region "$REGION"} \
                  --secret-id "$1" >/dev/null 2>&1 ;;
-        gcp) gcloud secrets describe "$1" ${GCP_PROJECT:+--project "$GCP_PROJECT"} \
+        gcp) gcp_gcloud secrets describe "$1" ${GCP_PROJECT:+--project "$GCP_PROJECT"} \
                  >/dev/null 2>&1 ;;
     esac
 }
@@ -148,11 +152,11 @@ store_write() {
             shred -u "$body" 2>/dev/null || rm -f "$body"
             ;;
         gcp)
-            store_exists "$name" || gcloud secrets create "$name" \
+            store_exists "$name" || gcp_gcloud secrets create "$name" \
                 ${GCP_PROJECT:+--project "$GCP_PROJECT"} \
                 --replication-policy=automatic \
                 --labels=managed-by=zitadel-oidc-clients >/dev/null
-            gcloud secrets versions add "$name" \
+            gcp_gcloud secrets versions add "$name" \
                 ${GCP_PROJECT:+--project "$GCP_PROJECT"} \
                 --data-file="$payload" >/dev/null
             ;;


### PR DESCRIPTION
`openbao-config.sh` got this fix earlier today (#1913). **Seven more scripts had the identical bug** and nobody had looked, so the same failure was waiting in each:

```
ERROR: (gcloud.storage.ls) [smaine.kahlouch@ogenki.io] does not have permission ...
smaine.kahlouch@gmail.com does not have storage.objects.list
```

That's gcloud printing its configured account label while Google evaluates a different token. A `gcloud auth login` had filed a personal-account credential under a Workspace name, so every stored credential resolves to an account with **no bindings** on the project — while ADC, which OpenTofu and the GCS state backend use, is the project **Owner**.

It broke `cnpg-prepare-restore.sh` in an operator's hands after breaking `openbao-config.sh` mid-deploy. The remaining five are the ones needed next: `zitadel-oidc-clients.sh`, `zitadel-idp.sh`, `harbor-oidc.sh` and `secret-store.sh` are *every step* of SSO setup, and `gcp-sweep-orphaned-disks.sh` runs during teardown.

## One helper, not seven copies

`scripts/lib/gcloud-adc.sh` defines `gcp_gcloud()` once; each script sources it. Factored out deliberately — this repository already knows what happens to a duplicated snippet: the GCP opt-in gate became fifteen hand-written copies with four scripts silently missing it, which is what `scripts/tm-provisioner.sh` was written to end. `openbao-config.sh` drops its private copy.

Where ADC isn't configured it falls back to the CLI account, so a workstation that only runs `gcloud auth login` is unaffected.

**`openbao-snapshot.sh` is deliberately not changed** — it runs inside the cluster from a CronJob and authenticates with workload identity through the metadata server. No CLI account involved.

## The stderr detail, which has bitten once

The identity log line goes to **stderr**, and the helper says why: callers capture `gcp_gcloud`'s stdout *as data* — a secret value, a bucket listing — so a line written to stdout lands inside it. That put a timestamped log line into `.tls/ca.pem` earlier today, where it failed TLS verification in a way that pointed at the certificate rather than at the logging.

## Verification

`cnpg-prepare-restore.sh` now reads the bucket that refused it minutes earlier (70 objects in `xplane-harbor-cnpg-cluster/`), and `openbao-config.sh` still writes a valid chain after losing its private copy — `openssl x509 -noout -subject` → `CN=Ogenki GCP Intermediate CA`. `shellcheck -S warning` clean across all nine scripts.