### PR TITLE
fix(teardown): make the one-command destroy safe, and pin the cleaned snapshot

### DIFF
--- a/opentofu/aws/eks/configure/workflows.tm.hcl
+++ b/opentofu/aws/eks/configure/workflows.tm.hcl
@@ -52,27 +52,35 @@ script "preview" {
   }
 }
 
+# Deliberately a no-op. This stack IS destroyed -- by eks/init's "EKS Full
+# Destroy", whose `stage2-destroy-addons` job runs `tofu destroy` in this
+# directory at the right moment.
+#
+# It used to destroy itself here, and that made `terramate script run --reverse
+# destroy` from opentofu/ unsafe. The reverse walk visits this stack FIRST
+# (stack.tm.hcl: `after = ["/opentofu/aws/eks/init"]`), so Cilium and Flux came
+# down raw: Flux never suspended, admission webhooks left admitting, PVCs,
+# NodePools and IAM access keys never cleaned. eks/init's prepare-destroy job
+# then ran against a cluster whose networking was already gone. The teardown
+# guide carried a warning telling people not to use the one command that ought
+# to work.
+#
+# Sequencing this correctly is not something the stack graph can express -- the
+# ordering the cluster needs is the opposite of the dependency ordering -- so
+# ownership sits in one place, eks/init, and this stack defers to it.
+#
+# Destroying ONLY Cilium and Flux is not a real operation anyway: it breaks
+# cluster networking and leaves an EKS cluster nothing can reconcile. If you
+# genuinely want it, run tofu directly in this directory and pass the four
+# version variables, which have no defaults.
 script "destroy" {
-  name        = "EKS Configure Destroy"
-  description = "Remove Cilium and Flux (WARNING: will break cluster networking)"
+  name        = "EKS Configure Destroy (handled by eks/init)"
+  description = "No-op: eks/init's destroy tears this stack down in the correct order"
 
   job {
     commands = [
-      # Single y/n prompt; cached for 10 min so `--reverse destroy` asks once.
-      # Bypass with TM_DESTROY_CONFIRMED=true for CI.
-      ["bash", "${terramate.root.path.fs.absolute}/scripts/tm-provisioner.sh", "--tm-run", "bash", "${terramate.root.path.fs.absolute}/scripts/terramate-destroy-confirm.sh"],
-      # `destroy` is a standalone entrypoint: unlike `deploy` it can be the first
-      # tofu command run in a stack, so it has to init itself. Without this a lock
-      # file predating a new provider fails the whole `--reverse destroy` sweep.
-      [global.provisioner, "init", "-lock-timeout=5m"],
-      # `-auto-approve`: confirmation already handled by the helper above.
-      # The version variables carry no defaults, and OpenTofu requires every
-      # variable to be set on destroy as well as on apply.
-      [global.provisioner, "destroy", "-auto-approve", "-var-file=variables.tfvars",
-        "-var=cilium_version=${global.cilium_version}",
-        "-var=gateway_api_version=${global.gateway_api_version}",
-        "-var=flux_operator_version=${global.flux_operator_version}",
-      "-var=flux_instance_version=${global.flux_instance_version}"],
+      ["echo", "[skip] eks/configure is destroyed by eks/init's `stage2-destroy-addons` job."],
+      ["echo", "       Run: cd opentofu/aws/eks/init && terramate script run destroy"],
     ]
   }
 }

--- a/security/base/zitadel/sqlinstance.yaml
+++ b/security/base/zitadel/sqlinstance.yaml
@@ -26,6 +26,17 @@ spec:
   # redirect URIs still name priv.cloud.ogenki.io and mycluster-0, which
   # is exactly the breakage this rotation exists to prevent.
   #
+  # The `-2` is a SECOND rotation the same day, and it supersedes plain
+  # zitadel-20260829: the legacy `Ogenki` project was deleted after that
+  # first snapshot was taken, so restoring from it would bring back seven
+  # apps with dead redirect URIs and role grants on a project nothing uses.
+  # Ordering was verified rather than assumed -- `project.removed` is at
+  # 19:54:29Z in the eventstore and this snapshot's newest base backup is
+  # 20260829T195453, 24s later, so the cleanup is inside it.
+  #
+  # zitadel-20260829 is deliberately left in the bucket as a fallback. Delete
+  # it once a rebuild has actually restored from this one.
+  #
   # NOTE: this was a COPY, so the live prefix is NOT empty. A restore
   # therefore still needs scripts/cnpg-prepare-restore.sh first (see the
   # expected-empty-archive note below). Earlier rotations MOVED the
