### PR TITLE
fix(aws): accept AWS-0038 in the eks/init trivy gate

### DIFF
--- a/opentofu/aws/eks/init/.trivyignore.yaml
+++ b/opentofu/aws/eks/init/.trivyignore.yaml
@@ -1,5 +1,9 @@
 # We need to work on these security issues
 misconfigurations:
+  # Control-plane logging is deliberately OFF (#1920): $144/month of CloudWatch
+  # vended logs nobody reads — observability here is VictoriaMetrics/VictoriaLogs.
+  # Accepting AWS-0038 is that decision, not an oversight.
+  - id: AVD-AWS-0038
   - id: AVD-KSV-0001
   - id: AVD-KSV-0003
   - id: AVD-KSV-0004


### PR DESCRIPTION
First deploy to exercise #1920 fails: the deploy-time trivy gate in `opentofu/aws/eks/init` flags five MEDIUM **AWS-0038** findings (control-plane logging disabled) from the upstream EKS module — i.e. exactly the decision #1920 made and documented, minus the gate update. CI never catches this because only the Terramate deploy script runs trivy inside the initialized stack (with `.terraform/modules` present).

One-line fix: add `AVD-AWS-0038` to the stack's `.trivyignore.yaml` with the rationale inline.

**Evidence:** `trivy config --exit-code=1 --ignorefile=./.trivyignore.yaml .` in the stack dir → exit 0. Deploy resumes right after merge (dual-cloud bootstrap currently blocked at this gate).