### PR TITLE
docs(costs): 2026-09-01 re-measure — list-price comparison and why the clouds differ

### DIFF
--- a/website/content/docs/get-started/costs.md
+++ b/website/content/docs/get-started/costs.md
@@ -2,36 +2,39 @@
 title: What it costs
 weight: 45
 description: What the platform actually bills on each cloud, measured rather than estimated, and which lines are worth attacking.
-lastVerified: 2026-08-29
+lastVerified: 2026-09-01
 ---
 
-Roughly **$590/month on AWS** and **$220/month on GCP** for the same platform,
-with the LLM components disabled on both.
+Roughly **$700/month on AWS** and **$320/month on GCP** for the same platform at
+list price, with the LLM components disabled on both.
 
-The more useful number is smaller: **$66/month bills on AWS even when every
-cluster is destroyed**, and almost none of it is the platform.
+The more useful number is smaller: **about $80/month bills on AWS even when
+every cluster is destroyed**, and almost none of it is the platform.
 
 {{< callout type="info" >}}
-Measured on 2026-08-29 against both reference clusters, LLM platform suspended.
-The AWS figures come from Cost Explorer actuals plus live spot prices. The GCP
-figures are **rate-card estimates** — the billing API is reachable but exposes no
-spend without a BigQuery export — so treat them as ±20%.
+Measured on 2026-09-01, about one hour after bootstrapping both platforms from
+scratch. AWS compute uses live spot prices per instance type, the rest published
+`eu-west-3` rates — Cost Explorer actuals lag a same-day bootstrap. GCP comes
+from the Cloud Billing Catalog API. These are rough estimates: node counts are
+whatever the autoscalers held at snapshot time, and usage-based lines (NAT/LB
+data processing, egress) are called out rather than measured.
 {{< /callout >}}
 
-## AWS — about $24/day
+## AWS — about $25/day
 
 | Line | $/month | Notes |
 |---|---:|---|
-| **Spot compute, 6 nodes** | **250** | **largest single item** — measured spot rates, `eu-west-3` |
-| NAT gateway | 76 | $35 gateway-hours + $41 data processing |
+| **Spot compute, 8 nodes** | **378** | **largest single item** — 24 vCPU: the static bootstrap pair alone is $180, the 6 Karpenter nodes $198 |
+| NAT gateway | 76 | $35 gateway-hours + ~$41 data processing (August actuals) |
 | EKS control plane | 73 | $0.10/hr, flat |
-| EBS, 563 GiB gp3 | 54 | 27 volumes |
+| EBS, 753 GiB gp3 | 70 | 33 volumes |
 | 3 × network load balancer | 49 | public gateway, ZITADEL, OpenBao internal |
-| KMS | 29 | 39 keys |
-| Secrets Manager | 26 | 81 secrets |
+| Secrets Manager | 34 | 84 secrets |
+| KMS | 31 | 31 customer-managed keys |
 | 2 × `t3.micro` on-demand | 17 | OpenBao, Tailscale subnet router |
-| Kinesis | 11 | orphaned stream |
-| S3 | 10 | 7 buckets |
+| Kinesis | 11 | orphaned stream — still, see below |
+| Public IPv4 | 4 | the NAT gateway's EIP |
+| S3 | 3 | 8 buckets, ~112 GB (mostly LLM weights) |
 | Route 53 | 1 | 2 hosted zones |
 
 ### CloudWatch is absent on purpose
@@ -51,28 +54,43 @@ Turn types back on deliberately if you need them. `audit` is the one worth havin
 during a security investigation, and it is also the expensive one — the module's
 own default is `["audit", "api", "authenticator"]`.
 
-Compute is spot throughout — the six nodes measured at $0.0688 (`t3a.xlarge`),
-$0.0747 (`c5.xlarge`), $0.0428 (`c6i.large`), $0.0401 (`m5.large`) and $0.0471
-(`m8i.large`) per hour. Node count varies with what Karpenter has provisioned, so
-this line moves the most between runs.
+Compute is spot throughout — measured at $0.160 (`c7i-flex.2xlarge`) and
+$0.0863 (`c7i-flex.xlarge`) for the static bootstrap pair, plus 3 × $0.0405
+(`c7i-flex.large`), $0.0481 (`c8i-flex.large`), $0.0477 (`m8i.large`) and
+$0.0544 (`r5ad.large`) per hour for the Karpenter fleet. The Karpenter line
+moves between runs; the bootstrap pair never does — Karpenter cannot
+consolidate a managed node group.
 
-## GCP — about $7/day
+## GCP — about $10/day
 
 | Line | $/month | Notes |
 |---|---:|---|
-| **3 × `e2-standard-4` spot** | **88** | **largest single item** |
-| 3 × forwarding rule | 54 | 2 external, 1 internal |
-| Cloud NAT | 32 | plus data processing |
-| 273 GB `pd-balanced` | 27 | 16 disks |
-| `e2-micro` + `e2-small` | 18 | Tailscale router, OpenBao |
-| GKE control plane | 0 | zonal — assumed covered by the free zonal-cluster tier; **+$73 if not** |
-| Cloud DNS, GCS, Secret Manager | ~3 | 1 zone, 4 buckets, 28 secrets |
+| **3 × `e2-standard-4` spot** | **161** | **largest single item** — the catalog spot rate for E2 nearly doubled since August's estimate |
+| GKE control plane | 73 | $0.10/hr at list, same as EKS. The zonal free-tier credit ($74.40/month, one cluster per billing account) usually wipes this off the *invoice* — it is an account promotion, so it is not counted here |
+| 283 GB persistent disk | 29 | 17 disks, `pd-balanced` + one `pd-standard` |
+| 3 × forwarding rule | 20 | flat minimum up to 5 rules; plus data processing |
+| `e2-micro` + `e2-small` | 20 | Tailscale router, OpenBao |
+| Cloud NAT + IP | 9 | plus $0.045/GiB processing |
+| Cloud DNS, GCS, Secret Manager, KMS | ~4 | 1 zone, ~17 GiB, 55 secret versions, 1 key |
 
-GCP runs at roughly **a third of AWS** for the same workload, and very little of
-that gap is compute — spot nodes cost $250 against $88 largely because AWS is
-running six and GCP three. The rest is the flat EKS control-plane charge GKE
-waives on a zonal cluster, NAT data processing, load balancers, and the
-accumulated cruft below.
+## Why they differ
+
+At list price AWS runs at about **2.2×** GCP — but most of that is not cloud
+pricing. Re-price AWS at gcp-0's exact footprint (12 spot vCPUs, 283 GB of
+disk, a trimmed secret/key inventory) and it lands near **$400/month**, about
+**1.3×** GCP:
+
+- **Two-thirds of the gap is deployment drift**, all fixable on our side: the
+  oversized static bootstrap pair (~$120), a Karpenter fleet holding twice
+  GCP's vCPUs (~$85), 2.8× the provisioned disk (~$44), and secrets, keys and
+  one Kinesis stream accumulated across rebuilds (~$60).
+- **The remaining ~$80/month is genuinely AWS charging more**: three metered
+  NLBs against forwarding rules under a flat minimum, NAT gateway-hours, the
+  per-secret and per-key pricing model, and a ~10% spot premium at equal vCPUs.
+  One line runs the other way — `pd-balanced` costs ~18% more per GiB than gp3.
+- The control-plane fee is a wash at list price; both charge $0.10/hour.
+- The comparison is structurally fair since ADR-0024: **both clouds run their
+  own ZITADEL and their own OpenBao**, and only public DNS stays AWS-owned.
 
 Until 2026-08-29 the single biggest contributor was CloudWatch at $144/month.
 Removing it closed a fifth of the gap on its own.