@@ -77,7 +88,7 @@ spec:
   # which removes the step on both clouds. See docs/guides/restore-a-database.
   objectStoreRecovery:
     bucketName: "${region}-ogenki-cnpg-backups"
-    path: "zitadel-20260829"
+    path: "zitadel-20260829-2"
   backup:
     schedule: "0 0 * * *"
     bucketName: "${region}-ogenki-cnpg-backups"

--- a/website/content/docs/get-started/aws/teardown.md
+++ b/website/content/docs/get-started/aws/teardown.md
@@ -124,6 +124,32 @@ unless you pass `--apply`:
 GCP has the same step as `stage2-sweep-orphaned-disks` — see the
 [GCP teardown]({{< relref "/docs/get-started/gcp/teardown.md" >}}).
 
+## Verify against AWS, not against the exit code
+
+A Terramate destroy can exit 0 having destroyed nothing. The safeguards refuse
+silently, a job that fails before `tofu` runs still ends the run, and a
+backgrounded invocation reports the status of whatever came last in the pipeline.
+The GCP side [says the same]({{< relref "/docs/reference/commands.md" >}}) for
+the same reason. Ask the provider:
+
+```bash
+aws eks list-clusters --region eu-west-3
+aws ec2 describe-instances --region eu-west-3 \
+  --filters Name=instance-state-name,Values=running \
+  --query 'Reservations[].Instances[].[InstanceId,Tags[?Key==`Name`].Value|[0]]' --output text
+aws ec2 describe-volumes --region eu-west-3 \
+  --filters Name=status,Values=available --query 'Volumes[].[VolumeId,Size]' --output text
+aws elbv2 describe-load-balancers --region eu-west-3 --query 'LoadBalancers[].LoadBalancerName' --output text
+aws ec2 describe-nat-gateways --region eu-west-3 \
+  --filter Name=state,Values=available --query 'NatGateways[].NatGatewayId' --output text
+aws ec2 describe-addresses --region eu-west-3 --query 'Addresses[].PublicIp' --output text
+```
+
+Empty output from all six is the only thing that means the platform is gone.
+NAT gateways and unattached Elastic IPs bill by the hour whether or not anything
+uses them, and available volumes bill by the GiB-month — those three are what an
+"successful" teardown most often leaves behind.
+
 ## What is not deleted
 
 The platform constitution withholds delete permissions from Crossplane for

--- a/website/content/docs/get-started/aws/teardown.md
+++ b/website/content/docs/get-started/aws/teardown.md
@@ -28,32 +28,33 @@ Four steps, defined in `opentofu/aws/eks/init/workflows.tm.hcl`:
 
 ## Full teardown
 
