### PR TITLE
chore(deps): bump Cilium 1.20.1, flux-operator 0.59.0, Karpenter 1.14.1 (LTS)

### DIFF
--- a/flux/sources/ocirepo-karpenter.yaml
+++ b/flux/sources/ocirepo-karpenter.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 10m
   url: oci://public.ecr.aws/karpenter/karpenter
   ref:
-    semver: "1.13.0"
+    semver: "1.14.1"
   verify:
     provider: cosign
     matchOIDCIdentity:

--- a/infrastructure/base/karpenter/helmrelease.yaml
+++ b/infrastructure/base/karpenter/helmrelease.yaml
@@ -13,8 +13,15 @@ spec:
   interval: 3m0s
   install:
     createNamespace: true
+    crds: CreateReplace
     remediation:
       retries: 3
+  upgrade:
+    # Flux defaults upgrade.crds to Skip, so a chart bump would upgrade the
+    # controller while leaving the CRDs at the previously installed version
+    # (e.g. no `Balanced` consolidationPolicy enum from 1.14). Karpenter ships
+    # its CRDs in the main chart, so replace them on every upgrade.
+    crds: CreateReplace
   values:
     settings:
       clusterName: ${cluster_name}

--- a/opentofu/config.tm.hcl
+++ b/opentofu/config.tm.hcl
@@ -43,9 +43,9 @@ globals {
   cert_manager_approle             = "cert-manager"
 
   # Helm chart versions for EKS bootstrap
-  cilium_version        = "1.20.0"
-  flux_operator_version = "0.55.0"
-  flux_instance_version = "0.55.0"
+  cilium_version        = "1.20.1"
+  flux_operator_version = "0.59.0"
+  flux_instance_version = "0.59.0"
 
   # Gateway API release. Shared for the same reason as cilium_version: Cilium is
   # the GatewayClass implementation, so the CRD set cannot move independently of


### PR DESCRIPTION
Pre-bootstrap version refresh, researched against upstream releases on 2026-09-01. All three are additive, no manifest/API changes required beyond this diff.

## What

| Component | From | To | Why |
|---|---|---|---|
| Cilium | 1.20.0 | 1.20.1 | Patch-only: ENI IPAM correctness on EKS, WireGuard node-handler leak fix, CIDR-policy-bypass fix (security-relevant), Envoy `http-idle-timeout` regression fix, Gateway address status fix for non-IP addresses (our Tailscale gateways). |
| flux-operator + flux-instance charts | 0.55.0 | 0.59.0 | Embeds Flux distribution **2.9.5** (matches flux2 CLI bumped by Renovate in #1932, incl. the postBuild-substitution panic fix). FluxInstance CRD verified untouched between tags. Web UI gains workload CPU/mem + healthCheckExprs inventory status; MCP server consolidates reconcile tools into `reconcile_flux_resource`. |
| Karpenter | 1.13.0 | 1.14.1 | 1.13 is a **non-LTS line no longer receiving patches** (skipped in the 2026-07-17 patch wave); 1.14 is LTS until Jul 2027. Upgrade guide: no breaking changes. Brings `Balanced` consolidation policy, destination-node `consolidateAfter`, secondary-ENI primary-IP accounting fix (relevant to our prefix-delegation max-pods history #1726/#1728). |

Also wires `install.crds`/`upgrade.crds: CreateReplace` into the Karpenter HelmRelease: Flux defaults `upgrade.crds` to **Skip**, so previous chart bumps silently left CRDs at the version first installed.

## Deliberately NOT changed

- `gateway_api_version` stays v1.6.1 — Cilium 1.20.1 supports exactly this set, lockstep intact.
- `cniVersion` in `cilium-cni-config.tf` stays — patch releases don't move the CNI default; next check at 1.21.
- WireGuard encryption stays — cilium/cilium#43493 was closed by the stale-bot on 2026-08-10 **without a fix** (`state_reason: not_planned`); the workaround remains load-bearing.
- Terramate stays 0.17.2 — it *is* the latest stable.

## Evidence

- `./scripts/validate-manifests.sh` → exit 0, all gates passed (schema + polaris, `skipMissingSchemas: false`)
- `./scripts/validate-doc-claims.sh` → 15/15 claims, 27 page checks