### PR TITLE
fix(karpenter): 4-vCPU floor on the default NodePool

### DIFF
--- a/infrastructure/base/karpenter-nodepools/default-nodepool.yaml
+++ b/infrastructure/base/karpenter-nodepools/default-nodepool.yaml
@@ -28,6 +28,15 @@ spec:
         - key: karpenter.k8s.aws/instance-cpu
           operator: Lt
           values: ["26"]
+        # ...but not tiny ones either. Measured 2026-09-01 (#1940): with no
+        # floor the fleet settles as many 2-vCPU nodes, and every node pays
+        # its own copy of the DaemonSet overhead (Cilium, CSI, exporters)
+        # plus scheduling fragmentation — ~22 vCPU consumed for a workload
+        # GCP packs into 12 on three 4-vCPU machines. A 4-vCPU floor keeps
+        # the 4–25 band: fewer, larger nodes, same spot diversity.
+        - key: karpenter.k8s.aws/instance-cpu
+          operator: Gt
+          values: ["3"]
         - key: karpenter.k8s.aws/instance-memory
           operator: Lt
           values: ["50001"]


### PR DESCRIPTION
Closes #1940. Measured 2026-09-01 (#1938/#1939 context): with no size floor Karpenter settles as many 2-vCPU nodes — ~22 vCPU consumed vs 12 on gcp-0's three 4-vCPU machines — since each node pays its own DaemonSet-overhead copy plus fragmentation. The #1939 experiment proved capacity just moves between groups, so granularity is the real lever.

`instance-cpu Gt 3` keeps the pool in a 4–25 vCPU band with the existing blast-radius ceiling; families/diversity unchanged. Expected: the ~8-node fleet re-consolidates onto ~4 xlarge-class nodes (plausibly ~$50–100/mo). Will re-measure with the two-stable-snapshots method after merge and settling.

Evidence: `validate-manifests.sh` → exit 0, all gates.