### PR TITLE
fix(security): pin zitadel's kubectl helper image to an existing tag

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -269,21 +269,21 @@
         "filename": "security/base/zitadel/helmrelease.yaml",
         "hashed_secret": "5bb6016169a24b72f0bb3d2826bd43a262442f44",
         "is_verified": false,
-        "line_number": 73
+        "line_number": 85
       },
       {
         "type": "Secret Keyword",
         "filename": "security/base/zitadel/helmrelease.yaml",
         "hashed_secret": "38d618ea3f63cf36f2e899505f161f05b40935a0",
         "is_verified": false,
-        "line_number": 74
+        "line_number": 86
       },
       {
         "type": "Secret Keyword",
         "filename": "security/base/zitadel/helmrelease.yaml",
         "hashed_secret": "54062eed5e8326a96f845559019aad3bd7003f32",
         "is_verified": false,
-        "line_number": 155
+        "line_number": 167
       }
     ],
     "tooling/base/gha-runners/dagger-scale-set-helmrelease.yaml": [
@@ -328,5 +328,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-30T08:55:20Z"
+  "generated_at": "2026-09-01T08:18:01Z"
 }

--- a/security/base/zitadel/helmrelease.yaml
+++ b/security/base/zitadel/helmrelease.yaml
@@ -58,11 +58,23 @@ spec:
     initJob:
       backoffLimit: 30 # Wait for the CNPG database instance to be ready
 
-    # Fix for missing alpine/k8s:1.34.2 image (chart default doesn't exist)
+    # The chart's kubectl helper image (setup/cleanup/init jobs) defaults its
+    # tag to the CLUSTER's Kubernetes version, and docker.io/alpine/k8s does
+    # not publish every patch release — tags jump 1.35.6 → 1.36.0, so GKE's
+    # v1.35.7 resolved to a tag that does not exist and the setup job died in
+    # ImagePullBackOff (found live on gcp-0, 2026-09-01; same class as the
+    # earlier missing-1.34.2 fix, but chart 10.x moved the knob from
+    # setupJob.machinekeyWriter to tools.kubectl). Pin an EXISTING tag within
+    # kubectl's ±1-minor skew of both clusters; re-check the tag exists when
+    # bumping cluster versions.
+    tools:
+      kubectl:
+        image:
+          tag: "1.36.2"
     setupJob:
       machinekeyWriter:
         image:
-          tag: "1.35.0"
+          tag: "1.36.2"
 
     # Login v2 disabled due to Helm chart bug with pod-level TLS
     # Bug: Init container uses HTTPS for internal connections when TLS.Enabled=true


### PR DESCRIPTION
Found live during today's dual bootstrap: **gcp-0's zitadel install fails** — the chart's pre-install `zitadel-setup` Job pulls `docker.io/alpine/k8s:1.35.7`, a tag that does not exist (the repo skips patch tags: …1.35.6 → 1.36.0…). The chart defaults the helper tag to the **cluster's** Kubernetes version (GKE is v1.35.7-gke). The uninstall remediation then fails identically via the `zitadel-cleanup` Job. aws-0 (v1.36.2) escapes only because that tag happens to exist.

Chart 10.x moved this knob to `tools.kubectl.image`; our previous `setupJob.machinekeyWriter.image.tag: 1.35.0` pin (the old missing-1.34.2 fix) no longer covers the jobs' main containers. Pin both paths to `1.36.2` — an existing tag within kubectl's ±1-minor skew of both clusters (1.35 GKE / 1.36 EKS).

**Evidence:** `./scripts/validate-manifests.sh` → exit 0 all gates; Docker Hub tag listing (`1.35.6, 1.36.0, 1.36.1, 1.36.2`, no `1.35.7`); gcp-0 events show `ErrImagePull … alpine/k8s:1.35.7: not found`.