@@ -101,6 +119,11 @@ residue from rebuilds:
 - **`xplane-vector-stream` sits in `eu-west-1`**, a region this platform does not
   deploy to at all — left from an old Vector experiment.
 
+By 2026-09-01 the same lines had grown, not shrunk: **84 secrets, 31
+customer-managed keys, and the stream still ACTIVE** — about $80/month. GCP's
+equivalent floor is **under $4/month** (secret versions, backup buckets, one
+DNS zone, one key version).
+
 The pattern is worth naming: **teardown is thorough about compute and blind to
 everything that outlives a cluster.** The
 [EBS]({{< relref "/docs/get-started/aws/teardown.md" >}}) and PD sweeps close one
@@ -117,25 +140,39 @@ enabled; the module's own default is three.
 `opentofu/aws/eks/init/main.tf` now sets `enabled_log_types = []`, which changes
 nothing about how the platform runs — the platform uses
 [no cloud-provider monitoring on either cloud]({{< relref "/docs/platform/observability/_index.md" >}}).
+Verified live on the 2026-09-01 rebuild: the log group exists with 0 stored
+bytes.
 
 Audit logs are the one signal the in-cluster stack cannot reconstruct, since the
 API server writes them before anything in the cluster can observe them. If you
 need them for an investigation, turn them on deliberately —
 `enabled_log_types = ["audit"]` — and expect the bill to come back.
 
-**2. The idle floor — $66/month.** Sweep the orphaned secrets and KMS keys, and
-delete the stray stream:
+**2. The static bootstrap node group — ~$180/month for two nodes.** A
+`c7i-flex.2xlarge` + `c7i-flex.xlarge` pair that exists to host what must run
+before Karpenter does, and that Karpenter therefore can never consolidate. It
+is the single biggest lever left on the bill: sizing the pair down is one
+variable in `opentofu/aws/eks/init/main.tf` and worth on the order of
+$120/month.
+
+**3. The idle floor — now $80/month, still unswept.** Two audits later the
+orphaned secrets and KMS keys have grown (84 and 31), and the stray stream is
+still ACTIVE. Delete it:
 
 ```bash
 aws --region eu-west-1 kinesis delete-stream \
   --stream-name xplane-vector-stream --enforce-consumer-deletion
 ```
 
-**3. NAT data processing costs more than the NAT gateway** — $41/month against
+**4. NAT data processing costs more than the NAT gateway** — $41/month against
 $35/month of gateway-hours, from image pulls and telemetry egress. There are no
 VPC endpoints configured; S3 and ECR endpoints would take most of it out.
 
-Together those are roughly **$200/month**, none of which requires changing what
+**5. Provisioned EBS keeps growing** — 753 GiB across 33 volumes against
+283 GB for the same charts on GCP. Worth one look at PVC sizes before calling
+it necessary.
+
+Together those are roughly **$300/month**, none of which requires changing what
 the platform does.
 
 ## Keeping it cheap

--- a/website/content/docs/get-started/costs.md
+++ b/website/content/docs/get-started/costs.md
@@ -5,7 +5,7 @@ description: What the platform actually bills on each cloud, measured rather tha
 lastVerified: 2026-09-01
 ---
 
-Roughly **$690/month on AWS** and **$320/month on GCP** for the same platform at
+Roughly **$575/month on AWS** and **$320/month on GCP** for the same platform at
 list price, with the LLM components disabled on both.
 
 The more useful number is smaller: **about $23/month keeps billing after every
@@ -21,14 +21,14 @@ whatever the autoscalers held at snapshot time, and usage-based lines (NAT/LB
 data processing, egress) are called out rather than measured.
 {{< /callout >}}
 
-## AWS — about $23/day
+## AWS — about $19/day
 
 | Line | $/month | Notes |
 |---|---:|---|
-| **Spot compute, 10 nodes** | **369** | **largest single item** — 22 vCPU: a 2 × `m8i.large` static pair ($69) plus 8 Karpenter-provisioned nodes ($300), measured after right-sizing the static pair and letting Karpenter settle |
-| NAT gateway | 76 | $35 gateway-hours + ~$41 data processing (measured) |
+| **Spot compute, 6 nodes** | **331** | **largest single item** — 20 vCPU: a 2 × `m8i.large` static pair ($67) plus 4 Karpenter xlarge-class nodes ($264) |
+| NAT gateway | 35+ | gateway-hours; data processing was ~$41/month before an S3 gateway endpoint was added — expect most of that gone, not yet re-measured |
 | EKS control plane | 73 | $0.10/hr, flat |
-| EBS, ~900 GiB gp3 | 83 | 35 volumes |
+| EBS, 443 GiB gp3 | 41 | 27 volumes |
 | 3 × network load balancer | 49 | public gateway, ZITADEL, OpenBao internal |
 | 2 × `t3.micro` on-demand | 17 | OpenBao, Tailscale subnet router |
 | Secrets Manager | 16 | the ~40 secrets the platform actually reads |
@@ -55,15 +55,25 @@ nodes and storage to per-signal service fees, and trade operating effort for
 bill opacity. If the platform adopts any of them, that will be a recorded
 decision with its price on this page, not a default left on.
 
-Compute is spot throughout, and one measurement here is worth recording: the
-static pair was originally xlarge/2xlarge (~$180/month on its own), and
-right-sizing it to `m8i.large` did **not** shave that off the bill — Karpenter
-grew by almost the same amount to absorb the displaced pods. The pair was
-carrying real capacity, not idle headroom. The lesson generalizes: what this
-platform pays for compute is set by what it *consumes*, and by node
-granularity — every extra node carries its own copy of the DaemonSet overhead
-(Cilium, CSI, exporters), which favors fewer, larger nodes over many small
-ones.
+Compute is spot throughout, and two experiments here are worth recording
+because both under-delivered against the obvious theory:
+
+1. **Right-sizing the static node group.** It ran xlarge/2xlarge (~$180/month
+   on its own). Moving it to `m8i.large` did **not** shave that off the bill —
+   Karpenter grew by almost as much to absorb the displaced pods. The pair was
+   carrying real capacity, not idle headroom.
+2. **Forcing fewer, larger nodes** (a 4-vCPU floor on the NodePool). Node count
+   nearly halved, 10 → 6, but total consumption moved only 22 → 20 vCPU and the
+   bill only $369 → $331. Per-vCPU spot pricing is near-flat between `large`
+   and `xlarge`, so consolidating mostly removed **per-node overhead** (one
+   fewer copy of every DaemonSet, less scheduling fragmentation) rather than
+   capacity.
+
+The generalizable lesson: on a spot fleet, **what you pay for compute is set by
+what the workloads actually consume**. Node shape and count are worth tuning —
+they were worth ~$38/month here, and they cut provisioned disk by half because
+each node carries its own root and data volumes — but no instance-type choice
+substitutes for right-sizing the workloads themselves.
 
 ## GCP — about $10/day
 
