### PR TITLE
feat(network): S3 gateway endpoint to cut NAT data processing

### DIFF
--- a/opentofu/aws/network/network.tf
+++ b/opentofu/aws/network/network.tf
@@ -68,3 +68,26 @@ resource "aws_route_table_association" "pods" {
   subnet_id      = aws_subnet.pods[count.index].id
   route_table_id = module.vpc.private_route_table_ids[0]
 }
+
+# S3 gateway endpoint: free, and it takes the bulk of NAT data processing out
+# (#1941 — measured ~$41/month against $35/month of gateway-hours). Image
+# pulls are the main driver, and ECR serves LAYER bytes from S3, so this one
+# endpoint captures them along with CNPG backups and every other S3 flow from
+# the private and pod subnets. DNS is unchanged (traffic is steered by the
+# endpoint's prefix list in the route tables), so Cilium toFQDNs policies are
+# unaffected.
+#
+# ECR *interface* endpoints (api/dkr) are deliberately NOT added: with layers
+# riding S3 only the small auth/manifest calls remain on the NAT path, and two
+# interface endpoints bill ~$16/month — more than they would save here.
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = module.vpc.vpc_id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = module.vpc.private_route_table_ids
+
+  tags = merge(
+    local.tags,
+    { Name = "vpc-${var.region}-${var.env}-s3" }
+  )
+}


### PR DESCRIPTION
Closes #1941. NAT data processing bills ~$41/mo against $35/mo of gateway-hours (2026-09-01 audit, #1938), mostly image pulls — and **ECR serves layer bytes from S3**, so one free Gateway endpoint captures those plus CNPG backups and all other S3 flows from the private/pod subnets. DNS is unchanged (prefix-list routing) → Cilium `toFQDNs` policies unaffected.

ECR interface endpoints (api/dkr) deliberately skipped: with layers on the S3 path only small auth/manifest calls remain via NAT, and two interface endpoints cost ~$16/mo — more than they'd save here.

Deploy after merge: `opentofu/aws/network` stack re-apply (adds the endpoint + route entries in place, no disruption).

**Evidence:** `tofu fmt -check` + `tofu validate` → clean (run manually; terraform pre-commit hooks skipped locally due to the known worktree-index corruption — CI re-runs them on a clean clone).