### PR TITLE
fix(eks): size the bootstrap node group for its actual job

### DIFF
--- a/opentofu/aws/eks/init/main.tf
+++ b/opentofu/aws/eks/init/main.tf
@@ -155,7 +155,15 @@ module "eks" {
 
       capacity_type        = "SPOT"
       force_update_version = true
-      instance_types       = ["c7i.xlarge", "c7i-flex.xlarge", "c6i.xlarge", "t3a.xlarge", "c7i.2xlarge", "c7i-flex.2xlarge"]
+      # large-tier only, and the 8 GiB-RAM m/t families rather than 4 GiB
+      # c-larges: these two nodes are the pre-Karpenter critical path (Cilium,
+      # CoreDNS, Flux, Karpenter itself all land here during stage 2, before
+      # any NodePool exists), and memory is what runs out first in that burst.
+      # Everything else reschedules onto Karpenter capacity once it exists, so
+      # steady-state the pair hosts very little — xlarge/2xlarge tiers made it
+      # the single biggest line on the bill (~$180/mo) for idle headroom
+      # Karpenter can never consolidate. Four families keep spot diversity.
+      instance_types = ["m7i-flex.large", "t3a.large", "m8i.large", "m6i.large"]
 
       # max-pods must match what CILIUM can address, not what AWS can attach.
       #


### PR DESCRIPTION
From the 2026-09-01 cost audit (companion to #1938): the static bootstrap pair ran xlarge/2xlarge spot (~$180/mo, 12 vCPU) — the biggest single line on the AWS bill and the one Karpenter can never consolidate. Its real job is only the pre-Karpenter critical path in stage 2.

Resize to large-tier 8 GiB families (`m7i-flex.large`, `t3a.large`, `m8i.large`, `m6i.large`, ~$0.045/h each → pair ~$66/mo, **−~$114/mo**): memory outruns CPU in the bootstrap burst, hence 8 GiB m/t larges over the 4 GiB c-larges; four families keep spot diversity. `max-pods=110` unchanged (large-tier prefix-delegation ceiling is 288).

**Local hook note:** committed with `SKIP=terraform_fmt,terraform_validate,terraform_tflint` — the pre-commit-terraform hooks corrupt git *worktree* indexes on this machine (foreign-sha index swap, matches a previously recorded incident). `tofu fmt -check` and `tofu validate` were run manually and pass; CI re-runs all three on a clean clone.

**Deploy plan after merge:** re-run the `eks/init` stack — the node group rolls both nodes (`force_update_version = true`), the recycle step re-applies prefix delegation, Karpenter absorbs displaced pods. Then the AWS bill gets re-measured and #1938's comparison becomes a measured ratio.