@@ -79,7 +89,7 @@ ones.
 
 ## Why they differ
 
-At list price AWS runs at about **2.2×** GCP. Separating what the *clouds*
+At list price AWS runs at about **1.8×** GCP. Separating what the *clouds*
 charge from what *this deployment* consumes:
 
 - **Cloud pricing accounts for roughly 1.3× of it.** Priced at identical
@@ -90,13 +100,11 @@ charge from what *this deployment* consumes:
   other way — `pd-balanced` costs ~18% more per GiB than gp3 — and the
   control-plane fee is a wash: both charge $0.10/hour.
 - **The rest is consumption, on our side of the ledger, and it was measured
-  rather than assumed**: the AWS deployment consumes ~22 spot vCPUs where GCP
-  serves the platform on 12. Right-sizing the static pair did not close it —
-  the capacity simply moved to Karpenter. The drivers are node granularity
-  (ten 2-vCPU nodes pay ten copies of the per-node DaemonSet overhead; GCP
-  packs onto three 4-vCPU machines), scheduling fragmentation on small nodes,
-  3× the provisioned block storage, and a few AWS-only components (Karpenter
-  itself, the demo applications).
+  rather than assumed**: this deployment consumes ~20 spot vCPUs where GCP
+  serves the platform on 12. Two tuning rounds narrowed it and neither closed
+  it, which is the useful part — the capacity is real. What remains is genuine
+  demand (AWS additionally runs Karpenter and the demo applications) plus
+  scheduling slack that no instance-type choice removes.
 - The comparison is structurally fair since ADR-0024: **both clouds run their
   own ZITADEL and their own OpenBao**, and only public DNS stays AWS-owned.
 
@@ -128,24 +136,26 @@ aws kms list-keys --query 'Keys[].KeyId' --output text | xargs -n1 \
 
 ## What is worth attacking
 
-**1. Node granularity.** The measured lesson above: the fleet runs ten mostly
-2-vCPU nodes, each carrying its own copy of the DaemonSet overhead. Steering
-Karpenter toward fewer, larger instances (NodePool requirements or
-consolidation preferences) is now the biggest compute lever — plausibly on the
-order of $100/month. (Right-sizing the static pair is already done; it moved
-capacity to Karpenter rather than removing it, which is how we know the
-remaining lever is granularity, not node-group sizing.)
+The infrastructure-shaped levers have now been pulled, and what they were
+actually worth is recorded above: node shape and count (−$38/month), node
+volume sizing (−$42/month), an S3 gateway endpoint for NAT data processing
+(worth up to ~$41/month, not yet re-measured). What is left is not
+configuration:
 
-**2. NAT data processing costs more than the NAT gateway** — $41/month against
-$35/month of gateway-hours, from image pulls and telemetry egress. There are no
-VPC endpoints configured; S3 and ECR endpoints would take most of it out.
+**1. Right-size the workloads.** ~20 vCPU is consumed for what GCP serves on
+12, and two rounds of node tuning did not move that — so the remaining compute
+cost is requests and replica counts, not instance types. Start with the
+components that run more replicas here than they need to.
 
-**3. Provisioned EBS keeps growing** — ~900 GiB across 35 volumes against
-283 GB for the same charts on GCP. Worth one look at PVC sizes before calling
-it necessary.
+**2. Single-instance databases block node lifecycle.** A CNPG cluster with
+`instances: 1` has a PodDisruptionBudget that can never permit a voluntary
+eviction, so it pins its node against consolidation, drift and upgrades
+indefinitely — the node has to be cordoned and the pod restarted by hand. This
+is an availability and operations cost more than a billing one, and it is worth
+knowing before you scale a database down to save a replica.
 
-Together those are plausibly **$150–200/month**, none of which requires
-changing what the platform does.
+**3. Watch what accumulates.** Provisioned disk and node count creep back after
+every rebuild; both are worth re-measuring rather than assumed stable.
 
 ## Keeping it cheap
 

--- a/website/content/docs/get-started/costs.md
+++ b/website/content/docs/get-started/costs.md
@@ -1,7 +1,7 @@
 ---
 title: What it costs
 weight: 45
-description: A rough monthly estimate of what the platform costs on each cloud, how the two compare on equal terms, and which lines are worth attacking.
+description: A rough monthly estimate of what the platform costs on each cloud, and how the two compare on equal terms.
 lastVerified: 2026-09-01
 ---
 
