### PR TITLE
fix(karpenter): size the default pool's data volume for the routine case

### DIFF
--- a/infrastructure/base/karpenter-nodepools/default-ec2nc.yaml
+++ b/infrastructure/base/karpenter-nodepools/default-ec2nc.yaml
@@ -10,7 +10,13 @@ spec:
     maxPods: 100
   # Default 4Gi OS + 20Gi data isn't enough for the LLM platform's preload
   # Jobs (model weights up to ~16GB into emptyDir before S3 upload).
-  # 80Gi gives ~60Gi free after kubelet/system overhead.
+  # 50Gi gives ~30-35Gi free after kubelet/system overhead and image cache —
+  # still 2× the largest documented preload. This volume is replicated on
+  # EVERY default-pool node (measured 2026-09-01, #1942: 8 × 80Gi = 640 GiB,
+  # ~70% of all provisioned EBS, for a preload path that is suspended by
+  # default); size it for the routine case, not the peak of an opt-in
+  # feature. If a future model exceeds it, raise this together with the gpu
+  # pool's ec2nc rather than paying for it fleet-wide.
   blockDeviceMappings:
     - deviceName: /dev/xvda
       ebs:
@@ -21,7 +27,7 @@ spec:
     - deviceName: /dev/xvdb
       ebs:
         volumeType: gp3
-        volumeSize: 80Gi
+        volumeSize: 50Gi
         encrypted: true
         deleteOnTermination: true
   subnetSelectorTerms:


### PR DESCRIPTION
Closes #1942. The EBS review found the ~900-vs-283 GiB gap is **not PVCs** (143 vs 83 Gi, delta = demo-app DB + Zitadel HA replica, both deliberate) — it's the **80Gi data volume on every default-pool node** (8 × 80 = 640 GiB, ~70% of provisioned EBS), sized for the LLM preload peak while that feature ships suspended.

50Gi keeps ~30–35Gi free after overhead + image cache — still 2× the largest documented preload (~16GB). If a future model outgrows it, raise it together with the GPU pool's ec2nc rather than fleet-wide. Karpenter drift-replaces nodes on EC2NodeClass change, so this rolls the fleet once, conveniently alongside the #1944 size floor.

Expected: roughly −$25/mo now, more as the node count drops. **Evidence:** `validate-manifests.sh` → exit 0 all gates; PVC/volume census in #1942.