-{{< callout type="warning" >}}
-Do **not** run `terramate script run --reverse destroy` from `opentofu/` on a
-cluster carrying real data or live Karpenter nodes. `eks/configure` is a
-separately registered stack (`after = ["/opentofu/aws/eks/init"]`) with its own
-bare `destroy` script — confirm → `tofu init` → `tofu destroy` — that never
-calls `eks-prepare-destroy.sh`. The reverse dependency walk destroys
-`eks/configure` **first**: Cilium and Flux are torn down raw, with Flux never
-suspended, webhooks never disabled, and PVCs/NodePools/IAM keys never
-cleaned up. Only afterwards does the sweep reach `eks/init`, whose own
-`prepare-destroy` job then runs against a cluster whose networking is
-already gone. This is a known ordering issue, tracked separately — it is not
-fixed today. Use [EKS only](#eks-only) above instead.
-{{< /callout >}}
-
-To tear down every stack — EKS, OpenBao, Network — in one sweep once the
-ordering above is fixed, or on a cluster you are certain holds no data worth
-protecting:
+Tears down every stack — EKS, OpenBao, Network — in one command:
 
 ```bash
 cd opentofu
-terramate script run --reverse destroy
+terramate script run --reverse destroy          # aws (the default)
+TM_CLOUD=all terramate script run --reverse destroy   # both clouds
 ```
 
-Destroys every stack in reverse dependency order with a single confirmation
-prompt (`scripts/terramate-destroy-confirm.sh`), cached for 10 minutes so
-the whole reverse sweep only asks once.
+Reverse dependency order, with a single confirmation prompt
+(`scripts/terramate-destroy-confirm.sh`) cached for 10 minutes so the whole
+sweep only asks once. `TM_DESTROY_CONFIRMED=true` skips it for CI.
+
+{{< callout type="info" >}}
+**Why `eks/configure` shows `[skip]`.** It is a registered stack
+(`after = ["/opentofu/aws/eks/init"]`), so a reverse walk reaches it *before*
+`eks/init` — the opposite of the order a cluster needs. It used to destroy
+itself there, which brought Cilium and Flux down raw: Flux never suspended,
+admission webhooks left admitting, and PVCs, NodePools and IAM access keys
+never cleaned up. `eks/init`'s `prepare-destroy` then ran against a cluster
+whose networking was already gone, and this page carried a warning telling
+people not to use the command that ought to work.
+
+Its `destroy` script is now a no-op that says so. The stack is still destroyed
+— by `eks/init`'s `stage2-destroy-addons` job, at the point in the sequence
+where it is safe. Ownership of the ordering lives in one place because the
+stack graph cannot express it.
+{{< /callout >}}
 
 ## What `eks-prepare-destroy.sh` does first
 

--- a/website/content/docs/get-started/gcp/teardown.md
+++ b/website/content/docs/get-started/gcp/teardown.md
@@ -23,7 +23,7 @@ cd opentofu/gcp/gke/init
 TM_CLOUD=gcp terramate script run destroy
 ```
 
-Five jobs, defined in `opentofu/gcp/gke/init/workflows.tm.hcl`:
+Six jobs, defined in `opentofu/gcp/gke/init/workflows.tm.hcl`:
 
 1. **confirm + init** — `scripts/terramate-destroy-confirm.sh`, then `tofu init`.
    Init runs *before* anything is destroyed on purpose: a lock file predating a
@@ -34,7 +34,10 @@ Five jobs, defined in `opentofu/gcp/gke/init/workflows.tm.hcl`:
    CRDs, Cilium, Flux). Never gates the cluster deletion.
 4. **`stage1-destroy-cluster`** — destroys the cluster itself. This one *is*
    allowed to fail loudly: it is the billable resource.
-5. **`stage2-reconcile-state`** — drops any stage-2 state left behind, now that
+5. **`stage2-sweep-orphaned-disks`** — the backstop for whatever step 2 could not
+   reclaim in time, and it runs *after* the cluster is gone precisely so nothing
+   is still attached ([why](#orphaned-persistent-disks)).
+6. **`stage2-reconcile-state`** — drops any stage-2 state left behind, now that
    the cluster holding those objects is provably gone.
 
 ## Full teardown


### PR DESCRIPTION
Replaces #1924, which went DIRTY: #1923 was squash-merged, so that branch's original commits diverged from main's single squashed commit and CI never ran. Same two commits, cherry-picked onto current main.

## The one-command teardown was documented as unsafe

`terramate script run --reverse destroy` from `opentofu/` carried a warning telling people not to use it. `eks/configure` declares `after = ["/opentofu/aws/eks/init"]`, so the reverse walk reached it **first** and ran its own bare destroy — Cilium and Flux torn down raw, Flux never suspended, admission webhooks left admitting, PVCs, NodePools and IAM access keys never cleaned. `eks/init`'s `prepare-destroy` then ran against a cluster whose networking was already gone.

`eks/configure`'s destroy is now a no-op naming the real entrypoint. The stack is still destroyed — by `eks/init`'s `stage2-destroy-addons` job, at the safe point. The ordering a cluster needs is the opposite of the dependency ordering, so it cannot live in the stack graph.

Verified with `terramate -C opentofu script info destroy`: that stack now shows the skip.

GCP is left alone deliberately — `gke/configure`'s destroy is best-effort by design ("MUST NOT FAIL THE RUN"), with measured evidence behind it.

## Recovery pin rotated to the cleaned snapshot

The legacy `Ogenki` ZITADEL project was deleted (7 apps whose redirect URIs still named `priv.cloud.ogenki.io` and `mycluster-0`). The previous same-day snapshot predates that, so a rebuild would restore the exact state #1923 spent the day removing.

Ordering verified, not assumed: `project.removed` at `19:54:29Z` in the eventstore, snapshot's newest base backup `20260829T195453` — 24s later. SSO re-verified after the deletion and before the backup: all five clients accept their redirect URIs, a deliberately stale one still rejected 400.

`zitadel-20260829` stays as a fallback until a rebuild has restored from the new pin.

## Doc staleness fixed

- **GCP said "Five jobs"**; `GKE Full Destroy` has six. The list omitted `stage2-sweep-orphaned-disks` — the backstop the same page describes as what stopped 8 disks / 43 GB leaking on 2026-08-28.
- **AWS had no verification step.** A Terramate destroy can exit 0 having destroyed nothing. Added the six queries that answer "is it gone", naming the three resources an apparently-successful teardown most often leaves billing: NAT gateways, unattached EIPs, available volumes.

## Validation

- `terramate -C opentofu script info destroy` → skip shown for `eks/configure`
- `validate-links.sh`, `verify-doc-paths.sh`, `validate-doc-claims.sh` → exit 0