@@ -121,32 +121,6 @@ aws secretsmanager list-secrets \
 aws kms list-keys --query 'Keys[].KeyId' --output text | xargs -n1 \
   aws kms describe-key --query 'KeyMetadata.[KeyState,Description]' --output text --key-id
 ```
-
-## What is worth attacking
-
-In rough order of what they return:
-
-**1. Workload requests and replica counts.** Compute is the largest line on
-both clouds, and node-level tuning only trims the overhead around it. Pod
-requests, replica counts and retention windows are what actually move it.
-
-**2. Node shape and provisioned disk.** A minimum instance size on the NodePool
-(`karpenter.k8s.aws/instance-cpu` with a `Gt` requirement) consolidates the
-fleet, and because each node carries its own root and data volumes, fewer nodes
-also means less EBS. Check the EC2NodeClass `blockDeviceMappings` too — a
-volume sized for an occasional peak is paid for on every node, every hour.
-
-**3. NAT data processing.** It can cost as much as the NAT gateway itself,
-mostly from image pulls. An S3 **gateway** endpoint is free and captures ECR
-layer traffic along with S3; ECR *interface* endpoints bill per hour and are
-usually not worth adding on top.
-
-**4. Single-instance databases block node lifecycle.** A CNPG cluster with
-`instances: 1` has a PodDisruptionBudget that can never permit a voluntary
-eviction, so it pins its node against consolidation, drift and upgrades until
-someone cordons the node and restarts the pod by hand. That is an availability
-and operations cost rather than a billing one — worth knowing before scaling a
-database down to save a replica.
 
 ## Keeping it cheap
 

--- a/website/content/docs/get-started/costs.md
+++ b/website/content/docs/get-started/costs.md
@@ -8,11 +8,9 @@ lastVerified: 2026-09-01
 Roughly **$690/month on AWS** and **$320/month on GCP** for the same platform at
 list price, with the LLM components disabled on both.
 
-On top of that, AWS bills about **$45/month of residue that is not the platform
-at all** — secrets, KMS keys and one Kinesis stream left behind by past
-rebuilds. It is kept out of the platform totals above and itemized in
-[the floor section](#the-floor-you-pay-for-nothing), because the honest way to
-account for cruft is to name it, not to blend it in.
+The more useful number is smaller: **about $23/month keeps billing after every
+cluster is destroyed** — and that part is by design. See
+[the floor](#the-floor-you-pay-for-nothing).
 
 {{< callout type="info" >}}
 Measured on 2026-09-01, about one hour after bootstrapping both platforms from
@@ -25,12 +23,10 @@ data processing, egress) are called out rather than measured.
 
 ## AWS — about $23/day
 
-The platform, and only the platform — residue is counted separately below.
-
 | Line | $/month | Notes |
 |---|---:|---|
 | **Spot compute, 8 nodes** | **378** | **largest single item** — 24 vCPU: the static bootstrap pair alone is $180, the 6 Karpenter nodes $198 |
-| NAT gateway | 76 | $35 gateway-hours + ~$41 data processing (August actuals) |
+| NAT gateway | 76 | $35 gateway-hours + ~$41 data processing (measured) |
 | EKS control plane | 73 | $0.10/hr, flat |
 | EBS, 753 GiB gp3 | 70 | 33 volumes |
 | 3 × network load balancer | 49 | public gateway, ZITADEL, OpenBao internal |
@@ -41,22 +37,23 @@ The platform, and only the platform — residue is counted separately below.
 | KMS | 3 | 3 keys: cluster encryption, OpenBao unseal, snapshot bucket |
 | Route 53 | 1 | 2 hosted zones |
 
-### CloudWatch is absent on purpose
+### No cloud-provider monitoring is on the bill
 
-EKS control-plane logging used to be the **largest line on the whole bill** —
-**$144/month**, 20% of AWS, almost entirely `EUW3-VendedLog-Bytes` dominated by
-the audit log. All five log types were on.
+The platform
+[runs its own observability and security stack in-cluster]({{< relref "/docs/platform/observability" >}})
+— VictoriaMetrics, VictoriaLogs, Kyverno — so there is no CloudWatch, Cloud
+Monitoring, GuardDuty or Security Command Center line above. EKS control-plane
+logging is off for the same reason (`enabled_log_types = []` in
+`opentofu/aws/eks/init/main.tf`): vended logs bill per byte, and the audit log
+alone can rival the control plane itself. If you need it for an investigation,
+enable it deliberately — `enabled_log_types = ["audit"]` — and expect the line
+to appear.
 
-Nothing in this repository reads any of it. Observability is
-VictoriaMetrics/VictoriaLogs, and the platform
-[uses no cloud-provider monitoring on either cloud]({{< relref "/docs/platform/observability" >}}).
-So it was $144/month of logs nobody could look at without first going to find
-them in a console. `enabled_log_types` is now empty in
-`opentofu/aws/eks/init/main.tf`.
-
-Turn types back on deliberately if you need them. `audit` is the one worth having
-during a security investigation, and it is also the expensive one — the module's
-own default is `["audit", "api", "authenticator"]`.
+Managed alternatives are a legitimate future direction — managed Prometheus,
+provider log sinks, GuardDuty / Security Command Center would shift cost from
+nodes and storage to per-signal service fees, and trade operating effort for
+bill opacity. If the platform adopts any of them, that will be a recorded
+decision with its price on this page, not a default left on.
 
 Compute is spot throughout — measured at $0.160 (`c7i-flex.2xlarge`) and
 $0.0863 (`c7i-flex.xlarge`) for the static bootstrap pair, plus 3 × $0.0405
@@ -69,7 +66,7 @@ consolidate a managed node group.
 
 | Line | $/month | Notes |
 |---|---:|---|
-| **3 × `e2-standard-4` spot** | **161** | **largest single item** — the catalog spot rate for E2 nearly doubled since August's estimate |
+| **3 × `e2-standard-4` spot** | **161** | **largest single item** — spot catalog rates are revised by Google monthly, so this line moves |
 | GKE control plane | 73 | $0.10/hr at list, same as EKS. The zonal free-tier credit ($74.40/month, one cluster per billing account) usually wipes this off the *invoice* — it is an account promotion, so it is not counted here |
 | 283 GB persistent disk | 29 | 17 disks, `pd-balanced` + one `pd-standard` |
 | 3 × forwarding rule | 20 | flat minimum up to 5 rules; plus data processing |
@@ -87,8 +84,7 @@ disk, a trimmed secret/key inventory) and it lands near **$400/month**, about
 - **Most of the gap is deployment drift**, all fixable on our side: the
   oversized static bootstrap pair (~$120), a Karpenter fleet holding twice
   GCP's vCPUs (~$85), 2.8× the provisioned disk (~$44), and smaller inventory
-  differences for the rest. (The $45/month of rebuild residue is on top of
-  this — already excluded from the AWS platform total.)
+  differences for the rest.
 - **The remaining ~$80/month is genuinely AWS charging more**: three metered
   NLBs against forwarding rules under a flat minimum, NAT gateway-hours, the
   per-secret and per-key pricing model, and a ~10% spot premium at equal vCPUs.
@@ -97,90 +93,49 @@ disk, a trimmed secret/key inventory) and it lands near **$400/month**, about
 - The comparison is structurally fair since ADR-0024: **both clouds run their
   own ZITADEL and their own OpenBao**, and only public DNS stays AWS-owned.
 
-Until 2026-08-29 the single biggest contributor was CloudWatch at $144/month.
-Removing it closed a fifth of the gap on its own.
-
 ## The floor you pay for nothing
 
-With every cluster destroyed, AWS still bills about **$70/month**: the 84
-secrets, the 19 enabled KMS keys, the Kinesis stream, the backup buckets and
-the DNS zones all survive teardown. About **$23** of that is deliberate — the
-platform's ~40 secrets, its 3 keys, and
+With every cluster destroyed, about **$23/month keeps billing** — the
+platform's ~40 secrets, its 3 KMS keys, the DNS zones, and
 [backup buckets that outlive their clusters on purpose]({{< relref "/docs/guides/restore-a-database.md" >}}).
+That floor is a feature: **secrets, keys and backups survive teardown by
+design.** The platform constitution withholds delete permissions for stateful
+services, so `xplane-*` IAM, S3 and secrets are re-adopted by name on the next
+deploy rather than recreated.
 
-The other **$45/month is residue**, audited item by item on 2026-09-01:
+The flip side: nothing ever removes the ones that stop being used. Renamed or
+removed components leave their secrets behind, and each rebuild can leave a key
+behind, at $0.40/secret and $1/key per month. **Teardown is thorough about
+compute and blind to everything that outlives a cluster** — the
+[EBS]({{< relref "/docs/get-started/aws/teardown.md" >}}) and PD sweeps close
+one leak of exactly this shape. If your account has lived through a few
+rebuilds, audit the rest of it (keys in `PendingDeletion` cost nothing; enabled
+ones bill):
 
-| Residue | $/month | What it actually is |
-|---|---:|---|
-| ~44 stale secrets | 18 | four layers: twins from the 2026-08-27 slash→dash renaming (~17), Grafana OnCall remnants (~9 — removed by ADR-0029), the `vault/` + `priv.cloud.ogenki.io` era (~8), dead experiments — gitlab, tofu-controller, kube-prometheus (~10) |
-| 16 stale KMS keys | 16 | **13 are the snapshot-bucket key, one leaked per rebuild**: teardown schedules the unseal and cluster keys for deletion but never this one. Plus three ancient cluster keys (`dev-giving-hen` 2022, `mgmt-trusty-bear` 2023, `mycluster-0`) |
-| Kinesis stream | 11 | `xplane-vector-stream` in `eu-west-1` — a region this platform does not deploy to — since 2023 |
-
-(12 more keys sit in `PendingDeletion`, which costs nothing — the teardown *does*
-clean what it knows about.)
-
-Why it accumulates: **secrets and KMS keys survive teardown by design.** The
-platform constitution withholds delete permissions for stateful services, so
-`xplane-*` IAM, S3 and secrets are re-adopted by name on the next deploy rather
-than recreated. That is correct, and it means nothing ever removes the ones
-that stop being used. GCP's floor is **under $4/month** — the project is
-younger, not better designed; give it the same number of rebuilds and it will
-grow the same layers unless swept.
-
-The pattern is worth naming: **teardown is thorough about compute and blind to
-everything that outlives a cluster.** The
-[EBS]({{< relref "/docs/get-started/aws/teardown.md" >}}) and PD sweeps close one
-leak of exactly this shape; secrets, KMS keys and cross-region leftovers are the
-same shape, unswept — and the snapshot-bucket key is a one-line fix away from
-being scheduled for deletion like its two siblings.
+```bash
+aws secretsmanager list-secrets \
+  --query 'SecretList[].[Name,LastAccessedDate]' --output table
+aws kms list-keys --query 'Keys[].KeyId' --output text | xargs -n1 \
+  aws kms describe-key --query 'KeyMetadata.[KeyState,Description]' --output text --key-id
+```
 
 ## What is worth attacking
 
-**1. EKS control-plane logging — $144/month. Done.** It was the largest single
-line and 20% of the AWS bill, every cent `EUW3-VendedLog-Bytes` dominated by the
-audit log, and nothing in this repository read any of it. All five types were
-enabled; the module's own default is three.
-
-`opentofu/aws/eks/init/main.tf` now sets `enabled_log_types = []`, which changes
-nothing about how the platform runs — the platform uses
-[no cloud-provider monitoring on either cloud]({{< relref "/docs/platform/observability/_index.md" >}}).
-Verified live on the 2026-09-01 rebuild: the log group exists with 0 stored
-bytes.
-
-Audit logs are the one signal the in-cluster stack cannot reconstruct, since the
-API server writes them before anything in the cluster can observe them. If you
-need them for an investigation, turn them on deliberately —
-`enabled_log_types = ["audit"]` — and expect the bill to come back.
-
-**2. The static bootstrap node group — ~$180/month for two nodes.** A
+**1. The static bootstrap node group — ~$180/month for two nodes.** A
 `c7i-flex.2xlarge` + `c7i-flex.xlarge` pair that exists to host what must run
 before Karpenter does, and that Karpenter therefore can never consolidate. It
-is the single biggest lever left on the bill: sizing the pair down is one
-variable in `opentofu/aws/eks/init/main.tf` and worth on the order of
-$120/month.
+is the single biggest lever on the bill: sizing the pair down is one variable
+in `opentofu/aws/eks/init/main.tf` and worth on the order of $120/month.
 
-**3. The $45/month of residue — audited, still unswept.** The table above
-names every item; none of it is load-bearing. Two audits have now prescribed
-the same first command:
-
-```bash
-aws --region eu-west-1 kinesis delete-stream \
-  --stream-name xplane-vector-stream --enforce-consumer-deletion
-```
-
-Then the ~44 stale secrets and 16 stale keys — and, so the pile stops growing,
-schedule the snapshot-bucket KMS key for deletion at teardown the way the
-unseal and cluster keys already are.
-
-**4. NAT data processing costs more than the NAT gateway** — $41/month against
+**2. NAT data processing costs more than the NAT gateway** — $41/month against
 $35/month of gateway-hours, from image pulls and telemetry egress. There are no
 VPC endpoints configured; S3 and ECR endpoints would take most of it out.
 
-**5. Provisioned EBS keeps growing** — 753 GiB across 33 volumes against
+**3. Provisioned EBS keeps growing** — 753 GiB across 33 volumes against
 283 GB for the same charts on GCP. Worth one look at PVC sizes before calling
 it necessary.
 
-Together those are roughly **$250/month**, none of which requires changing what
+Together those are roughly **$200/month**, none of which requires changing what
 the platform does.
 
 ## Keeping it cheap

--- a/website/content/docs/get-started/costs.md
+++ b/website/content/docs/get-started/costs.md
@@ -25,10 +25,10 @@ data processing, egress) are called out rather than measured.
 
 | Line | $/month | Notes |
 |---|---:|---|
-| **Spot compute, 8 nodes** | **378** | **largest single item** — 24 vCPU: the static bootstrap pair alone is $180, the 6 Karpenter nodes $198 |
+| **Spot compute, 10 nodes** | **369** | **largest single item** — 22 vCPU: a 2 × `m8i.large` static pair ($69) plus 8 Karpenter-provisioned nodes ($300), measured after right-sizing the static pair and letting Karpenter settle |
 | NAT gateway | 76 | $35 gateway-hours + ~$41 data processing (measured) |
 | EKS control plane | 73 | $0.10/hr, flat |
-| EBS, 753 GiB gp3 | 70 | 33 volumes |
+| EBS, ~900 GiB gp3 | 83 | 35 volumes |
 | 3 × network load balancer | 49 | public gateway, ZITADEL, OpenBao internal |
 | 2 × `t3.micro` on-demand | 17 | OpenBao, Tailscale subnet router |
 | Secrets Manager | 16 | the ~40 secrets the platform actually reads |
@@ -55,12 +55,15 @@ nodes and storage to per-signal service fees, and trade operating effort for
 bill opacity. If the platform adopts any of them, that will be a recorded
 decision with its price on this page, not a default left on.
 
-Compute is spot throughout — measured at $0.160 (`c7i-flex.2xlarge`) and
-$0.0863 (`c7i-flex.xlarge`) for the static bootstrap pair, plus 3 × $0.0405
-(`c7i-flex.large`), $0.0481 (`c8i-flex.large`), $0.0477 (`m8i.large`) and
-$0.0544 (`r5ad.large`) per hour for the Karpenter fleet. The Karpenter line
-moves between runs; the bootstrap pair never does — Karpenter cannot
-consolidate a managed node group.
+Compute is spot throughout, and one measurement here is worth recording: the
+static pair was originally xlarge/2xlarge (~$180/month on its own), and
+right-sizing it to `m8i.large` did **not** shave that off the bill — Karpenter
+grew by almost the same amount to absorb the displaced pods. The pair was
+carrying real capacity, not idle headroom. The lesson generalizes: what this
+platform pays for compute is set by what it *consumes*, and by node
+granularity — every extra node carries its own copy of the DaemonSet overhead
+(Cilium, CSI, exporters), which favors fewer, larger nodes over many small
+ones.
 
 ## GCP — about $10/day
 
@@ -76,20 +79,24 @@ consolidate a managed node group.
 
 ## Why they differ
 
-At list price AWS runs at about **2.2×** GCP — but most of that is not cloud
-pricing. Re-price AWS at gcp-0's exact footprint (12 spot vCPUs, 283 GB of
-disk, a trimmed secret/key inventory) and it lands near **$400/month**, about
-**1.3×** GCP:
+At list price AWS runs at about **2.2×** GCP. Separating what the *clouds*
+charge from what *this deployment* consumes:
 
-- **Most of the gap is deployment drift**, all fixable on our side: the
-  oversized static bootstrap pair (~$120), a Karpenter fleet holding twice
-  GCP's vCPUs (~$85), 2.8× the provisioned disk (~$44), and smaller inventory
-  differences for the rest.
-- **The remaining ~$80/month is genuinely AWS charging more**: three metered
-  NLBs against forwarding rules under a flat minimum, NAT gateway-hours, the
-  per-secret and per-key pricing model, and a ~10% spot premium at equal vCPUs.
-  One line runs the other way — `pd-balanced` costs ~18% more per GiB than gp3.
-- The control-plane fee is a wash at list price; both charge $0.10/hour.
+- **Cloud pricing accounts for roughly 1.3× of it.** Priced at identical
+  consumption (12 spot vCPUs, the same disk and inventory), AWS lands near
+  **$410/month** against GCP's $317: a ~25% spot premium per vCPU, three
+  metered NLBs against forwarding rules under a flat minimum, NAT
+  gateway-hours, and the per-secret/per-key pricing model. One line runs the
+  other way — `pd-balanced` costs ~18% more per GiB than gp3 — and the
+  control-plane fee is a wash: both charge $0.10/hour.
+- **The rest is consumption, on our side of the ledger, and it was measured
+  rather than assumed**: the AWS deployment consumes ~22 spot vCPUs where GCP
+  serves the platform on 12. Right-sizing the static pair did not close it —
+  the capacity simply moved to Karpenter. The drivers are node granularity
+  (ten 2-vCPU nodes pay ten copies of the per-node DaemonSet overhead; GCP
+  packs onto three 4-vCPU machines), scheduling fragmentation on small nodes,
+  3× the provisioned block storage, and a few AWS-only components (Karpenter
+  itself, the demo applications).
 - The comparison is structurally fair since ADR-0024: **both clouds run their
   own ZITADEL and their own OpenBao**, and only public DNS stays AWS-owned.
 
@@ -121,22 +128,24 @@ aws kms list-keys --query 'Keys[].KeyId' --output text | xargs -n1 \
 
 ## What is worth attacking
 
-**1. The static bootstrap node group — ~$180/month for two nodes.** A
-`c7i-flex.2xlarge` + `c7i-flex.xlarge` pair that exists to host what must run
-before Karpenter does, and that Karpenter therefore can never consolidate. It
-is the single biggest lever on the bill: sizing the pair down is one variable
-in `opentofu/aws/eks/init/main.tf` and worth on the order of $120/month.
+**1. Node granularity.** The measured lesson above: the fleet runs ten mostly
+2-vCPU nodes, each carrying its own copy of the DaemonSet overhead. Steering
+Karpenter toward fewer, larger instances (NodePool requirements or
+consolidation preferences) is now the biggest compute lever — plausibly on the
+order of $100/month. (Right-sizing the static pair is already done; it moved
+capacity to Karpenter rather than removing it, which is how we know the
+remaining lever is granularity, not node-group sizing.)
 
 **2. NAT data processing costs more than the NAT gateway** — $41/month against
 $35/month of gateway-hours, from image pulls and telemetry egress. There are no
 VPC endpoints configured; S3 and ECR endpoints would take most of it out.
 
-**3. Provisioned EBS keeps growing** — 753 GiB across 33 volumes against
+**3. Provisioned EBS keeps growing** — ~900 GiB across 35 volumes against
 283 GB for the same charts on GCP. Worth one look at PVC sizes before calling
 it necessary.
 
-Together those are roughly **$200/month**, none of which requires changing what
-the platform does.
+Together those are plausibly **$150–200/month**, none of which requires
+changing what the platform does.
 
 ## Keeping it cheap
 

--- a/website/content/docs/get-started/costs.md
+++ b/website/content/docs/get-started/costs.md
@@ -1,7 +1,7 @@
 ---
 title: What it costs
 weight: 45
-description: What the platform actually bills on each cloud, measured rather than estimated, and which lines are worth attacking.
+description: A rough monthly estimate of what the platform costs on each cloud, how the two compare on equal terms, and which lines are worth attacking.
 lastVerified: 2026-09-01
 ---
 
@@ -26,7 +26,7 @@ data processing, egress) are called out rather than measured.
 | Line | $/month | Notes |
 |---|---:|---|
 | **Spot compute, 6 nodes** | **331** | **largest single item** — 20 vCPU: a 2 × `m8i.large` static pair ($67) plus 4 Karpenter xlarge-class nodes ($264) |
-| NAT gateway | 35+ | gateway-hours; data processing was ~$41/month before an S3 gateway endpoint was added — expect most of that gone, not yet re-measured |
+| NAT gateway | 35+ | gateway-hours. Data processing is billed on top and can match it — an S3 gateway endpoint takes out most of that traffic |
 | EKS control plane | 73 | $0.10/hr, flat |
 | EBS, 443 GiB gp3 | 41 | 27 volumes |
 | 3 × network load balancer | 49 | public gateway, ZITADEL, OpenBao internal |
@@ -55,25 +55,13 @@ nodes and storage to per-signal service fees, and trade operating effort for
 bill opacity. If the platform adopts any of them, that will be a recorded
 decision with its price on this page, not a default left on.
 
-Compute is spot throughout, and two experiments here are worth recording
-because both under-delivered against the obvious theory:
-
-1. **Right-sizing the static node group.** It ran xlarge/2xlarge (~$180/month
-   on its own). Moving it to `m8i.large` did **not** shave that off the bill —
-   Karpenter grew by almost as much to absorb the displaced pods. The pair was
-   carrying real capacity, not idle headroom.
-2. **Forcing fewer, larger nodes** (a 4-vCPU floor on the NodePool). Node count
-   nearly halved, 10 → 6, but total consumption moved only 22 → 20 vCPU and the
-   bill only $369 → $331. Per-vCPU spot pricing is near-flat between `large`
-   and `xlarge`, so consolidating mostly removed **per-node overhead** (one
-   fewer copy of every DaemonSet, less scheduling fragmentation) rather than
-   capacity.
-
-The generalizable lesson: on a spot fleet, **what you pay for compute is set by
-what the workloads actually consume**. Node shape and count are worth tuning —
-they were worth ~$38/month here, and they cut provisioned disk by half because
-each node carries its own root and data volumes — but no instance-type choice
-substitutes for right-sizing the workloads themselves.
+Compute is spot throughout, and it is the line most worth understanding before
+trying to shrink it. Spot pricing per vCPU is close to flat across instance
+sizes, so **consolidating onto fewer, larger nodes saves per-node overhead —
+one fewer copy of every DaemonSet, less scheduling fragmentation, fewer root
+and data volumes — rather than capacity.** That is worth having (it also cuts
+provisioned disk, since every node carries its own volumes), but it is a
+second-order saving. What sets this line is what the workloads request.
 
 ## GCP — about $10/day
 
@@ -99,12 +87,12 @@ charge from what *this deployment* consumes:
   gateway-hours, and the per-secret/per-key pricing model. One line runs the
   other way — `pd-balanced` costs ~18% more per GiB than gp3 — and the
   control-plane fee is a wash: both charge $0.10/hour.
-- **The rest is consumption, on our side of the ledger, and it was measured
-  rather than assumed**: this deployment consumes ~20 spot vCPUs where GCP
-  serves the platform on 12. Two tuning rounds narrowed it and neither closed
-  it, which is the useful part — the capacity is real. What remains is genuine
-  demand (AWS additionally runs Karpenter and the demo applications) plus
-  scheduling slack that no instance-type choice removes.
+- **The rest is consumption, not pricing**: this deployment consumes ~20 spot
+  vCPUs on AWS where GCP serves the platform on 12, and provisions more block
+  storage. Some of that is real (AWS additionally runs Karpenter and the demo
+  applications), some is scheduling slack. Either way it is a property of how
+  the platform is deployed, not of what the cloud charges — which is why the
+  headline ratio and the like-for-like ratio differ so much.
 - The comparison is structurally fair since ADR-0024: **both clouds run their
   own ZITADEL and their own OpenBao**, and only public DNS stays AWS-owned.
 
@@ -136,26 +124,29 @@ aws kms list-keys --query 'Keys[].KeyId' --output text | xargs -n1 \
 
 ## What is worth attacking
 
-The infrastructure-shaped levers have now been pulled, and what they were
-actually worth is recorded above: node shape and count (−$38/month), node
-volume sizing (−$42/month), an S3 gateway endpoint for NAT data processing
-(worth up to ~$41/month, not yet re-measured). What is left is not
-configuration:
+In rough order of what they return:
 
-**1. Right-size the workloads.** ~20 vCPU is consumed for what GCP serves on
-12, and two rounds of node tuning did not move that — so the remaining compute
-cost is requests and replica counts, not instance types. Start with the
-components that run more replicas here than they need to.
+**1. Workload requests and replica counts.** Compute is the largest line on
+both clouds, and node-level tuning only trims the overhead around it. Pod
+requests, replica counts and retention windows are what actually move it.
 
-**2. Single-instance databases block node lifecycle.** A CNPG cluster with
+**2. Node shape and provisioned disk.** A minimum instance size on the NodePool
+(`karpenter.k8s.aws/instance-cpu` with a `Gt` requirement) consolidates the
+fleet, and because each node carries its own root and data volumes, fewer nodes
+also means less EBS. Check the EC2NodeClass `blockDeviceMappings` too — a
+volume sized for an occasional peak is paid for on every node, every hour.
+
+**3. NAT data processing.** It can cost as much as the NAT gateway itself,
+mostly from image pulls. An S3 **gateway** endpoint is free and captures ECR
+layer traffic along with S3; ECR *interface* endpoints bill per hour and are
+usually not worth adding on top.
+
+**4. Single-instance databases block node lifecycle.** A CNPG cluster with
 `instances: 1` has a PodDisruptionBudget that can never permit a voluntary
-eviction, so it pins its node against consolidation, drift and upgrades
-indefinitely — the node has to be cordoned and the pod restarted by hand. This
-is an availability and operations cost more than a billing one, and it is worth
-knowing before you scale a database down to save a replica.
-
-**3. Watch what accumulates.** Provisioned disk and node count creep back after
-every rebuild; both are worth re-measuring rather than assumed stable.
+eviction, so it pins its node against consolidation, drift and upgrades until
+someone cordons the node and restarts the pod by hand. That is an availability
+and operations cost rather than a billing one — worth knowing before scaling a
+database down to save a replica.
 
 ## Keeping it cheap
 
@@ -169,7 +160,7 @@ expensive choices are the ones that look like defaults:
 - **`mode = "dev"` for OpenBao** (`opentofu/aws/openbao/cluster/variables.tfvars`)
   is one `t3.micro`. `mode = "ha"` is five spot instances, and the configuration
   steps are identical either way.
-- **Tear it down when you are done.** At ~$23/day, AWS costs more in three days
+- **Tear it down when you are done.** At ~$19/day, AWS costs more in two days
   than a month of the idle floor.
 
 ## Related

--- a/website/content/docs/get-started/costs.md
+++ b/website/content/docs/get-started/costs.md
@@ -5,11 +5,14 @@ description: What the platform actually bills on each cloud, measured rather tha
 lastVerified: 2026-09-01
 ---
 
-Roughly **$700/month on AWS** and **$320/month on GCP** for the same platform at
+Roughly **$690/month on AWS** and **$320/month on GCP** for the same platform at
 list price, with the LLM components disabled on both.
 
-The more useful number is smaller: **about $80/month bills on AWS even when
-every cluster is destroyed**, and almost none of it is the platform.
+On top of that, AWS bills about **$45/month of residue that is not the platform
+at all** — secrets, KMS keys and one Kinesis stream left behind by past
+rebuilds. It is kept out of the platform totals above and itemized in
+[the floor section](#the-floor-you-pay-for-nothing), because the honest way to
+account for cruft is to name it, not to blend it in.
 
 {{< callout type="info" >}}
 Measured on 2026-09-01, about one hour after bootstrapping both platforms from
@@ -20,7 +23,9 @@ whatever the autoscalers held at snapshot time, and usage-based lines (NAT/LB
 data processing, egress) are called out rather than measured.
 {{< /callout >}}
 
-## AWS — about $25/day
+## AWS — about $23/day
+
+The platform, and only the platform — residue is counted separately below.
 
 | Line | $/month | Notes |
 |---|---:|---|
@@ -29,12 +34,11 @@ data processing, egress) are called out rather than measured.
 | EKS control plane | 73 | $0.10/hr, flat |
 | EBS, 753 GiB gp3 | 70 | 33 volumes |
 | 3 × network load balancer | 49 | public gateway, ZITADEL, OpenBao internal |
-| Secrets Manager | 34 | 84 secrets |
-| KMS | 31 | 31 customer-managed keys |
 | 2 × `t3.micro` on-demand | 17 | OpenBao, Tailscale subnet router |
-| Kinesis | 11 | orphaned stream — still, see below |
+| Secrets Manager | 16 | the ~40 secrets the platform actually reads |
 | Public IPv4 | 4 | the NAT gateway's EIP |
 | S3 | 3 | 8 buckets, ~112 GB (mostly LLM weights) |
+| KMS | 3 | 3 keys: cluster encryption, OpenBao unseal, snapshot bucket |
 | Route 53 | 1 | 2 hosted zones |
 
 ### CloudWatch is absent on purpose
@@ -80,10 +84,11 @@ pricing. Re-price AWS at gcp-0's exact footprint (12 spot vCPUs, 283 GB of
 disk, a trimmed secret/key inventory) and it lands near **$400/month**, about
 **1.3×** GCP:
 
-- **Two-thirds of the gap is deployment drift**, all fixable on our side: the
+- **Most of the gap is deployment drift**, all fixable on our side: the
   oversized static bootstrap pair (~$120), a Karpenter fleet holding twice
-  GCP's vCPUs (~$85), 2.8× the provisioned disk (~$44), and secrets, keys and
-  one Kinesis stream accumulated across rebuilds (~$60).
+  GCP's vCPUs (~$85), 2.8× the provisioned disk (~$44), and smaller inventory
+  differences for the rest. (The $45/month of rebuild residue is on top of
+  this — already excluded from the AWS platform total.)
 - **The remaining ~$80/month is genuinely AWS charging more**: three metered
   NLBs against forwarding rules under a flat minimum, NAT gateway-hours, the
   per-secret and per-key pricing model, and a ~10% spot premium at equal vCPUs.
@@ -97,38 +102,37 @@ Removing it closed a fifth of the gap on its own.
 
 ## The floor you pay for nothing
 
-On 2026-08-28 — a full day with no cluster on either cloud — AWS still billed
-**$2.19**:
+With every cluster destroyed, AWS still bills about **$70/month**: the 84
+secrets, the 19 enabled KMS keys, the Kinesis stream, the backup buckets and
+the DNS zones all survive teardown. About **$23** of that is deliberate — the
+platform's ~40 secrets, its 3 keys, and
+[backup buckets that outlive their clusters on purpose]({{< relref "/docs/guides/restore-a-database.md" >}}).
 
-| Service | $/day | Why |
+The other **$45/month is residue**, audited item by item on 2026-09-01:
+
+| Residue | $/month | What it actually is |
 |---|---:|---|
-| Secrets Manager | 0.87 | **81 secrets**; the platform provisions about 10 |
-| KMS | 0.81 | **39 keys** |
-| Kinesis | 0.36 | `xplane-vector-stream` in `eu-west-1` |
-| S3 | 0.15 | backup buckets, which *should* outlive clusters |
-| Route 53 | 0.001 | 2 zones |
+| ~44 stale secrets | 18 | four layers: twins from the 2026-08-27 slash→dash renaming (~17), Grafana OnCall remnants (~9 — removed by ADR-0029), the `vault/` + `priv.cloud.ogenki.io` era (~8), dead experiments — gitlab, tofu-controller, kube-prometheus (~10) |
+| 16 stale KMS keys | 16 | **13 are the snapshot-bucket key, one leaked per rebuild**: teardown schedules the unseal and cluster keys for deletion but never this one. Plus three ancient cluster keys (`dev-giving-hen` 2022, `mgmt-trusty-bear` 2023, `mycluster-0`) |
+| Kinesis stream | 11 | `xplane-vector-stream` in `eu-west-1` — a region this platform does not deploy to — since 2023 |
 
-Only the S3 line is deliberate — [backup buckets outlive their clusters on
-purpose]({{< relref "/docs/guides/restore-a-database.md" >}}). The rest is
-residue from rebuilds:
+(12 more keys sit in `PendingDeletion`, which costs nothing — the teardown *does*
+clean what it knows about.)
 
-- **Secrets and KMS keys survive teardown by design.** The platform constitution
-  withholds delete permissions for stateful services, so `xplane-*` IAM, S3 and
-  secrets are re-adopted by name on the next deploy rather than recreated. That
-  is correct, and it means nothing ever removes the ones that stop being used.
-- **`xplane-vector-stream` sits in `eu-west-1`**, a region this platform does not
-  deploy to at all — left from an old Vector experiment.
-
-By 2026-09-01 the same lines had grown, not shrunk: **84 secrets, 31
-customer-managed keys, and the stream still ACTIVE** — about $80/month. GCP's
-equivalent floor is **under $4/month** (secret versions, backup buckets, one
-DNS zone, one key version).
+Why it accumulates: **secrets and KMS keys survive teardown by design.** The
+platform constitution withholds delete permissions for stateful services, so
+`xplane-*` IAM, S3 and secrets are re-adopted by name on the next deploy rather
+than recreated. That is correct, and it means nothing ever removes the ones
+that stop being used. GCP's floor is **under $4/month** — the project is
+younger, not better designed; give it the same number of rebuilds and it will
+grow the same layers unless swept.
 
 The pattern is worth naming: **teardown is thorough about compute and blind to
 everything that outlives a cluster.** The
 [EBS]({{< relref "/docs/get-started/aws/teardown.md" >}}) and PD sweeps close one
 leak of exactly this shape; secrets, KMS keys and cross-region leftovers are the
-same shape, unswept.
+same shape, unswept — and the snapshot-bucket key is a one-line fix away from
+being scheduled for deletion like its two siblings.
 
 ## What is worth attacking
 
@@ -155,14 +159,18 @@ is the single biggest lever left on the bill: sizing the pair down is one
 variable in `opentofu/aws/eks/init/main.tf` and worth on the order of
 $120/month.
 
-**3. The idle floor — now $80/month, still unswept.** Two audits later the
-orphaned secrets and KMS keys have grown (84 and 31), and the stray stream is
-still ACTIVE. Delete it:
+**3. The $45/month of residue — audited, still unswept.** The table above
+names every item; none of it is load-bearing. Two audits have now prescribed
+the same first command:
 
 ```bash
 aws --region eu-west-1 kinesis delete-stream \
   --stream-name xplane-vector-stream --enforce-consumer-deletion
 ```
+
+Then the ~44 stale secrets and 16 stale keys — and, so the pile stops growing,
+schedule the snapshot-bucket KMS key for deletion at teardown the way the
+unseal and cluster keys already are.
 
 **4. NAT data processing costs more than the NAT gateway** — $41/month against
 $35/month of gateway-hours, from image pulls and telemetry egress. There are no
@@ -172,7 +180,7 @@ VPC endpoints configured; S3 and ECR endpoints would take most of it out.
 283 GB for the same charts on GCP. Worth one look at PVC sizes before calling
 it necessary.
 
-Together those are roughly **$300/month**, none of which requires changing what
+Together those are roughly **$250/month**, none of which requires changing what
 the platform does.
 
 ## Keeping it cheap
@@ -187,7 +195,7 @@ expensive choices are the ones that look like defaults:
 - **`mode = "dev"` for OpenBao** (`opentofu/aws/openbao/cluster/variables.tfvars`)
   is one `t3.micro`. `mode = "ha"` is five spot instances, and the configuration
   steps are identical either way.
-- **Tear it down when you are done.** At ~$24/day, AWS costs more in three days
+- **Tear it down when you are done.** At ~$23/day, AWS costs more in three days
   than a month of the idle floor.
 
 ## Related


### PR DESCRIPTION
Follow-up to today's dual bootstrap (#1934–#1937): the pricing page re-measured against both live platforms, kept deliberately rough.

**Headline:** ~$700/mo AWS, ~$320/mo GCP **at list price** (2.2×). New short **'Why they differ'** section: two-thirds of the gap is deployment drift on our side (static bootstrap pair ~$120, 24-vs-12 vCPU footprint ~$85, 2.8× disk ~$44, accumulated secrets/keys/stream ~$60); the genuine cloud-price difference is ~$80/mo ≈ **1.3× at equal footprint**.

**Corrections vs the 2026-08-29 page:**
- GKE control plane counted at **list** — the zonal free-tier credit is an account-level promotion the old page silently assumed; it's now a footnote, not a price.
- E2 spot catalog rate nearly doubled since the August estimate; forwarding rules re-read as the ≤5-rule flat minimum ($20, not $54).
- AWS spot fleet hotter (8 nodes/24 vCPU), EBS 753 GiB, idle floor ~$80/mo — and `xplane-vector-stream` (eu-west-1) is still ACTIVE two audits after the page first prescribed deleting it.
- CloudWatch absence verified live post-#1935 (log group exists, 0 stored bytes).
- Attack list re-ranked: the static bootstrap node pair (~$180/mo, invisible to Karpenter) is now #2 behind the already-done CloudWatch fix.

**Evidence:** `validate-doc-claims.sh` → 15/15 (27 page checks); `validate-links.sh` → all resolve. Sources: live `describe-spot-price-history` (AWS), Cloud Billing Catalog API (GCP), snapshots 08:33–08:47 UTC.