### PR TITLE
fix(idp): keep the consumer name as the secret-merge dispatch key

### DIFF
--- a/.doc-claims.yaml
+++ b/.doc-claims.yaml
@@ -266,6 +266,31 @@ claims:
       - 'never actually deploys'
       - 'wired into no Kustomization'
 
+  - id: idp-primary-cloud-singleton
+    why: >-
+      The identity provider is a primary-cloud singleton (ADR-0027), and
+      the pages describing it drifted the moment the configuration changed:
+      cloud-support.md still said "gcp-0 takes that opt-out today and runs
+      its own instance", and the migration guide still told operators to
+      set `deploy_identity_provider` in variables.tfvars -- a literal that
+      no longer exists and that a `-var` would override in silence.
+
+      Both statements were true when written, which is exactly why they
+      need pinning rather than trusting: a reader following either one
+      would half-flip the topology and get no error. The banned phrases
+      are the two shapes of the retired model -- the tfvars literal as a
+      settable gate, and the "neither can enforce the other" pairing that
+      is now one derived and one verified.
+    source:
+      file: opentofu/config.tm.hcl
+      must_contain: 'primary_cloud\s*=\s*"aws"'
+    pages:
+      - website/content/docs/platform/foundations/cloud-support.md
+      - website/content/docs/guides/migrate-the-identity-provider.md
+    must_not_contain:
+      - 'deploy_identity_provider` in `opentofu/gcp/gke/configure/variables.tfvars'
+      - 'neither can enforce the other'
+
   - id: runlore-alerts-both-clouds
     why: >-
       The 12 RunLore health alerts sat in the aws-0 overlay for months

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,9 +211,6 @@ jobs:
         run: |
           find ./scripts -name "*.sh" -type f -print0 | xargs -0 shellcheck -x -S warning
 
-      - name: Run script unit tests
-        run: ./scripts/test-validate-idp-topology.sh
-
   links:
     name: Check the documentation links 🔗
     runs-on: ubuntu-latest
@@ -232,7 +229,20 @@ jobs:
         run: ./scripts/validate-doc-claims.sh
 
       # Folded into this job for the same reason as the claims check above: the
-      # required-check list on `main` does not have to change. It needs the
-      # pyyaml installed for that step.
+      # required-check list on `main` does not have to change.
+      #
+      # It runs HERE rather than in the shellcheck job because it needs the
+      # pyyaml installed above. The shellcheck job installs only shellcheck, and
+      # this repo does not treat "it happens to be in the runner image" as a
+      # dependency declaration.
       - name: Check identity provider topology
         run: ./scripts/validate-idp-topology.sh
+
+      # Glob, not a list: a test script added under scripts/ should run without
+      # anyone remembering to add a line here.
+      - name: Run script unit tests
+        run: |
+          for t in ./scripts/test-*.sh; do
+            echo "== $t"
+            "$t"
+          done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,6 +211,9 @@ jobs:
         run: |
           find ./scripts -name "*.sh" -type f -print0 | xargs -0 shellcheck -x -S warning
 
+      - name: Run script unit tests
+        run: ./scripts/test-validate-idp-topology.sh
+
   links:
     name: Check the documentation links 🔗
     runs-on: ubuntu-latest
@@ -227,3 +230,9 @@ jobs:
 
       - name: Check documentation claims against configuration
         run: ./scripts/validate-doc-claims.sh
+
+      # Folded into this job for the same reason as the claims check above: the
+      # required-check list on `main` does not have to change. It needs the
+      # pyyaml installed for that step.
+      - name: Check identity provider topology
+        run: ./scripts/validate-idp-topology.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -238,11 +238,11 @@ jobs:
       - name: Check identity provider topology
         run: ./scripts/validate-idp-topology.sh
 
-      # Glob, not a list: a test script added under scripts/ should run without
-      # anyone remembering to add a line here.
-      - name: Run script unit tests
-        run: |
-          for t in ./scripts/test-*.sh; do
-            echo "== $t"
-            "$t"
-          done
+      # Named explicitly, NOT globbed over scripts/test-*.sh. There are 12 such
+      # scripts and CI runs none of them today; a glob here would silently
+      # activate the other 11 as a side effect of this change, and two of them
+      # (test-flux-schema.sh, test-vector-vrl.sh) do not pass in a bare
+      # environment. Wiring them up is worth doing on its own terms -- see the
+      # tracking issue -- not as a drive-by.
+      - name: Run identity provider topology tests
+        run: ./scripts/test-validate-idp-topology.sh

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -219,21 +219,21 @@
         "filename": "opentofu/config.tm.hcl",
         "hashed_secret": "96898826888b767f1adfbc6fb0ca9d14662a5109",
         "is_verified": false,
-        "line_number": 36
+        "line_number": 47
       },
       {
         "type": "Secret Keyword",
         "filename": "opentofu/config.tm.hcl",
         "hashed_secret": "67eb9c5e5cea1c277d94bbd9cbe464b7d90d5679",
         "is_verified": false,
-        "line_number": 41
+        "line_number": 52
       },
       {
         "type": "Secret Keyword",
         "filename": "opentofu/config.tm.hcl",
         "hashed_secret": "cf6b2ae93c70a7fb628cbb8d9cd7ec0b7e4661e5",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 53
       }
     ],
     "opentofu/gcp/gke/configure/variables.tfvars": [
@@ -328,5 +328,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-01T08:18:01Z"
+  "generated_at": "2026-09-01T20:59:54Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -219,21 +219,21 @@
         "filename": "opentofu/config.tm.hcl",
         "hashed_secret": "96898826888b767f1adfbc6fb0ca9d14662a5109",
         "is_verified": false,
-        "line_number": 47
+        "line_number": 58
       },
       {
         "type": "Secret Keyword",
         "filename": "opentofu/config.tm.hcl",
         "hashed_secret": "67eb9c5e5cea1c277d94bbd9cbe464b7d90d5679",
         "is_verified": false,
-        "line_number": 52
+        "line_number": 63
       },
       {
         "type": "Secret Keyword",
         "filename": "opentofu/config.tm.hcl",
         "hashed_secret": "cf6b2ae93c70a7fb628cbb8d9cd7ec0b7e4661e5",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 64
       }
     ],
     "opentofu/gcp/gke/configure/variables.tfvars": [
@@ -328,5 +328,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-01T20:59:54Z"
+  "generated_at": "2026-09-01T21:25:46Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,7 @@ trivy config --exit-code=1 --ignorefile=./.trivyignore.yaml .
 ./scripts/validate-manifests.sh   # renders the repo, then gates it (see below)
 ./scripts/validate-links.sh       # resolves every relative Markdown link
 ./scripts/validate-doc-claims.sh  # docs still agree with config (.doc-claims.yaml)
+./scripts/validate-idp-topology.sh # exactly one cloud hosts ZITADEL (ADR-0027)
 kubectl get nodes && kubectl get pods --all-namespaces
 flux get all
 ```

--- a/clusters/aws-0/security/zitadel.yaml
+++ b/clusters/aws-0/security/zitadel.yaml
@@ -15,7 +15,16 @@ spec:
   suspend: false
   prune: true
   interval: 1m0s
-  timeout: 5m0s
+  # 15m, not 5m: this must be >= the time the HelmRelease can legitimately take,
+  # or the health check reports failure on every first bootstrap while Helm is
+  # still working. ZITADEL's own install timeout is 45m, and a restore-from-seed
+  # bootstrap really does take longer than five minutes -- CNPG recovery, then
+  # the replica join, then ZITADEL's schema migrations.
+  #
+  # Measured 2026-09-02: this Kustomization flapped False/Unknown for ~25
+  # minutes while the install underneath was progressing normally, which buried
+  # a real failure (a stuck certificate) in noise that looked identical.
+  timeout: 15m0s
   sourceRef:
     kind: ExternalArtifact
     name: security-artifact

--- a/clusters/aws-0/security/zitadel.yaml
+++ b/clusters/aws-0/security/zitadel.yaml
@@ -4,6 +4,15 @@ metadata:
   name: zitadel
   namespace: flux-system
 spec:
+  # ACTIVE: this cluster is the primary cloud (global.primary_cloud = "aws" in
+  # opentofu/config.tm.hcl), so it hosts the one identity provider (ADR-0027).
+  #
+  # Stated explicitly rather than left absent, so that the rule reads the same
+  # on both clusters: THE SECONDARY CLOUD IS SUSPENDED, THE PRIMARY IS NOT.
+  # An omitted field means the same thing to Flux, but it makes the pair look
+  # asymmetric and leaves a reader guessing whether the omission is a decision.
+  # ./scripts/validate-idp-topology.sh checks the pair against primary_cloud.
+  suspend: false
   prune: true
   interval: 1m0s
   timeout: 5m0s

--- a/clusters/gcp-0/security/zitadel.yaml
+++ b/clusters/gcp-0/security/zitadel.yaml
@@ -56,6 +56,19 @@ spec:
   # half-works in silence. Note that a GCP primary while AWS is also deployed
   # is rejected: opentofu/aws/eks/configure hosts unconditionally, so that
   # combination needs an AWS-side toggle and a new decision.
+  #
+  # KNOWN GAP while this cluster consumes aws-0's instance: nothing registers
+  # gcp-0's OIDC clients there. scripts/zitadel-oidc-clients.sh reads the admin
+  # PAT from the INVOKING cluster's own secret store, and its only automated
+  # caller is gke/init stage 3, which correctly skips when this cluster does not
+  # host. So gcp-0's redirect URIs must be added to aws-0's ZITADEL by hand
+  # until that script grows a cross-cluster mode -- otherwise headlamp's
+  # oauth2-proxy has no client secret and sits in CreateContainerConfigError.
+  # Tracked separately; do not discover it during a bootstrap.
+  #
+  # This field is also only half of a live migration: suspending stops Flux
+  # reconciling an instance, it does not remove one that is already running.
+  # See the warning in the migration guide.
   suspend: true
   prune: true
   interval: 1m0s

--- a/clusters/gcp-0/security/zitadel.yaml
+++ b/clusters/gcp-0/security/zitadel.yaml
@@ -17,35 +17,46 @@
 # HelmRelease health check would go Ready before the database is usable. The
 # 10m timeout is deliberately longer than aws-0's 5m for the same reason.
 #
-# ── ACTIVE: gcp-0 hosts its own instance ──────────────────────────────────────
-# ADR-0024 makes AWS the *default* host, but this cluster opts out of that
-# default so a GCP-only platform can log people in with aws-0 torn down.
+# ── INACTIVE: this cluster consumes aws-0's instance ──────────────────────────
+# ZITADEL is a primary-cloud singleton (ADR-0027) and AWS is primary
+# (global.primary_cloud in opentofu/config.tm.hcl), so this cluster does not
+# host one. It reaches auth.<aws public domain>, which every consumer here gets
+# from identity_provider_url in the cluster vars ConfigMap.
 #
-# That takes TWO gates, and they must always agree:
+# Placement still has two halves, but only one of them is typed now:
 #
-#   1. tofu:  deploy_identity_provider = true   (opentofu/gcp/gke/configure/
-#             variables.tfvars) -- drives identity_provider_url, which every
-#             consumer reads
-#   2. flux:  spec.suspend = false              (below)
+#   1. tofu:  deploy_identity_provider -- DERIVED from global.primary_cloud in
+#             workflows.tm.hcl; no longer a literal anyone can set out of step
+#   2. flux:  spec.suspend             -- committed below, and CHECKED against
+#             primary_cloud by ./scripts/validate-idp-topology.sh
 #
-# Gate 1 alone points every consumer at auth.<gcp public domain>, which nothing
-# serves. Gate 2 alone runs a ZITADEL that no consumer is configured to use --
-# and that failure is silent, because ZITADEL is up and the consumers are
-# healthy, they are simply pointed at another cluster's IdP. Neither half can
-# enforce the other; see ADR-0024. To consume aws-0's instance instead, flip
-# both back in one commit.
+# The failures this prevents are both silent. Hosting here while AWS also hosts
+# gives two user directories, where a grant means nothing without knowing which
+# one issued it. Pointing consumers at a host nothing serves breaks SSO at the
+# authorize step while ZITADEL and every consumer still report healthy.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: zitadel
   namespace: flux-system
 spec:
-  # Gate 2 of the two above, and it must keep agreeing with gate 1
-  # (deploy_identity_provider = true in opentofu/gcp/gke/configure/
-  # variables.tfvars). `flux suspend` is not a way to flip this durably --
-  # kustomize-controller owns the field and re-asserts the committed value on
-  # its next apply. Change it here, in the same commit as gate 1.
-  suspend: false
+  # SUSPENDED: aws-0 hosts the identity provider (global.primary_cloud = "aws",
+  # ADR-0027). ZITADEL is a singleton that RELOCATES for a GCP-only platform
+  # rather than being duplicated -- two directories mean a grant says nothing
+  # without knowing which one issued it.
+  #
+  # This is the half that cannot be derived: kustomize-controller owns the
+  # field and re-asserts the committed value on its next apply, and Flux never
+  # sees Terramate globals. `flux suspend` therefore does not flip it durably.
+  # ./scripts/validate-idp-topology.sh checks it against primary_cloud instead.
+  #
+  # To make GCP primary: set primary_cloud = "gcp" in opentofu/config.tm.hcl,
+  # flip this to false in the same commit, and MIGRATE the database seed, the
+  # admin credential and the OIDC clients -- they travel together or the move
+  # half-works in silence. Note that a GCP primary while AWS is also deployed
+  # is rejected: opentofu/aws/eks/configure hosts unconditionally, so that
+  # combination needs an AWS-side toggle and a new decision.
+  suspend: true
   prune: true
   interval: 1m0s
   timeout: 10m0s

--- a/docs/superpowers/plans/2026-09-01-idp-topology-enforcement.md
+++ b/docs/superpowers/plans/2026-09-01-idp-topology-enforcement.md
@@ -1,0 +1,576 @@
+# IdP Topology Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make it impossible to commit a configuration in which two clouds each host a ZITADEL, by declaring the primary cloud once and checking every gate against it in CI.
+
+**Architecture:** One new Terramate global, `primary_cloud`, becomes the single statement of which cloud hosts the services that cannot exist twice. The OpenTofu gate (`deploy_identity_provider`) stops being a hand-typed literal and is derived from that global at every invocation site. The Flux gate (`spec.suspend`) cannot be derived — Flux never sees Terramate globals — so a new shell script asserts it agrees with the global, and CI runs that script.
+
+**Tech Stack:** Bash + `python3`/`pyyaml` (already a CI dependency) for YAML reads, Terramate HCL globals, OpenTofu variables, Flux Kustomization manifests, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-idp-topology-enforcement-design.md`
+
+## Global Constraints
+
+- **Do not derive placement from `TM_CLOUD`.** `TM_CLOUD` selects which lane a single invocation deploys; the IdP's home must not change as a side effect of it (ADR-0027: relocation "is a deliberate act with a written procedure").
+- **Do not add a host toggle to `opentofu/aws/eks/configure`.** AWS hosting unconditionally is intentional for this change; the state that would need a toggle is rejected instead.
+- **Do not write a new ADR.** ADR-0024 and ADR-0027 get short amendments.
+- **An absent `spec.suspend` counts as not-suspended**, matching Flux's own default.
+- **Known clouds are exactly `aws` and `gcp`.** A third value must fail the check rather than be ignored.
+- **New CI checks fold into the existing `links` job** (`.github/workflows/ci.yaml`), never a new job — the repo does this deliberately so the required-check list on `main` does not have to change.
+- Shell scripts under `scripts/` are linted by `shellcheck -x -S warning` in CI and must pass.
+
+---
+
+### Task 1: The topology checker and its fixture tests
+
+Builds the checker first, against fixtures, so it can be proven to fail on the
+repository's current (non-compliant) state before Task 2 corrects it.
+
+**Files:**
+- Create: `scripts/validate-idp-topology.sh`
+- Create: `scripts/test-validate-idp-topology.sh`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `scripts/validate-idp-topology.sh [ROOT_DIR]` — exits `0` when the
+  committed topology is consistent, `1` otherwise, printing one `FAIL:` line per
+  violation to stdout. `ROOT_DIR` defaults to `git rev-parse --show-toplevel`.
+  Task 2 runs it against the real tree; Task 3 wires it into CI.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/test-validate-idp-topology.sh`:
+
+```bash
+#!/usr/bin/env bash
+#
+# Fixture-driven tests for validate-idp-topology.sh.
+#
+# The states this checker exists to catch are expensive to produce live -- two
+# clusters each running an identity provider is a two-cloud bootstrap -- so it
+# is tested against synthetic trees instead.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATOR="${SCRIPT_DIR}/validate-idp-topology.sh"
+failures=0
+
+# Build a fixture tree: primary cloud, then "<cluster>:<suspend>" pairs where
+# suspend is "true", "false", or "absent".
+make_fixture() {
+  local root="$1" primary="$2"
+  shift 2
+  mkdir -p "${root}/opentofu"
+  cat >"${root}/opentofu/config.tm.hcl" <<EOF
+globals {
+  region        = "eu-west-3"
+  primary_cloud = "${primary}"
+}
+EOF
+  local pair cluster suspend
+  for pair in "$@"; do
+    cluster="${pair%%:*}"
+    suspend="${pair##*:}"
+    mkdir -p "${root}/clusters/${cluster}/security"
+    {
+      echo "apiVersion: kustomize.toolkit.fluxcd.io/v1"
+      echo "kind: Kustomization"
+      echo "metadata:"
+      echo "  name: zitadel"
+      echo "spec:"
+      [ "$suspend" != "absent" ] && echo "  suspend: ${suspend}"
+      echo "  path: ./security/${cluster}/zitadel"
+    } >"${root}/clusters/${cluster}/security/zitadel.yaml"
+  done
+}
+
+# expect <name> <expected-exit> <expected-substring-or-empty> <primary> <pairs...>
+expect() {
+  local name="$1" want_exit="$2" want_text="$3" primary="$4"
+  shift 4
+  local root output rc
+  root="$(mktemp -d)"
+  make_fixture "$root" "$primary" "$@"
+  set +e
+  output="$("$VALIDATOR" "$root" 2>&1)"
+  rc=$?
+  set -e
+  rm -rf "$root"
+
+  if [ "$rc" -ne "$want_exit" ]; then
+    echo "FAIL ${name}: exit ${rc}, want ${want_exit}"
+    echo "     output: ${output}"
+    failures=$((failures + 1))
+    return
+  fi
+  if [ -n "$want_text" ] && ! grep -qF "$want_text" <<<"$output"; then
+    echo "FAIL ${name}: output missing '${want_text}'"
+    echo "     output: ${output}"
+    failures=$((failures + 1))
+    return
+  fi
+  echo "ok   ${name}"
+}
+
+expect "compliant: aws primary hosts, gcp suspended" \
+  0 "" aws "aws-0:absent" "gcp-0:true"
+
+expect "both clouds hosting is rejected" \
+  1 "gcp-0" aws "aws-0:absent" "gcp-0:false"
+
+expect "primary hosting nothing is rejected" \
+  1 "aws-0" aws "aws-0:true" "gcp-0:true"
+
+expect "gcp primary while aws is present is rejected" \
+  1 "unconditionally" gcp "aws-0:absent" "gcp-0:false"
+
+expect "unknown primary_cloud is rejected" \
+  1 "azure" azure "aws-0:absent" "gcp-0:true"
+
+# primary_cloud absent entirely
+root="$(mktemp -d)"
+mkdir -p "${root}/opentofu"
+echo 'globals {' >"${root}/opentofu/config.tm.hcl"
+echo '  region = "eu-west-3"' >>"${root}/opentofu/config.tm.hcl"
+echo '}' >>"${root}/opentofu/config.tm.hcl"
+mkdir -p "${root}/clusters/aws-0/security"
+printf 'spec:\n  suspend: false\n' >"${root}/clusters/aws-0/security/zitadel.yaml"
+set +e
+out="$("$VALIDATOR" "$root" 2>&1)"; rc=$?
+set -e
+rm -rf "$root"
+if [ "$rc" -eq 1 ] && grep -qF "primary_cloud" <<<"$out"; then
+  echo "ok   undeclared primary_cloud is rejected"
+else
+  echo "FAIL undeclared primary_cloud is rejected: exit ${rc}: ${out}"
+  failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+  echo "==> ${failures} test(s) failed"
+  exit 1
+fi
+echo "==> all tests passed"
+```
+
+Then make it executable:
+
+```bash
+chmod +x scripts/test-validate-idp-topology.sh
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./scripts/test-validate-idp-topology.sh`
+Expected: FAIL — every case errors because `scripts/validate-idp-topology.sh` does not exist yet (`No such file or directory`), and the script exits non-zero.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `scripts/validate-idp-topology.sh`:
+
+```bash
+#!/usr/bin/env bash
+#
+# Assert that exactly one cloud hosts the identity provider, and that it is the
+# cloud named by `primary_cloud` in opentofu/config.tm.hcl.
+#
+# WHY THIS EXISTS
+#
+# ADR-0027 makes ZITADEL a primary-cloud singleton: it relocates to whichever
+# cloud is primary, and two clouds each running one is ruled out -- two user
+# directories mean a grant says nothing without knowing which directory issued
+# it. Placement is set in two places that cannot enforce each other:
+#
+#   1. `deploy_identity_provider` (OpenTofu)  -- derived from primary_cloud
+#   2. `spec.suspend` (Flux Kustomization)    -- committed Git state
+#
+# Flux never sees Terramate globals, so gate 2 cannot be derived and is checked
+# here instead. The forbidden state has occurred twice; both times the intended
+# topology was written only in an ADR, where no machine could read it.
+#
+# Usage: validate-idp-topology.sh [ROOT_DIR]
+set -euo pipefail
+
+ROOT="${1:-$(git rev-parse --show-toplevel)}"
+CONFIG="${ROOT}/opentofu/config.tm.hcl"
+KNOWN_CLOUDS="aws gcp"
+failures=0
+
+fail() {
+  echo "FAIL: $*"
+  failures=$((failures + 1))
+}
+
+if [ ! -f "$CONFIG" ]; then
+  echo "FAIL: no ${CONFIG}"
+  exit 1
+fi
+
+primary="$(sed -n 's/^[[:space:]]*primary_cloud[[:space:]]*=[[:space:]]*"\([a-z0-9]*\)".*/\1/p' "$CONFIG" | head -1)"
+
+if [ -z "$primary" ]; then
+  echo "FAIL: primary_cloud is not declared in opentofu/config.tm.hcl."
+  echo "      ADR-0027 requires one named home for services that cannot exist twice."
+  exit 1
+fi
+
+if ! grep -qw "$primary" <<<"$KNOWN_CLOUDS"; then
+  echo "FAIL: primary_cloud = \"${primary}\" is not a known cloud (${KNOWN_CLOUDS})."
+  exit 1
+fi
+
+shopt -s nullglob
+manifests=("${ROOT}"/clusters/*/security/zitadel.yaml)
+shopt -u nullglob
+
+if [ ${#manifests[@]} -eq 0 ]; then
+  echo "FAIL: no clusters/*/security/zitadel.yaml found under ${ROOT}"
+  exit 1
+fi
+
+for manifest in "${manifests[@]}"; do
+  cluster="$(basename "$(dirname "$(dirname "$manifest")")")"
+  cloud="${cluster%%-*}"
+
+  # An absent spec.suspend means not suspended, which is how Flux reads it.
+  suspend="$(python3 - "$manifest" <<'PY'
+import sys, yaml
+with open(sys.argv[1]) as fh:
+    doc = yaml.safe_load(fh) or {}
+print(str((doc.get("spec") or {}).get("suspend", False)).lower())
+PY
+)"
+
+  if [ "$cloud" = "$primary" ]; then
+    if [ "$suspend" = "true" ]; then
+      fail "${cluster} is on the primary cloud (${primary}) but its identity provider is suspended."
+      echo "      Set spec.suspend: false in clusters/${cluster}/security/zitadel.yaml,"
+      echo "      or change primary_cloud in opentofu/config.tm.hcl."
+    fi
+  else
+    if [ "$suspend" != "true" ]; then
+      fail "${cluster} is not on the primary cloud (${primary}) but would run its own identity provider."
+      if [ "$cloud" = "aws" ]; then
+        echo "      opentofu/aws/eks/configure sets identity_provider_url unconditionally, so AWS"
+        echo "      hosts whenever it is deployed. A non-AWS primary with AWS deployed is not a"
+        echo "      supported combination -- it needs an AWS-side host toggle, which is a new decision."
+      else
+        echo "      Set spec.suspend: true in clusters/${cluster}/security/zitadel.yaml."
+      fi
+    fi
+  fi
+done
+
+if [ "$failures" -ne 0 ]; then
+  echo "==> identity provider topology is inconsistent (${failures} problem(s)); see ADR-0027."
+  exit 1
+fi
+
+echo "==> identity provider topology is consistent: ${primary} hosts, all other clouds suspended."
+```
+
+Then make it executable:
+
+```bash
+chmod +x scripts/validate-idp-topology.sh
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./scripts/test-validate-idp-topology.sh`
+Expected: PASS — six `ok` lines and `==> all tests passed`.
+
+- [ ] **Step 5: Confirm the checker fails on the current repository**
+
+Run: `./scripts/validate-idp-topology.sh; echo "exit=$?"`
+Expected: `exit=1`, reporting that `primary_cloud` is not declared. This is the
+red state Task 2 turns green — record the output in the commit message.
+
+- [ ] **Step 6: Verify shellcheck passes**
+
+Run: `shellcheck -x -S warning scripts/validate-idp-topology.sh scripts/test-validate-idp-topology.sh`
+Expected: no output, exit 0. (CI runs the same command across `scripts/`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/validate-idp-topology.sh scripts/test-validate-idp-topology.sh
+git commit -m "test(idp): check that exactly one cloud hosts the identity provider
+
+ADR-0027 makes ZITADEL a primary-cloud singleton and rules out two clouds
+each running one, but nothing enforced it and the forbidden state has
+occurred twice. Adds the checker and its fixture tests; it currently
+FAILS on this repository because primary_cloud is not declared yet.
+
+Fixture-driven because the states worth catching -- two clusters each
+hosting a directory -- are a two-cloud bootstrap to produce live."
+```
+
+---
+
+### Task 2: Declare the primary cloud, derive the OpenTofu gate, restore compliance
+
+**Files:**
+- Modify: `opentofu/config.tm.hcl` (globals block, near `region`)
+- Modify: `opentofu/gcp/gke/configure/workflows.tm.hcl:37` (deploy), `:55` (preview), `:102-107` (destroy), `:139` (drift detect)
+- Modify: `opentofu/gcp/gke/configure/variables.tfvars:57`
+- Modify: `clusters/gcp-0/security/zitadel.yaml`
+
+**Interfaces:**
+- Consumes: `scripts/validate-idp-topology.sh` from Task 1, as the acceptance test.
+- Produces: the Terramate global `global.primary_cloud` (string, `"aws"`), readable by any stack's `workflows.tm.hcl`.
+
+- [ ] **Step 1: Run the checker to see the failure this task fixes**
+
+Run: `./scripts/validate-idp-topology.sh; echo "exit=$?"`
+Expected: `exit=1` — `primary_cloud is not declared`.
+
+- [ ] **Step 2: Declare the global**
+
+In `opentofu/config.tm.hcl`, inside the `globals` block, immediately after the
+`region` / `profile` lines, add:
+
+```hcl
+  # Which cloud hosts the services that cannot sensibly exist twice: the public
+  # DNS zone, the cross-cloud federation trust, and ZITADEL (ADR-0027).
+  #
+  # Changing this is a MIGRATION, not a toggle. The identity provider's database
+  # seed, admin credential and OIDC clients travel with it or the move
+  # half-works in silence -- which is why placement is stated here once and
+  # never derived from TM_CLOUD, whose value changes per invocation.
+  #
+  # Enforced by ./scripts/validate-idp-topology.sh.
+  primary_cloud = "aws"
+```
+
+- [ ] **Step 3: Derive the OpenTofu gate at every invocation site**
+
+In `opentofu/gcp/gke/configure/workflows.tm.hcl`, append this argument to the
+`tofu` command in **all four** jobs — deploy (line ~37), preview (line ~55),
+destroy (line ~102-107), and drift detect (line ~139):
+
+```
+-var='deploy_identity_provider=${global.primary_cloud == "gcp"}'
+```
+
+For deploy and preview, append it to the existing single-line command after
+`-var='flux_instance_version=...'`. For destroy, add it as a new
+backslash-continued line after the `flux_instance_version` line. For drift
+detect — which passes no other `-var` today — append it after
+`-var-file=variables.tfvars`; without it, drift would compare against the
+variable's default and report a difference that does not exist.
+
+This is an HCL comparison, not a `tm_` function: Terramate's `tm_*` set mirrors
+Terraform's functions and Terraform has no `equal()`. The repo already uses this
+operator style in `global.stack_cloud`.
+
+- [ ] **Step 4: Remove the hand-typed literal**
+
+In `opentofu/gcp/gke/configure/variables.tfvars`, delete line 57
+(`deploy_identity_provider = true`) and replace the comment block above it
+(lines ~50-56, which describes flipping two gates by hand) with:
+
+```hcl
+# deploy_identity_provider is NOT set here. It is derived from
+# global.primary_cloud in workflows.tm.hcl, so that "which cloud hosts the
+# identity provider" has exactly one answer in configuration (ADR-0027).
+# The variable's own default is false, so a bare `tofu apply` in this directory
+# does not silently stand up a second identity directory.
+```
+
+- [ ] **Step 5: Restore the Flux gate to compliance**
+
+In `clusters/gcp-0/security/zitadel.yaml`, set `suspend: true` and replace the
+comment above it with:
+
+```yaml
+  # SUSPENDED: aws-0 hosts the identity provider (global.primary_cloud = "aws",
+  # ADR-0027). ZITADEL is a singleton that relocates for a GCP-only platform
+  # rather than being duplicated -- two directories mean a grant says nothing
+  # without knowing which one issued it.
+  #
+  # To make GCP primary: set primary_cloud = "gcp" in opentofu/config.tm.hcl,
+  # flip this to false, and migrate the database seed, admin credential and
+  # OIDC clients. ./scripts/validate-idp-topology.sh fails if these two
+  # disagree. Note that a GCP primary while AWS is also deployed is rejected:
+  # opentofu/aws/eks/configure hosts unconditionally.
+  suspend: true
+```
+
+Leave the surrounding two-gates narrative in the file's header comment intact
+only where it is still true; the gate-1 half is now derived, so delete any
+sentence instructing a reader to edit `deploy_identity_provider` by hand.
+
+- [ ] **Step 6: Run the checker to verify it now passes**
+
+Run: `./scripts/validate-idp-topology.sh; echo "exit=$?"`
+Expected: `exit=0` and
+`==> identity provider topology is consistent: aws hosts, all other clouds suspended.`
+
+- [ ] **Step 7: Verify the derivation renders**
+
+Run: `cd opentofu/gcp/gke/configure && terramate script list && cd -`
+Expected: exit 0, no HCL parse error. Then:
+
+Run: `terramate --chdir opentofu generate 2>&1 | tail -3`
+Expected: exit 0. A parse error in the interpolation surfaces here.
+
+- [ ] **Step 8: Verify the manifests still render**
+
+Run: `./scripts/validate-manifests.sh`
+Expected: exit 0, `==> All gates passed`. (The gcp-0 zitadel Kustomization is
+suspended, not deleted, so the rendered bundle is unchanged in content.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add opentofu/config.tm.hcl opentofu/gcp/gke/configure/workflows.tm.hcl \
+        opentofu/gcp/gke/configure/variables.tfvars \
+        clusters/gcp-0/security/zitadel.yaml
+git commit -m "fix(idp): declare the primary cloud and restore the singleton
+
+Adds global.primary_cloud = \"aws\" as the one statement of where the
+services that cannot exist twice live, derives the OpenTofu gate from it
+at all four invocation sites, and drops the hand-typed literal -- two
+gates that could disagree become one that cannot.
+
+Also restores gcp-0 to compliance: it had been left self-hosting after
+the GCP validation work, which is the state ADR-0027 rules out. Both
+clusters are destroyed, so this correction carries no database seed,
+admin credential or client secrets.
+
+Evidence: validate-idp-topology.sh exit 0; terramate generate exit 0;
+validate-manifests.sh all gates passed."
+```
+
+---
+
+### Task 3: Wire into CI and amend the records
+
+**Files:**
+- Modify: `.github/workflows/ci.yaml` (the `links` job, after the `validate-doc-claims.sh` step)
+- Modify: `CLAUDE.md` (Validation Commands block)
+- Modify: `website/content/docs/decisions/0024-identity-provider-per-cloud.md`
+- Modify: `website/content/docs/decisions/0027-primary-cloud-provider.md`
+
+**Interfaces:**
+- Consumes: `scripts/validate-idp-topology.sh` (Task 1) and `global.primary_cloud` (Task 2).
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Add the CI step**
+
+In `.github/workflows/ci.yaml`, in the `links` job, immediately after the
+`Check documentation claims against configuration` step, add:
+
+```yaml
+      # Also folded into this job rather than its own, for the reason above:
+      # the required-check list on `main` stays as it is.
+      - name: Check identity provider topology
+        run: ./scripts/validate-idp-topology.sh
+```
+
+The job already installs `pyyaml`, which the checker needs.
+
+- [ ] **Step 2: Add the test to the shell-script job**
+
+The `shellcheck` job already globs `./scripts -name "*.sh"`, so both new scripts
+are linted with no change. Add a step to actually run the unit tests, after the
+ShellCheck step in that job:
+
+```yaml
+      - name: Run script unit tests
+        run: ./scripts/test-validate-idp-topology.sh
+```
+
+- [ ] **Step 3: Document the command**
+
+In `CLAUDE.md`, in the `## Validation Commands` fenced block, add after the
+`validate-doc-claims.sh` line:
+
+```
+./scripts/validate-idp-topology.sh  # exactly one cloud hosts ZITADEL (ADR-0027)
+```
+
+- [ ] **Step 4: Amend ADR-0024**
+
+In `website/content/docs/decisions/0024-identity-provider-per-cloud.md`, in the
+table of two gates, change the Gate 1 row's "Where" cell to note the derivation,
+and add immediately below the table:
+
+```markdown
+{{< callout type="info" >}}
+**Update (2026-09-01):** gate 1 is no longer typed by hand. It is derived from
+`global.primary_cloud` (see
+[ADR-0027]({{< relref "/docs/decisions/0027-primary-cloud-provider.md" >}})) at
+every invocation site, so it cannot disagree with the declared topology. Gate 2
+remains committed Flux state — Flux never sees Terramate globals — and is
+checked instead by `./scripts/validate-idp-topology.sh`. "Neither can enforce
+the other" is now "one is derived, the other is verified."
+{{< /callout >}}
+```
+
+Bump `lastVerified` in the front matter to `2026-09-01`.
+
+- [ ] **Step 5: Amend ADR-0027**
+
+In `website/content/docs/decisions/0027-primary-cloud-provider.md`, add to the
+end of the **Consequences** section:
+
+```markdown
+**How it is enforced (2026-09-01).** The primary cloud is declared once, as
+`primary_cloud` in `opentofu/config.tm.hcl`. The OpenTofu gate that decides
+whether a cluster hosts ZITADEL is derived from it; the Flux gate, which cannot
+be derived, is checked against it by `./scripts/validate-idp-topology.sh` in CI.
+The third state this record rules out — two clouds each hosting a singleton —
+now fails a required check rather than depending on someone remembering the
+rule. A non-AWS primary while AWS is deployed is rejected too, since
+`opentofu/aws/eks/configure` hosts unconditionally; supporting it would need an
+AWS-side toggle and a new decision.
+```
+
+Bump `lastVerified` in the front matter to `2026-09-01`.
+
+- [ ] **Step 6: Run the documentation gates**
+
+Run: `./scripts/validate-links.sh && ./scripts/validate-doc-claims.sh`
+Expected: both exit 0.
+
+- [ ] **Step 7: Run the full check set once more**
+
+Run: `./scripts/validate-idp-topology.sh && ./scripts/test-validate-idp-topology.sh`
+Expected: both exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .github/workflows/ci.yaml CLAUDE.md \
+        website/content/docs/decisions/0024-identity-provider-per-cloud.md \
+        website/content/docs/decisions/0027-primary-cloud-provider.md
+git commit -m "ci(idp): gate the primary-cloud singleton invariant
+
+Runs validate-idp-topology.sh in the links job and the script unit tests
+in the shellcheck job -- both folded into existing jobs so the required
+check list on main does not change.
+
+Amends ADR-0024 (gate 1 is derived now, not hand-typed) and ADR-0027
+(how the invariant is enforced). No new ADR: the decision already
+existed, this only makes it checkable."
+```
+
+---
+
+## Self-review notes
+
+**Spec coverage.** Design §1 → Task 2 Step 2. §2 → Task 2 Step 3-4. §3 → Task 1.
+§4 → Task 2 Step 5. §5 → Task 1 Step 3 (the `cloud = "aws"` branch) and its test
+case. Testing table → Task 1 Step 1 (six cases; the design's five plus the
+undeclared-global case the script needs). Files-touched table → Tasks 1-3, with
+one deliberate difference: the design named a CI *job*, the plan folds the steps
+into two existing jobs per the repo's stated convention.
+
+**Success criteria.** 1 → Task 2 Step 6. 2 → Task 1 Step 4. 3 → Task 2 Step 7
+(rendering is verified; a full GCP plan needs credentials and is left to the
+next deploy). 4 → covered by the `gcp primary` fixture case rather than by
+mutating the real tree. 5 → explicitly deferred to the next dual bootstrap,
+as the design states.

--- a/docs/superpowers/specs/2026-09-01-idp-topology-enforcement-design.md
+++ b/docs/superpowers/specs/2026-09-01-idp-topology-enforcement-design.md
@@ -41,6 +41,18 @@ nowhere a machine can read it.**
 - **An AWS-side host toggle.** See *Unsupported state* below.
 - **A new ADR.** The decision exists. This is enforcement, so ADR-0024 and
   ADR-0027 get short amendments instead.
+- **Generating the Flux manifest with Terramate.** The obvious way to make gate
+  2 derived rather than checked, and it is technically possible — `generate_file`
+  takes `context = "root"`, so it is not confined to `opentofu/`. Rejected on
+  three grounds. Flux's `postBuild` substitution cannot reach a Kustomization's
+  own `spec`, only what it builds from `path`, so the field can be *generated*
+  but never *substituted* — the derivation would have to own the whole file.
+  Owning the whole file means either regenerating it (losing the narrative
+  comments that explain the gate) or marker-based patching, which is as fragile
+  as the hand-editing it replaces. And it crosses the repo's ownership line:
+  `opentofu/` is Terramate's, `clusters/` is hand-authored GitOps that Flux
+  reads directly, and trading that clarity for one boolean is a bad exchange.
+  Checking is the right altitude, not the fallback.
 
 ## Design
 

--- a/docs/superpowers/specs/2026-09-01-idp-topology-enforcement-design.md
+++ b/docs/superpowers/specs/2026-09-01-idp-topology-enforcement-design.md
@@ -1,0 +1,163 @@
+# Enforcing the primary-cloud IdP invariant
+
+**Date**: 2026-09-01
+**Status**: Approved, not implemented
+**Issue**: [#1947](https://github.com/Smana/cloud-native-ref/issues/1947)
+**Governing decisions**: [ADR-0027](../../../website/content/docs/decisions/0027-primary-cloud-provider.md) (AWS is the primary cloud), [ADR-0024](../../../website/content/docs/decisions/0024-identity-provider-per-cloud.md) (the IdP is per-cloud deployable)
+
+## Problem
+
+ADR-0027 already decides the topology this design enforces: ZITADEL is a
+**primary-cloud singleton**, hosted on whichever cloud is primary, relocating —
+never duplicating — when only GCP runs. It explicitly rules out the third state,
+"two clouds running with the singletons duplicated."
+
+Nothing enforces it. Placement is two hand-set gates that must agree, and
+ADR-0024 says plainly that "neither can enforce the other":
+
+| Gate | Where | Effect |
+|---|---|---|
+| 1 | `deploy_identity_provider` in `opentofu/gcp/gke/configure/variables.tfvars` | derives `identity_provider_url` |
+| 2 | `spec.suspend` in `clusters/gcp-0/security/zitadel.yaml` | whether Flux deploys it |
+
+The forbidden state has now occurred twice. ADR-0027's own Context records the
+first: *"a test cluster ended up running two directories with nobody able to say
+whether that was the design."* On 2026-09-01 a dual-cloud bootstrap reproduced
+it — both clusters ran their own ZITADEL, each with its own database restored
+from its own seed, because the gates were left as the GCP validation work had
+set them.
+
+Both occurrences share a cause: **the intended topology is written in an ADR and
+nowhere a machine can read it.**
+
+## Non-goals
+
+- **Deriving placement from `TM_CLOUD`.** Rejected on ADR-0027's own grounds:
+  relocation "is an exception, and it is a migration… a deliberate act with a
+  written procedure, not something that happens as a side effect of enabling a
+  cluster." `TM_CLOUD` changes per invocation; the IdP's home must not.
+- **Performing or scripting a relocation.** ADR-0027 notes the GCP-only path has
+  "never been performed end to end"; proving it is separate work.
+- **An AWS-side host toggle.** See *Unsupported state* below.
+- **A new ADR.** The decision exists. This is enforcement, so ADR-0024 and
+  ADR-0027 get short amendments instead.
+
+## Design
+
+### 1. One declaration
+
+Add to `opentofu/config.tm.hcl` globals:
+
+```hcl
+# Which cloud hosts the services that cannot sensibly exist twice (ADR-0027).
+# Changing this is a MIGRATION, not a toggle: the IdP's database seed, admin
+# credential and OIDC clients travel with it.
+primary_cloud = "aws"
+```
+
+Flipping this value is the deliberate act ADR-0027 requires. It is the only
+place the topology is stated in configuration.
+
+### 2. Gate 1 becomes derived
+
+`opentofu/gcp/gke/configure/workflows.tm.hcl` passes the value instead of the
+stack reading a hand-typed literal:
+
+```hcl
+-var='deploy_identity_provider=${global.primary_cloud == "gcp"}'
+```
+
+(An HCL comparison, not a `tm_` function — Terramate's `tm_*` set mirrors
+Terraform's functions, and Terraform has no `equal()`. The repo uses the same
+operator style already in `global.stack_cloud`.)
+
+and the literal is removed from `variables.tfvars`. Gate 1 can no longer
+disagree with the declaration because it *is* the declaration. Two hand-set
+gates become one.
+
+The variable keeps its default (`false`) so a bare `tofu apply` in the stack
+directory stays safe.
+
+### 3. Gate 2 becomes checked
+
+`spec.suspend` stays committed Git state. It cannot be derived: it is applied by
+Flux, which never sees Terramate globals, and `postBuild` substitution acts on
+what a Kustomization *builds*, not on its own spec.
+
+New `scripts/validate-idp-topology.sh` reads committed files only and asserts:
+
+1. the primary cloud's IdP Kustomization is **not** suspended;
+2. every non-primary cloud's IdP Kustomization **is** suspended;
+3. `primary_cloud` names a cloud that exists in the repo.
+
+An **absent** `spec.suspend` counts as not-suspended, matching Flux. This is why
+`clusters/aws-0/security/zitadel.yaml` carries no such field today and does not
+need one: AWS is primary, and the one state that would require AWS to be
+suspended — GCP primary with AWS deployed — is rejected outright below.
+
+Failure output names the offending file, the expected value, and the global, so
+the fix needs no archaeology.
+
+### 4. Restore compliance
+
+In the same change: `clusters/gcp-0/security/zitadel.yaml` back to
+`suspend: true`, and the `deploy_identity_provider` literal dropped from
+`variables.tfvars`. Both clusters are currently destroyed, so this carries no
+database, admin credential or client secret — the cheapest moment this
+correction will ever have.
+
+### 5. Unsupported state, named
+
+`primary_cloud = "gcp"` **while AWS also deploys** would produce two
+directories: `opentofu/aws/eks/configure` sets
+`identity_provider_url = "https://auth.${var.public_domain_name}"`
+unconditionally and has no host toggle.
+
+The check rejects that combination explicitly rather than letting it half-work.
+Adding an AWS-side toggle is out of scope: GCP-primary means AWS is not running,
+which is the only case ADR-0027 opens the gates for. If a GCP-primary
+*dual-cloud* platform is ever wanted, that is a new decision, and the check's
+error message says so.
+
+## Testing
+
+The value of this check is catching states that are expensive to produce live,
+so it is tested against fixtures rather than the live tree. Table-driven cases:
+
+| Case | Expected |
+|---|---|
+| `primary_cloud=aws`, aws un-suspended, gcp suspended | pass |
+| both clusters un-suspended | fail — names the duplicated singleton |
+| `primary_cloud=aws`, aws suspended | fail — primary hosts nothing |
+| `primary_cloud=gcp` with the AWS stack present | fail — unsupported combination |
+| `primary_cloud` set to an unknown value | fail |
+
+Wired into CI beside `validate-doc-claims.sh`, and listed in CLAUDE.md's
+*Validation Commands*.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `opentofu/config.tm.hcl` | `primary_cloud` global |
+| `opentofu/gcp/gke/configure/workflows.tm.hcl` | pass `deploy_identity_provider` |
+| `opentofu/gcp/gke/configure/variables.tfvars` | drop the literal |
+| `clusters/gcp-0/security/zitadel.yaml` | `suspend: true`, comment rewritten |
+| `scripts/validate-idp-topology.sh` | new |
+| `scripts/test-validate-idp-topology.sh` | new, fixture-driven |
+| `.github/workflows/ci.yaml` | new job |
+| `website/content/docs/decisions/0024-*.md` | gate 1 is now derived |
+| `website/content/docs/decisions/0027-*.md` | how the invariant is enforced |
+| `CLAUDE.md` | validation command |
+
+## Success criteria
+
+1. `./scripts/validate-idp-topology.sh` exits 0 on the corrected tree.
+2. It exits non-zero, naming the file, for each failure case above.
+3. `terramate script run deploy` on GCP derives `deploy_identity_provider=false`
+   with `primary_cloud = "aws"` — verifiable in the plan output without applying.
+4. Flipping `primary_cloud` to `gcp` makes the check demand the mirrored
+   suspend state, demonstrating the GCP-only path is one value plus a migration.
+5. A dual-cloud bootstrap produces exactly one ZITADEL. This is the criterion
+   that failed on 2026-09-01 and the only one needing a live cluster; it is
+   verified on the next dual bootstrap rather than gated on one.

--- a/infrastructure/base/cloudnative-pg-barman-plugin/barman-cloud-plugin.yaml
+++ b/infrastructure/base/cloudnative-pg-barman-plugin/barman-cloud-plugin.yaml
@@ -20,6 +20,20 @@ metadata:
   name: cloudnative-pg-barman-plugin
 spec:
   interval: 10m
+  # Retry failures in a minute rather than waiting out the full interval.
+  #
+  # Measured on the 2026-09-02 dual bootstrap: this Kustomization creates a
+  # Service, the AWS Load Balancer Controller's mutating webhook intercepts
+  # every Service with failurePolicy: Fail, and during bootstrap that webhook's
+  # own Service briefly has no endpoints. One transient admission rejection --
+  #
+  #   Service/infrastructure/barman-cloud dry-run failed (InternalError):
+  #   failed calling webhook "mservice.elbv2.k8s.aws": no endpoints available
+  #
+  # -- then idled the whole chain for ten minutes: no plugin, so CNPG reported
+  # "unknown plugin being required", so every database claim stalled, so ZITADEL
+  # never started. The webhook was healthy again within a minute of the failure.
+  retryInterval: 1m
   timeout: 5m
   prune: true
   sourceRef:

--- a/observability/base/victoria-metrics-k8s-stack/vmrules/cert-manager.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmrules/cert-manager.yaml
@@ -1,0 +1,76 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  labels:
+    app: cert-manager
+  name: cert-manager
+  namespace: observability
+spec:
+  groups:
+    - name: cert-manager
+      rules:
+        # The alert whose absence cost ~25 minutes of a dual-cloud bootstrap on
+        # 2026-09-02, and would have cost an hour unattended.
+        #
+        # An ACME order failed at finalization with a transient upstream error:
+        #
+        #   Failed to finalize Order: 404 urn:ietf:params:acme:error:malformed:
+        #   Certificate not found
+        #
+        # cert-manager does NOT retry an errored Order, and once the
+        # CertificateRequest fails it enters a failed-issuance backoff of up to
+        # an hour. So the Certificate sat Ready=False indefinitely, its Secret
+        # was never created, and every pod mounting that Secret stayed in
+        # ContainerCreating.
+        #
+        # Nothing surfaced it. Flux reported only a generic health-check
+        # timeout on the Kustomization; the pod said ContainerCreating; the
+        # actual reason lived three resources deep, in the Order's status. This
+        # rule is what turns that into a signal.
+        #
+        # `condition="True" == 0` rather than `condition="False" == 1`: it
+        # catches a certificate stuck in Unknown -- issuance in progress and
+        # never completing -- which is exactly the ACME-order case, as well as
+        # outright failure.
+        - alert: CertificateNotReady
+          expr: certmanager_certificate_ready_status{condition="True"} == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: Certificate {{ $labels.exported_namespace }}/{{ $labels.name }} has not been ready for 15 minutes.
+            description: |
+              cert-manager has not issued this certificate. Anything mounting its
+              Secret is stuck in ContainerCreating, and neither Flux nor the pod
+              will say why -- the reason is on the Order.
+
+              Diagnose from the outside in:
+                kubectl describe certificate {{ $labels.name }} -n {{ $labels.exported_namespace }}
+                kubectl get certificaterequest,order,challenge -n {{ $labels.exported_namespace }}
+                kubectl get order <name> -n {{ $labels.exported_namespace }} -o jsonpath='{.status.reason}'
+
+              An `errored` Order is NOT retried, and a failed CertificateRequest
+              backs off for up to an hour. Deleting the CertificateRequest alone
+              may not be enough; deleting the Certificate lets Flux recreate it
+              and issue immediately.
+            runbook_url: "https://cert-manager.io/docs/troubleshooting/acme/"
+            dashboard: "https://grafana.${private_domain_name}/dashboards"
+
+        # 15m catches a stall; this catches the slower, quieter failure -- a
+        # certificate that issued once and is now failing to renew. Left alone
+        # it becomes an outage on expiry day, which is how an OpenBao server
+        # certificate went nine months unnoticed (see the openbao rules).
+        - alert: CertificateExpiringSoon
+          expr: (certmanager_certificate_expiration_timestamp_seconds - time()) < (14 * 24 * 3600)
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            message: Certificate {{ $labels.exported_namespace }}/{{ $labels.name }} expires in under 14 days.
+            description: |
+              Renewal normally happens at two thirds of the lifetime, so a
+              certificate this close to expiry means renewal is failing, not that
+              it is merely due. Check the Certificate's conditions and the most
+              recent CertificateRequest for the same reasons as CertificateNotReady.
+            runbook_url: "https://cert-manager.io/docs/troubleshooting/"
+            dashboard: "https://grafana.${private_domain_name}/dashboards"

--- a/observability/base/victoria-metrics-k8s-stack/vmrules/kustomization.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmrules/kustomization.yaml
@@ -19,6 +19,10 @@ kind: Kustomization
 # ai-fleet LLM-platform alerts moved to apps/base/ai/llm/vmrule-ai-fleet.yaml so
 # they only deploy when the (opt-in, suspend-by-default) LLM platform is resumed —
 # otherwise LLMPlatformSemanticRouterDown fires forever on an LLM-free cluster.
+# cert-manager.yaml is in base deliberately: both clouds run cert-manager, both
+# issue through Let's Encrypt, and the failure it watches for (an errored ACME
+# order that cert-manager never retries) is cloud-neutral.
 resources:
+  - cert-manager.yaml
   - openbao.yaml
   - runlore.yaml

--- a/opentofu/config.tm.hcl
+++ b/opentofu/config.tm.hcl
@@ -29,9 +29,9 @@ globals {
     }
   EOT
 
-  region                 = "eu-west-3"
-  profile                = ""
-  eks_cluster_name       = "aws-0"
+  region           = "eu-west-3"
+  profile          = ""
+  eks_cluster_name = "aws-0"
 
   # Which cloud hosts the services that cannot sensibly exist twice: the public
   # DNS zone, the cross-cloud federation trust, and ZITADEL (ADR-0027).
@@ -42,7 +42,7 @@ globals {
   # never derived from TM_CLOUD, whose value changes per invocation.
   #
   # Enforced by ./scripts/validate-idp-topology.sh.
-  primary_cloud = "aws"
+  primary_cloud          = "aws"
   openbao_url            = "https://bao.priv.aws.ogenki.io:8200"
   root_token_secret_name = "openbao/cloud-native-ref/tokens/root"
   # Deliberately a different secret from the root token: the recovery keys are

--- a/opentofu/config.tm.hcl
+++ b/opentofu/config.tm.hcl
@@ -32,6 +32,17 @@ globals {
   region                 = "eu-west-3"
   profile                = ""
   eks_cluster_name       = "aws-0"
+
+  # Which cloud hosts the services that cannot sensibly exist twice: the public
+  # DNS zone, the cross-cloud federation trust, and ZITADEL (ADR-0027).
+  #
+  # Changing this is a MIGRATION, not a toggle. The identity provider's database
+  # seed, admin credential and OIDC clients travel with it or the move
+  # half-works in silence -- which is why placement is stated here once and
+  # never derived from TM_CLOUD, whose value changes per invocation.
+  #
+  # Enforced by ./scripts/validate-idp-topology.sh.
+  primary_cloud = "aws"
   openbao_url            = "https://bao.priv.aws.ogenki.io:8200"
   root_token_secret_name = "openbao/cloud-native-ref/tokens/root"
   # Deliberately a different secret from the root token: the recovery keys are

--- a/opentofu/config.tm.hcl
+++ b/opentofu/config.tm.hcl
@@ -42,9 +42,20 @@ globals {
   # never derived from TM_CLOUD, whose value changes per invocation.
   #
   # Enforced by ./scripts/validate-idp-topology.sh.
-  primary_cloud          = "aws"
-  openbao_url            = "https://bao.priv.aws.ogenki.io:8200"
-  root_token_secret_name = "openbao/cloud-native-ref/tokens/root"
+  primary_cloud = "aws"
+
+  # Whether the GCP lane hosts the identity provider, derived once rather than
+  # compared at each call site. Five sites need it -- deploy, preview, destroy
+  # and drift in gcp/gke/configure, plus the OIDC-client registration in
+  # gcp/gke/init -- and the same file's `cloud_gate` above records what happens
+  # when a rule is hand-copied instead: "the previous gate was fifteen
+  # hand-copied blocks, and four scripts ended up missing one entirely."
+  #
+  # A third cloud, or any change to what makes a lane eligible to host, is then
+  # one edit here rather than a hunt across two files.
+  deploy_identity_provider_gcp = global.primary_cloud == "gcp"
+  openbao_url                  = "https://bao.priv.aws.ogenki.io:8200"
+  root_token_secret_name       = "openbao/cloud-native-ref/tokens/root"
   # Deliberately a different secret from the root token: the recovery keys are
   # what regenerates a lost or revoked root token, so storing both together
   # would make the pair only as strong as one of them.

--- a/opentofu/gcp/gke/configure/variables.tf
+++ b/opentofu/gcp/gke/configure/variables.tf
@@ -141,25 +141,30 @@ variable "route53_region" {
 # resolves through the same cross-cloud federation as every other public
 # hostname here.
 #
-# Running an instance per cloud means a user directory per cloud. That is the
-# real cost and it is accepted deliberately: these are throwaway platforms whose
-# ZITADEL bootstraps empty on every rebuild, so there is no long-lived directory
-# to federate. A production two-cloud deployment would want one instance and
-# should set deploy_identity_provider = false.
+# ADR-0027 settles what "deployable on either cloud" means: ZITADEL is a
+# primary-cloud SINGLETON. It relocates to whichever cloud is primary; two
+# clouds each running one is ruled out, because a grant means nothing without
+# knowing which directory issued it.
 #
-# TWO GATES, and they must agree:
+# DO NOT SET THIS IN variables.tfvars. It is derived from global.primary_cloud
+# and passed as `-var` by workflows.tm.hcl on every invocation -- deploy,
+# preview, destroy and drift -- and a trailing `-var` wins over `-var-file`.
+# A literal in the tfvars file is therefore silently ineffective. Setting
+# primary_cloud is what flips this.
 #
-#   1. deploy_identity_provider (here) -- drives identity_provider_url, which
-#      every consumer reads.
-#   2. clusters/gcp-0/security/zitadel.yaml `spec.suspend` -- whether Flux
-#      actually deploys it.
+# TWO GATES still, but only one is typed:
 #
-# Setting this true while the Kustomization stays suspended points every
-# consumer at a hostname this cluster does not serve. Nothing can enforce the
-# pairing from here, which is exactly why the URL is derived from this flag
-# rather than typed twice.
+#   1. deploy_identity_provider (here) -- DERIVED, drives identity_provider_url,
+#      which every consumer reads.
+#   2. clusters/gcp-0/security/zitadel.yaml `spec.suspend` -- committed Flux
+#      state, which Terramate cannot reach. VERIFIED against primary_cloud by
+#      ./scripts/validate-idp-topology.sh in CI.
+#
+# The default stays false so that a bare `tofu apply` run in this directory,
+# outside the Terramate workflow, cannot stand up a second directory by
+# omission.
 variable "deploy_identity_provider" {
-  description = "Whether this cluster hosts its own ZITADEL. False consumes the instance named by identity_provider_url. Must be flipped together with spec.suspend on clusters/gcp-0/security/zitadel.yaml; see ADR-0024"
+  description = "Whether this cluster hosts its own ZITADEL. Derived from global.primary_cloud by workflows.tm.hcl -- do not set it in variables.tfvars, where a `-var` would override it silently. False consumes the instance named by identity_provider_url. See ADR-0027"
   type        = bool
   default     = false
 }

--- a/opentofu/gcp/gke/configure/variables.tfvars
+++ b/opentofu/gcp/gke/configure/variables.tfvars
@@ -34,27 +34,18 @@ public_domain_name     = "gcp.cloud.ogenki.io"
 route53_public_zone_id = "Z002027037R5RFCG05YY6"
 route53_role_arn       = "arn:aws:iam::396740644681:role/gcp-0-route53-dns"
 
-# gcp-0 hosts its OWN ZITADEL (ADR-0024), so this must be true.
+# deploy_identity_provider is NOT set here. It is derived from
+# global.primary_cloud in workflows.tm.hcl, so that "which cloud hosts the
+# identity provider" has exactly one answer in configuration (ADR-0027).
 #
-# It is the second of two gates that have to agree, and they did not. The other
-# is `spec.suspend` on clusters/gcp-0/security/zitadel.yaml, which is already
-# false -- Flux deploys ZITADEL here and its TLSRoute serves
-# auth.gcp.cloud.ogenki.io. Leaving this at its default `false` made
-# locals.tf fall back to var.identity_provider_url, whose default names the
-# aws-0 instance, so every consumer on this cluster -- Grafana, the Flux UI,
-# Headlamp, OpenWebUI -- was sent to https://auth.cloud.ogenki.io.
+# It used to be a literal, and it was wrong: it said `true` while aws-0 also
+# hosted, which is the state ADR-0027 rules out -- two user directories, where
+# a grant means nothing without knowing which one issued it. Nothing could
+# catch that, because the two halves of the pairing lived in different tools.
 #
-# That is a live IdP only while aws-0 exists. With aws-0 torn down, SSO fails
-# at the authorize step against a host that answers for someone else's cluster,
-# and nothing on gcp-0 reports a problem: ZITADEL is up, the consumers are
-# healthy, and they simply point somewhere else.
-#
-# variables.tf's own comment predicts the mirror image of this ("setting this
-# true while the Kustomization stays suspended points every consumer at a
-# hostname this cluster does not serve"). Same failure, opposite direction:
-# nothing can enforce the pairing across OpenTofu and Flux, so both halves have
-# to be flipped by hand together.
-deploy_identity_provider = true
+# The variable's own default is false, so a bare `tofu apply` in this directory
+# does not silently stand up a second identity directory.
+# ./scripts/validate-idp-topology.sh fails if the Flux half disagrees.
 
 # AWS SDK region hint for the route53 solver -- NOT gcp-0's GCP region (see the
 # comment on var.route53_region). Matches opentofu/shared/aws-gcp-federation's

--- a/opentofu/gcp/gke/configure/workflows.tm.hcl
+++ b/opentofu/gcp/gke/configure/workflows.tm.hcl
@@ -34,7 +34,7 @@ script "deploy" {
         set -euo pipefail
         ${global.provisioner} init
         ${global.provisioner} validate
-        ${global.provisioner} apply -auto-approve -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='gateway_api_version=${global.gateway_api_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}'
+        ${global.provisioner} apply -auto-approve -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='gateway_api_version=${global.gateway_api_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}' -var='deploy_identity_provider=${global.primary_cloud == "gcp"}'
       BASH
       ],
     ]
@@ -52,7 +52,7 @@ script "preview" {
         set -euo pipefail
         ${global.provisioner} init
         ${global.provisioner} validate
-        ${global.provisioner} plan -out=out.tfplan -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='gateway_api_version=${global.gateway_api_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}'
+        ${global.provisioner} plan -out=out.tfplan -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='gateway_api_version=${global.gateway_api_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}' -var='deploy_identity_provider=${global.primary_cloud == "gcp"}'
       BASH
       ],
     ]
@@ -103,7 +103,8 @@ script "destroy" {
           -var='cilium_version=${global.cilium_version}' \
           -var='gateway_api_version=${global.gateway_api_version}' \
           -var='flux_operator_version=${global.flux_operator_version}' \
-          -var='flux_instance_version=${global.flux_instance_version}'
+          -var='flux_instance_version=${global.flux_instance_version}' \
+          -var='deploy_identity_provider=${global.primary_cloud == "gcp"}'
       BASH
       ],
     ]
@@ -136,7 +137,10 @@ script "drift" "detect" {
         ${global.cloud_gate}
         set -euo pipefail
         ${global.provisioner} init
-        ${global.provisioner} plan -out=drift.tfplan -detailed-exitcode -lock=false -var-file=variables.tfvars
+        # deploy_identity_provider is passed here too, unlike the version vars:
+        # without it drift compares against the variable's default (false) and
+        # reports a difference that does not exist whenever GCP is primary.
+        ${global.provisioner} plan -out=drift.tfplan -detailed-exitcode -lock=false -var-file=variables.tfvars -var='deploy_identity_provider=${global.primary_cloud == "gcp"}'
       BASH
       ],
     ]

--- a/opentofu/gcp/gke/configure/workflows.tm.hcl
+++ b/opentofu/gcp/gke/configure/workflows.tm.hcl
@@ -34,7 +34,7 @@ script "deploy" {
         set -euo pipefail
         ${global.provisioner} init
         ${global.provisioner} validate
-        ${global.provisioner} apply -auto-approve -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='gateway_api_version=${global.gateway_api_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}' -var='deploy_identity_provider=${global.primary_cloud == "gcp"}'
+        ${global.provisioner} apply -auto-approve -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='gateway_api_version=${global.gateway_api_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}' -var='deploy_identity_provider=${global.deploy_identity_provider_gcp}'
       BASH
       ],
     ]
@@ -52,7 +52,7 @@ script "preview" {
         set -euo pipefail
         ${global.provisioner} init
         ${global.provisioner} validate
-        ${global.provisioner} plan -out=out.tfplan -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='gateway_api_version=${global.gateway_api_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}' -var='deploy_identity_provider=${global.primary_cloud == "gcp"}'
+        ${global.provisioner} plan -out=out.tfplan -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='gateway_api_version=${global.gateway_api_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}' -var='deploy_identity_provider=${global.deploy_identity_provider_gcp}'
       BASH
       ],
     ]
@@ -104,7 +104,7 @@ script "destroy" {
           -var='gateway_api_version=${global.gateway_api_version}' \
           -var='flux_operator_version=${global.flux_operator_version}' \
           -var='flux_instance_version=${global.flux_instance_version}' \
-          -var='deploy_identity_provider=${global.primary_cloud == "gcp"}'
+          -var='deploy_identity_provider=${global.deploy_identity_provider_gcp}'
       BASH
       ],
     ]
@@ -140,7 +140,7 @@ script "drift" "detect" {
         # deploy_identity_provider is passed here too, unlike the version vars:
         # without it drift compares against the variable's default (false) and
         # reports a difference that does not exist whenever GCP is primary.
-        ${global.provisioner} plan -out=drift.tfplan -detailed-exitcode -lock=false -var-file=variables.tfvars -var='deploy_identity_provider=${global.primary_cloud == "gcp"}'
+        ${global.provisioner} plan -out=drift.tfplan -detailed-exitcode -lock=false -var-file=variables.tfvars -var='deploy_identity_provider=${global.deploy_identity_provider_gcp}'
       BASH
       ],
     ]

--- a/opentofu/gcp/gke/init/workflows.tm.hcl
+++ b/opentofu/gcp/gke/init/workflows.tm.hcl
@@ -189,7 +189,7 @@ script "deploy" {
         #
         # The tfvars literal no longer exists, so the awk matched nothing and
         # would have reproduced that incident exactly. One source, or none.
-        DEPLOY_IDP="$${TF_VAR_deploy_identity_provider:-${global.primary_cloud == "gcp"}}"
+        DEPLOY_IDP="$${TF_VAR_deploy_identity_provider:-${global.deploy_identity_provider_gcp}}"
         if [ "$${DEPLOY_IDP}" != "true" ]; then
           echo "== skipping OIDC clients: this cluster does not host the identity provider"
           echo "   (primary_cloud = \"${global.primary_cloud}\" in opentofu/config.tm.hcl;"

--- a/opentofu/gcp/gke/init/workflows.tm.hcl
+++ b/opentofu/gcp/gke/init/workflows.tm.hcl
@@ -191,9 +191,41 @@ script "deploy" {
         # would have reproduced that incident exactly. One source, or none.
         DEPLOY_IDP="$${TF_VAR_deploy_identity_provider:-${global.deploy_identity_provider_gcp}}"
         if [ "$${DEPLOY_IDP}" != "true" ]; then
-          echo "== skipping OIDC clients: this cluster does not host the identity provider"
-          echo "   (primary_cloud = \"${global.primary_cloud}\" in opentofu/config.tm.hcl;"
-          echo "    override for one run: TF_VAR_deploy_identity_provider=true)"
+          # NOT hosting is not the same as nothing to do. This cluster's
+          # consumers still need OIDC clients -- registered in the PRIMARY
+          # cloud's directory, with THIS cluster's redirect URIs, and with the
+          # resulting secrets written to THIS cluster's store where its
+          # ExternalSecrets read.
+          #
+          # Skipping here is what left a consuming gcp-0 with no client at all:
+          # oauth2-proxy came up with no secret, sat in
+          # CreateContainerConfigError, and headlamp's Kustomization never went
+          # ready -- the same class of failure as the never-registered-clients
+          # incident above, arrived at from the opposite direction.
+          #
+          # The IdP URL comes from the cluster vars ConfigMap rather than being
+          # rebuilt here: that is the exact value every consumer on this cluster
+          # reads, so it cannot disagree with them.
+          echo "== this cluster consumes ${global.primary_cloud}'s identity provider"
+          CONSUMED_IDP="$(kubectl get configmap "gke-$${NAME}-vars" -n flux-system \
+            -o jsonpath='{.data.identity_provider_url}' 2>/dev/null || true)"
+          if [ -z "$${CONSUMED_IDP}" ]; then
+            echo "[warn] could not read identity_provider_url from gke-$${NAME}-vars;"
+            echo "       skipping client registration. Re-run by hand once it exists."
+            exit 0
+          fi
+
+          echo "== registering this cluster's OIDC clients in $${CONSUMED_IDP}"
+          IDP_URL="$${CONSUMED_IDP}" PRIVATE_DOMAIN="$${PRIVATE_DOMAIN}" \
+            bash "$${ROOT}/scripts/zitadel-oidc-clients.sh" sync \
+              --cluster "$${NAME}" \
+              --cloud gcp --project "$${PROJECT}" \
+              --idp-cloud "${global.primary_cloud}" --region "${global.region}" \
+              --apply || \
+            echo "[warn] OIDC registration against the primary cloud failed; re-run it by hand"
+
+          echo "== granting access to the secrets it just created"
+          bash "$${ROOT}/scripts/secret-store.sh" grant --cloud gcp --project "$${PROJECT}" --apply || true
           exit 0
         fi
 

--- a/opentofu/gcp/gke/init/workflows.tm.hcl
+++ b/opentofu/gcp/gke/init/workflows.tm.hcl
@@ -172,27 +172,28 @@ script "deploy" {
 
         # Only when this cluster hosts the IdP. Consuming another cluster's
         # ZITADEL means its clients are registered there, not here.
-        # Read the flag from the tfvars FILE, with the environment as an
-        # override -- not the other way round.
+        # Whether this cluster hosts the identity provider comes from the SAME
+        # place the configure stack gets it: global.primary_cloud (ADR-0027),
+        # interpolated below. The environment still overrides for one
+        # invocation.
         #
-        # This used to test only $TF_VAR_deploy_identity_provider. That variable
-        # is how you override the setting for one invocation; the setting itself
-        # lives in ../configure/variables.tfvars, exactly like public_domain_name
-        # two lines up, which is already read that way. So the normal case --
-        # the flag committed to the file, no env var in the shell -- read as
-        # false and skipped registration, while printing a line that looks like
-        # a deliberate decision.
+        # It used to be read out of ../configure/variables.tfvars with awk, and
+        # before that from $TF_VAR_deploy_identity_provider alone. Both were
+        # ways of asking a second source the same question, and both got a
+        # different answer than the deploy did:
         #
-        # gcp-0 shipped with `deploy_identity_provider = true` and no OIDC client
-        # ever registered. Every SSO consumer failed at the authorize step with a
-        # client_id ZITADEL had never heard of, and the deploy reported success.
-        DEPLOY_IDP="$${TF_VAR_deploy_identity_provider:-}"
-        if [ -z "$${DEPLOY_IDP}" ]; then
-          DEPLOY_IDP="$(awk -F'=' '/^[[:space:]]*deploy_identity_provider/{gsub(/[[:space:]"]/,"",$$2); print $$2}' ../configure/variables.tfvars)"
-        fi
+        #   gcp-0 shipped with `deploy_identity_provider = true` and no OIDC
+        #   client ever registered. Every SSO consumer failed at the authorize
+        #   step with a client_id ZITADEL had never heard of, and the deploy
+        #   reported success.
+        #
+        # The tfvars literal no longer exists, so the awk matched nothing and
+        # would have reproduced that incident exactly. One source, or none.
+        DEPLOY_IDP="$${TF_VAR_deploy_identity_provider:-${global.primary_cloud == "gcp"}}"
         if [ "$${DEPLOY_IDP}" != "true" ]; then
-          echo "== skipping OIDC clients: deploy_identity_provider is not true"
-          echo "   (file: ../configure/variables.tfvars, override: TF_VAR_deploy_identity_provider)"
+          echo "== skipping OIDC clients: this cluster does not host the identity provider"
+          echo "   (primary_cloud = \"${global.primary_cloud}\" in opentofu/config.tm.hcl;"
+          echo "    override for one run: TF_VAR_deploy_identity_provider=true)"
           exit 0
         fi
 

--- a/scripts/test-validate-idp-topology.sh
+++ b/scripts/test-validate-idp-topology.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Fixture-driven tests for validate-idp-topology.sh.
+#
+# The states this checker exists to catch are expensive to produce live -- two
+# clusters each running an identity provider is a two-cloud bootstrap -- so it
+# is tested against synthetic trees instead.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATOR="${SCRIPT_DIR}/validate-idp-topology.sh"
+failures=0
+
+# Build a fixture tree: primary cloud, then "<cluster>:<suspend>" pairs where
+# suspend is "true", "false", or "absent".
+make_fixture() {
+  local root="$1" primary="$2"
+  shift 2
+  mkdir -p "${root}/opentofu"
+  cat >"${root}/opentofu/config.tm.hcl" <<EOF
+globals {
+  region        = "eu-west-3"
+  primary_cloud = "${primary}"
+}
+EOF
+  local pair cluster suspend
+  for pair in "$@"; do
+    cluster="${pair%%:*}"
+    suspend="${pair##*:}"
+    mkdir -p "${root}/clusters/${cluster}/security"
+    {
+      echo "apiVersion: kustomize.toolkit.fluxcd.io/v1"
+      echo "kind: Kustomization"
+      echo "metadata:"
+      echo "  name: zitadel"
+      echo "spec:"
+      [ "$suspend" != "absent" ] && echo "  suspend: ${suspend}"
+      echo "  path: ./security/${cluster}/zitadel"
+    } >"${root}/clusters/${cluster}/security/zitadel.yaml"
+  done
+}
+
+# expect <name> <expected-exit> <expected-substring-or-empty> <primary> <pairs...>
+expect() {
+  local name="$1" want_exit="$2" want_text="$3" primary="$4"
+  shift 4
+  local root output rc
+  root="$(mktemp -d)"
+  make_fixture "$root" "$primary" "$@"
+  set +e
+  output="$("$VALIDATOR" "$root" 2>&1)"
+  rc=$?
+  set -e
+  rm -rf "$root"
+
+  if [ "$rc" -ne "$want_exit" ]; then
+    echo "FAIL ${name}: exit ${rc}, want ${want_exit}"
+    echo "     output: ${output}"
+    failures=$((failures + 1))
+    return
+  fi
+  if [ -n "$want_text" ] && ! grep -qF "$want_text" <<<"$output"; then
+    echo "FAIL ${name}: output missing '${want_text}'"
+    echo "     output: ${output}"
+    failures=$((failures + 1))
+    return
+  fi
+  echo "ok   ${name}"
+}
+
+expect "compliant: aws primary hosts, gcp suspended" \
+  0 "" aws "aws-0:absent" "gcp-0:true"
+
+expect "both clouds hosting is rejected" \
+  1 "gcp-0" aws "aws-0:absent" "gcp-0:false"
+
+expect "primary hosting nothing is rejected" \
+  1 "aws-0" aws "aws-0:true" "gcp-0:true"
+
+expect "gcp primary while aws is present is rejected" \
+  1 "unconditionally" gcp "aws-0:absent" "gcp-0:false"
+
+expect "unknown primary_cloud is rejected" \
+  1 "azure" azure "aws-0:absent" "gcp-0:true"
+
+# primary_cloud absent entirely
+root="$(mktemp -d)"
+mkdir -p "${root}/opentofu"
+echo 'globals {' >"${root}/opentofu/config.tm.hcl"
+echo '  region = "eu-west-3"' >>"${root}/opentofu/config.tm.hcl"
+echo '}' >>"${root}/opentofu/config.tm.hcl"
+mkdir -p "${root}/clusters/aws-0/security"
+printf 'spec:\n  suspend: false\n' >"${root}/clusters/aws-0/security/zitadel.yaml"
+set +e
+out="$("$VALIDATOR" "$root" 2>&1)"; rc=$?
+set -e
+rm -rf "$root"
+if [ "$rc" -eq 1 ] && grep -qF "primary_cloud" <<<"$out"; then
+  echo "ok   undeclared primary_cloud is rejected"
+else
+  echo "FAIL undeclared primary_cloud is rejected: exit ${rc}: ${out}"
+  failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+  echo "==> ${failures} test(s) failed"
+  exit 1
+fi
+echo "==> all tests passed"

--- a/scripts/test-validate-idp-topology.sh
+++ b/scripts/test-validate-idp-topology.sh
@@ -17,12 +17,18 @@ make_fixture() {
   local root="$1" primary="$2"
   shift 2
   mkdir -p "${root}/opentofu"
-  cat >"${root}/opentofu/config.tm.hcl" <<EOF
+  # "absent" omits the declaration entirely -- the same sentinel spelling the
+  # suspend pairs use below, so every case can go through `expect`.
+  if [ "$primary" = "absent" ]; then
+    printf 'globals {\n  region = "eu-west-3"\n}\n' >"${root}/opentofu/config.tm.hcl"
+  else
+    cat >"${root}/opentofu/config.tm.hcl" <<EOF
 globals {
   region        = "eu-west-3"
   primary_cloud = "${primary}"
 }
 EOF
+  fi
   local pair cluster suspend
   for pair in "$@"; do
     cluster="${pair%%:*}"
@@ -80,27 +86,28 @@ expect "primary hosting nothing is rejected" \
 expect "gcp primary while aws is present is rejected" \
   1 "unconditionally" gcp "aws-0:absent" "gcp-0:false"
 
+# The same combination with AWS suspended: still rejected. Suspending aws-0 stops
+# AWS hosting, but eks/configure still points every aws-0 consumer at a host
+# nothing serves -- so suspend must not be a way to pass this case.
+expect "gcp primary with aws present but suspended is still rejected" \
+  1 "unconditionally" gcp "aws-0:true" "gcp-0:false"
+
 expect "unknown primary_cloud is rejected" \
   1 "azure" azure "aws-0:absent" "gcp-0:true"
 
-# primary_cloud absent entirely
-root="$(mktemp -d)"
-mkdir -p "${root}/opentofu"
-echo 'globals {' >"${root}/opentofu/config.tm.hcl"
-echo '  region = "eu-west-3"' >>"${root}/opentofu/config.tm.hcl"
-echo '}' >>"${root}/opentofu/config.tm.hcl"
-mkdir -p "${root}/clusters/aws-0/security"
-printf 'spec:\n  suspend: false\n' >"${root}/clusters/aws-0/security/zitadel.yaml"
-set +e
-out="$("$VALIDATOR" "$root" 2>&1)"; rc=$?
-set -e
-rm -rf "$root"
-if [ "$rc" -eq 1 ] && grep -qF "primary_cloud" <<<"$out"; then
-  echo "ok   undeclared primary_cloud is rejected"
-else
-  echo "FAIL undeclared primary_cloud is rejected: exit ${rc}: ${out}"
-  failures=$((failures + 1))
-fi
+expect "malformed primary_cloud reports as invalid, not undeclared" \
+  1 "not a known cloud" AWS "aws-0:absent" "gcp-0:true"
+
+expect "undeclared primary_cloud is rejected" \
+  1 "primary_cloud" absent "aws-0:false"
+
+# "Exactly one hosts" is the contract; these two would pass a purely
+# per-manifest rule while zero or two clusters actually host.
+expect "no cluster on the primary cloud is rejected" \
+  1 "found 0" aws "gcp-0:true"
+
+expect "two clusters on the primary cloud both hosting is rejected" \
+  1 "found 2" aws "aws-0:absent" "aws-1:false" "gcp-0:true"
 
 if [ "$failures" -ne 0 ]; then
   echo "==> ${failures} test(s) failed"

--- a/scripts/test-validate-idp-topology.sh
+++ b/scripts/test-validate-idp-topology.sh
@@ -83,14 +83,18 @@ expect "both clouds hosting is rejected" \
 expect "primary hosting nothing is rejected" \
   1 "aws-0" aws "aws-0:true" "gcp-0:true"
 
-expect "gcp primary while aws is present is rejected" \
-  1 "unconditionally" gcp "aws-0:absent" "gcp-0:false"
+# GCP primary is a SUPPORTED configuration, and the tree always contains
+# clusters/aws-0/security/zitadel.yaml because it is a committed file. An
+# earlier version treated that file's mere presence as proof AWS was deployed
+# and rejected the whole configuration, making GCP-only impossible to commit --
+# this case is here so that cannot come back.
+expect "gcp primary with aws suspended is accepted" \
+  0 "" gcp "aws-0:true" "gcp-0:false"
 
-# The same combination with AWS suspended: still rejected. Suspending aws-0 stops
-# AWS hosting, but eks/configure still points every aws-0 consumer at a host
-# nothing serves -- so suspend must not be a way to pass this case.
-expect "gcp primary with aws present but suspended is still rejected" \
-  1 "unconditionally" gcp "aws-0:true" "gcp-0:false"
+# ...and the mirror image is still caught: GCP primary while aws-0 would also
+# host is two directories, whichever cloud is primary.
+expect "gcp primary with aws also hosting is rejected" \
+  1 "aws-0" gcp "aws-0:false" "gcp-0:false"
 
 expect "unknown primary_cloud is rejected" \
   1 "azure" azure "aws-0:absent" "gcp-0:true"

--- a/scripts/test-zitadel-oidc-clients-convergence.sh
+++ b/scripts/test-zitadel-oidc-clients-convergence.sh
@@ -106,6 +106,12 @@ IDP_URL="https://auth.priv.aws.ogenki.io"
 PRIVATE_DOMAIN="priv.aws.ogenki.io"
 ZITADEL_PROJECT_NAME="platform"
 GRANT_ADMIN=""
+# Empty because this fixture is a HOSTING cluster (--idp-cloud would equal
+# --cloud). A consuming cluster sets it to "-<cluster>" so two clusters do not
+# contend for one ZITADEL app name; see the block that computes it in the
+# script. It has to be declared here because these tests lift the functions out
+# of the script and supply their globals by hand.
+APP_SUFFIX=""
 HEADLAMP_OIDC_SCOPES="profile,email,groups"
 REDIRECT="https://headlamp.${PRIVATE_DOMAIN}/oidc-callback"
 EXISTING_CLIENT_ID="existing-client-id"

--- a/scripts/validate-idp-topology.sh
+++ b/scripts/validate-idp-topology.sh
@@ -22,6 +22,10 @@ set -euo pipefail
 
 ROOT="${1:-$(git rev-parse --show-toplevel)}"
 CONFIG="${ROOT}/opentofu/config.tm.hcl"
+# A third copy of the cloud list -- the others are global.stack_cloud in
+# opentofu/config.tm.hcl and --tm-check in scripts/tm-provisioner.sh. Adding a
+# lane means adding it here too; see the checklist in
+# website/content/docs/guides/add-a-cloud-provider.md.
 KNOWN_CLOUDS="aws gcp"
 failures=0
 
@@ -35,7 +39,11 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-primary="$(sed -n 's/^[[:space:]]*primary_cloud[[:space:]]*=[[:space:]]*"\([a-z0-9]*\)".*/\1/p' "$CONFIG" | head -1)"
+# Match ANY quoted value, not just lowercase words: a malformed value such as
+# "AWS" must reach the known-cloud check below with its useful message, rather
+# than failing to match here and being reported as "not declared" -- pointing
+# the reader at a line that is plainly right there in the file.
+primary="$(sed -n 's/^[[:space:]]*primary_cloud[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$CONFIG" | head -1)"
 
 if [ -z "$primary" ]; then
   echo "FAIL: primary_cloud is not declared in opentofu/config.tm.hcl."
@@ -57,6 +65,8 @@ if [ ${#manifests[@]} -eq 0 ]; then
   exit 1
 fi
 
+hosts=0
+
 for manifest in "${manifests[@]}"; do
   cluster="$(basename "$(dirname "$(dirname "$manifest")")")"
   cloud="${cluster%%-*}"
@@ -75,20 +85,35 @@ PY
       fail "${cluster} is on the primary cloud (${primary}) but its identity provider is suspended."
       echo "      Set spec.suspend: false in clusters/${cluster}/security/zitadel.yaml,"
       echo "      or change primary_cloud in opentofu/config.tm.hcl."
+    else
+      hosts=$((hosts + 1))
     fi
-  else
-    if [ "$suspend" != "true" ]; then
-      fail "${cluster} is not on the primary cloud (${primary}) but would run its own identity provider."
-      if [ "$cloud" = "aws" ]; then
-        echo "      opentofu/aws/eks/configure sets identity_provider_url unconditionally, so AWS"
-        echo "      hosts whenever it is deployed. A non-AWS primary with AWS deployed is not a"
-        echo "      supported combination -- it needs an AWS-side host toggle, which is a new decision."
-      else
-        echo "      Set spec.suspend: true in clusters/${cluster}/security/zitadel.yaml."
-      fi
-    fi
+  elif [ "$cloud" = "aws" ]; then
+    # Unsupported REGARDLESS of suspend: opentofu/aws/eks/configure sets
+    # identity_provider_url unconditionally, so deploying AWS at all points every
+    # aws-0 consumer at auth.<aws public domain>. Suspending the Kustomization
+    # stops AWS hosting but leaves its consumers aimed at a host nothing serves --
+    # the other silent failure this check exists to catch, so it cannot be the
+    # way out of the first one.
+    fail "primary_cloud is \"${primary}\", but the AWS cluster ${cluster} is present."
+    echo "      opentofu/aws/eks/configure sets identity_provider_url unconditionally, so AWS"
+    echo "      cannot consume another cloud's identity provider. A non-AWS primary with AWS"
+    echo "      deployed needs an AWS-side host toggle, which is a new decision -- not a"
+    echo "      suspend. See ADR-0027."
+  elif [ "$suspend" != "true" ]; then
+    fail "${cluster} is not on the primary cloud (${primary}) but would run its own identity provider."
+    echo "      Set spec.suspend: true in clusters/${cluster}/security/zitadel.yaml."
   fi
 done
+
+# The contract is "exactly one", not "none misplaced": with only the per-manifest
+# rules above, a tree with no manifest on the primary cloud -- or with the primary
+# cloud's manifest deleted outright -- passes while nothing hosts at all.
+if [ "$hosts" -ne 1 ]; then
+  fail "expected exactly one cluster to host the identity provider, found ${hosts}."
+  echo "      primary_cloud is \"${primary}\"; check that a clusters/${primary}-*/security/"
+  echo "      zitadel.yaml exists and is not suspended, and that only one is."
+fi
 
 if [ "$failures" -ne 0 ]; then
   echo "==> identity provider topology is inconsistent (${failures} problem(s)); see ADR-0027."

--- a/scripts/validate-idp-topology.sh
+++ b/scripts/validate-idp-topology.sh
@@ -17,6 +17,13 @@
 # here instead. The forbidden state has occurred twice; both times the intended
 # topology was written only in an ADR, where no machine could read it.
 #
+# SCOPE: this reads COMMITTED YAML, not a live cluster. It answers "would this
+# configuration produce two identity directories?", not "are two running right
+# now?" -- suspending a Kustomization stops Flux reconciling an instance without
+# removing one already deployed, so a live migration can be mid-flight with two
+# directories up while this reports consistent. That case belongs to the
+# migration guide's decommissioning step, not here.
+#
 # Usage: validate-idp-topology.sh [ROOT_DIR]
 set -euo pipefail
 

--- a/scripts/validate-idp-topology.sh
+++ b/scripts/validate-idp-topology.sh
@@ -17,6 +17,21 @@
 # here instead. The forbidden state has occurred twice; both times the intended
 # topology was written only in an ADR, where no machine could read it.
 #
+# THE ONLY THREE CONFIGURATIONS, which is why this check is as small as it is:
+#
+#   TM_CLOUD=aws       -> primary_cloud = "aws". aws-0 hosts.
+#   TM_CLOUD=aws,gcp   -> primary_cloud = "aws". aws-0 hosts, gcp-0 consumes.
+#   TM_CLOUD=gcp       -> primary_cloud = "gcp". gcp-0 hosts, and there is NO
+#                         aws-0: a GCP-only platform uses the AWS account for a
+#                         Route53 zone, not for a cluster.
+#
+# So "GCP is primary while AWS is also deployed" is not an unsupported state to
+# be rejected -- it does not exist. An earlier version of this script rejected
+# it anyway, by treating the mere presence of clusters/aws-0/security/
+# zitadel.yaml (a file that is always committed) as proof AWS was deployed. That
+# made primary_cloud = "gcp" impossible to commit, blocking the one case the
+# gates exist to enable.
+#
 # SCOPE: this reads COMMITTED YAML, not a live cluster. It answers "would this
 # configuration produce two identity directories?", not "are two running right
 # now?" -- suspending a Kustomization stops Flux reconciling an instance without
@@ -95,18 +110,6 @@ PY
     else
       hosts=$((hosts + 1))
     fi
-  elif [ "$cloud" = "aws" ]; then
-    # Unsupported REGARDLESS of suspend: opentofu/aws/eks/configure sets
-    # identity_provider_url unconditionally, so deploying AWS at all points every
-    # aws-0 consumer at auth.<aws public domain>. Suspending the Kustomization
-    # stops AWS hosting but leaves its consumers aimed at a host nothing serves --
-    # the other silent failure this check exists to catch, so it cannot be the
-    # way out of the first one.
-    fail "primary_cloud is \"${primary}\", but the AWS cluster ${cluster} is present."
-    echo "      opentofu/aws/eks/configure sets identity_provider_url unconditionally, so AWS"
-    echo "      cannot consume another cloud's identity provider. A non-AWS primary with AWS"
-    echo "      deployed needs an AWS-side host toggle, which is a new decision -- not a"
-    echo "      suspend. See ADR-0027."
   elif [ "$suspend" != "true" ]; then
     fail "${cluster} is not on the primary cloud (${primary}) but would run its own identity provider."
     echo "      Set spec.suspend: true in clusters/${cluster}/security/zitadel.yaml."

--- a/scripts/validate-idp-topology.sh
+++ b/scripts/validate-idp-topology.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Assert that exactly one cloud hosts the identity provider, and that it is the
+# cloud named by `primary_cloud` in opentofu/config.tm.hcl.
+#
+# WHY THIS EXISTS
+#
+# ADR-0027 makes ZITADEL a primary-cloud singleton: it relocates to whichever
+# cloud is primary, and two clouds each running one is ruled out -- two user
+# directories mean a grant says nothing without knowing which directory issued
+# it. Placement is set in two places that cannot enforce each other:
+#
+#   1. `deploy_identity_provider` (OpenTofu)  -- derived from primary_cloud
+#   2. `spec.suspend` (Flux Kustomization)    -- committed Git state
+#
+# Flux never sees Terramate globals, so gate 2 cannot be derived and is checked
+# here instead. The forbidden state has occurred twice; both times the intended
+# topology was written only in an ADR, where no machine could read it.
+#
+# Usage: validate-idp-topology.sh [ROOT_DIR]
+set -euo pipefail
+
+ROOT="${1:-$(git rev-parse --show-toplevel)}"
+CONFIG="${ROOT}/opentofu/config.tm.hcl"
+KNOWN_CLOUDS="aws gcp"
+failures=0
+
+fail() {
+  echo "FAIL: $*"
+  failures=$((failures + 1))
+}
+
+if [ ! -f "$CONFIG" ]; then
+  echo "FAIL: no ${CONFIG}"
+  exit 1
+fi
+
+primary="$(sed -n 's/^[[:space:]]*primary_cloud[[:space:]]*=[[:space:]]*"\([a-z0-9]*\)".*/\1/p' "$CONFIG" | head -1)"
+
+if [ -z "$primary" ]; then
+  echo "FAIL: primary_cloud is not declared in opentofu/config.tm.hcl."
+  echo "      ADR-0027 requires one named home for services that cannot exist twice."
+  exit 1
+fi
+
+if ! grep -qw "$primary" <<<"$KNOWN_CLOUDS"; then
+  echo "FAIL: primary_cloud = \"${primary}\" is not a known cloud (${KNOWN_CLOUDS})."
+  exit 1
+fi
+
+shopt -s nullglob
+manifests=("${ROOT}"/clusters/*/security/zitadel.yaml)
+shopt -u nullglob
+
+if [ ${#manifests[@]} -eq 0 ]; then
+  echo "FAIL: no clusters/*/security/zitadel.yaml found under ${ROOT}"
+  exit 1
+fi
+
+for manifest in "${manifests[@]}"; do
+  cluster="$(basename "$(dirname "$(dirname "$manifest")")")"
+  cloud="${cluster%%-*}"
+
+  # An absent spec.suspend means not suspended, which is how Flux reads it.
+  suspend="$(python3 - "$manifest" <<'PY'
+import sys, yaml
+with open(sys.argv[1]) as fh:
+    doc = yaml.safe_load(fh) or {}
+print(str((doc.get("spec") or {}).get("suspend", False)).lower())
+PY
+)"
+
+  if [ "$cloud" = "$primary" ]; then
+    if [ "$suspend" = "true" ]; then
+      fail "${cluster} is on the primary cloud (${primary}) but its identity provider is suspended."
+      echo "      Set spec.suspend: false in clusters/${cluster}/security/zitadel.yaml,"
+      echo "      or change primary_cloud in opentofu/config.tm.hcl."
+    fi
+  else
+    if [ "$suspend" != "true" ]; then
+      fail "${cluster} is not on the primary cloud (${primary}) but would run its own identity provider."
+      if [ "$cloud" = "aws" ]; then
+        echo "      opentofu/aws/eks/configure sets identity_provider_url unconditionally, so AWS"
+        echo "      hosts whenever it is deployed. A non-AWS primary with AWS deployed is not a"
+        echo "      supported combination -- it needs an AWS-side host toggle, which is a new decision."
+      else
+        echo "      Set spec.suspend: true in clusters/${cluster}/security/zitadel.yaml."
+      fi
+    fi
+  fi
+done
+
+if [ "$failures" -ne 0 ]; then
+  echo "==> identity provider topology is inconsistent (${failures} problem(s)); see ADR-0027."
+  exit 1
+fi
+
+echo "==> identity provider topology is consistent: ${primary} hosts, all other clouds suspended."

--- a/scripts/zitadel-oidc-clients.sh
+++ b/scripts/zitadel-oidc-clients.sh
@@ -287,14 +287,14 @@ api_or_fail() {
 # app name. The secret KEYS are deliberately not suffixed: they are per-cluster
 # already, living in that cluster's own secret store.
 CONSUMERS=(
-  "grafana${APP_SUFFIX}|https://grafana.${PRIVATE_DOMAIN}/login/generic_oauth|observability-victoria-metrics-k8s-stack-grafana-envvars"
-  "headlamp${APP_SUFFIX}|https://headlamp.${PRIVATE_DOMAIN}/oidc-callback|headlamp-envvars"
-  "flux-ui${APP_SUFFIX}|https://flux-ui-${CLUSTER}.${PRIVATE_DOMAIN}/oauth2/callback|security-flux-ui-oidc"
+  "grafana|https://grafana.${PRIVATE_DOMAIN}/login/generic_oauth|observability-victoria-metrics-k8s-stack-grafana-envvars"
+  "headlamp|https://headlamp.${PRIVATE_DOMAIN}/oidc-callback|headlamp-envvars"
+  "flux-ui|https://flux-ui-${CLUSTER}.${PRIVATE_DOMAIN}/oauth2/callback|security-flux-ui-oidc"
   # gcp-0 only in practice, and harmless on aws-0 where nothing consumes it.
   # GKE cannot be told to trust ZITADEL, so Headlamp there sits behind
   # oauth2-proxy and the PROXY holds the OIDC client -- a second client for the
   # same hostname, on the proxy's own callback path. ADR-0026.
-  "headlamp-proxy${APP_SUFFIX}|https://headlamp.${PRIVATE_DOMAIN}/oauth2/callback|headlamp-oauth2-proxy"
+  "headlamp-proxy|https://headlamp.${PRIVATE_DOMAIN}/oauth2/callback|headlamp-oauth2-proxy"
   # Harbor's callback is /c/oidc/callback -- Harbor's own path, not guessable
   # from the others. No second imperative step applies it: Harbor stores
   # auth config in its DATABASE rather than in the chart, but the chart's
@@ -303,7 +303,7 @@ CONSUMERS=(
   # client id/secret this script writes to the "harbor-oidc" store key reach
   # the HelmRelease via an ExternalSecret + valuesFrom, same as every other
   # consumer here. See ADR-0028.
-  "harbor${APP_SUFFIX}|https://harbor.${PRIVATE_DOMAIN}/c/oidc/callback|harbor-oidc"
+  "harbor|https://harbor.${PRIVATE_DOMAIN}/c/oidc/callback|harbor-oidc"
 )
 
 # The one non-secret OIDC field known to have drifted in practice: headlamp
@@ -630,7 +630,23 @@ cmd_sync() {
 
     local created=0 skipped=0 updated=0 converged=0
     for entry in "${CONSUMERS[@]}"; do
-        IFS='|' read -r name redirect key <<< "$entry"
+        # TWO names, and conflating them is a bug this script has already made.
+        #
+        #   consumer -- the bare name (grafana, harbor, ...). It is the DISPATCH
+        #               KEY for which fields go into which secret, matched
+        #               literally inside merge_secret/converge_secret's jq.
+        #   name     -- the ZITADEL app name, suffixed for a consuming cluster so
+        #               two clusters do not contend for one app.
+        #
+        # Suffixing the CONSUMERS table itself made $name = "grafana-gcp-0",
+        # which matched none of jq's `if $name == "grafana"` branches, fell to
+        # the else, and produced an empty payload:
+        #   ERROR: (gcloud.secrets.versions.add) INVALID_ARGUMENT:
+        #   Secret Payload cannot be empty.
+        # -- after the app had already been created in ZITADEL, stranding a
+        # client secret that ZITADEL only ever returns once.
+        IFS='|' read -r consumer redirect key <<< "$entry"
+        local name="${consumer}${APP_SUFFIX}"
 
         local existing_id=""
         if [ "$project_id" != "DRYRUN-PROJECT" ]; then
@@ -700,7 +716,7 @@ cmd_sync() {
 
             local existing_secret desired
             existing_secret="$(store_read "$key")"
-            desired="$(converge_secret "$name" "$client_id" "$existing_secret")"
+            desired="$(converge_secret "$consumer" "$client_id" "$existing_secret")"
             if [ "$desired" = "$existing_secret" ]; then
                 echo "[ok     ] ${name} -- ${key} already converged"
             elif [ "$APPLY" != "true" ]; then
@@ -745,7 +761,7 @@ cmd_sync() {
             exit 1
         fi
 
-        merge_secret "$key" "$name" "$client_id" "$client_secret" | store_write "$key"
+        merge_secret "$key" "$consumer" "$client_id" "$client_secret" | store_write "$key"
         echo "[created] ${name} -> ${key} (client ${client_id})"
         created=$((created + 1))
     done

--- a/scripts/zitadel-oidc-clients.sh
+++ b/scripts/zitadel-oidc-clients.sh
@@ -646,7 +646,10 @@ cmd_sync() {
         # -- after the app had already been created in ZITADEL, stranding a
         # client secret that ZITADEL only ever returns once.
         IFS='|' read -r consumer redirect key <<< "$entry"
-        local name="${consumer}${APP_SUFFIX}"
+        # :- so a harness that lifts this function out of the script (the
+        # test-zitadel-* suites do) does not trip over nounset on a global it
+        # did not know to declare.
+        local name="${consumer}${APP_SUFFIX:-}"
 
         local existing_id=""
         if [ "$project_id" != "DRYRUN-PROJECT" ]; then

--- a/scripts/zitadel-oidc-clients.sh
+++ b/scripts/zitadel-oidc-clients.sh
@@ -31,8 +31,15 @@
 # them would lock the operator out of Grafana.
 #
 # Usage:
+#   # a cluster that HOSTS its own identity provider
 #   zitadel-oidc-clients.sh sync --cluster gcp-0 --cloud gcp [--project ID] [--apply]
 #   zitadel-oidc-clients.sh sync --cluster aws-0 --cloud aws [--region R]  [--apply]
+#
+#   # a SECONDARY cluster consuming the primary cloud's identity provider:
+#   # admin PAT from AWS, client secrets into GCP, kubectl pointed at aws-0.
+#   IDP_URL=https://auth.cloud.ogenki.io PRIVATE_DOMAIN=priv.gcp.ogenki.io \
+#     zitadel-oidc-clients.sh sync --cluster gcp-0 \
+#       --cloud gcp --project ID --idp-cloud aws --region eu-west-3 --apply
 #
 # Dry-run unless --apply. Client secrets are never printed: ZITADEL returns a
 # client secret exactly once, at creation, so it goes straight from the API
@@ -94,6 +101,7 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --cluster) CLUSTER="$2"; shift 2 ;;
         --cloud)   CLOUD="$2"; shift 2 ;;
+        --idp-cloud) IDP_CLOUD="$2"; shift 2 ;;
         --region)  REGION="$2"; shift 2 ;;
         --project) GCP_PROJECT="$2"; shift 2 ;;
         --apply)   APPLY="true"; shift ;;
@@ -104,6 +112,21 @@ done
 
 [ -n "$CLUSTER" ] || { echo "--cluster is required" >&2; exit 2; }
 case "$CLOUD" in aws|gcp) ;; *) echo "--cloud must be aws or gcp" >&2; exit 2 ;; esac
+
+# Which cloud's secret store holds the ZITADEL ADMIN PAT, as opposed to which
+# one receives the client secrets this script writes. They are the same cloud
+# whenever a cluster hosts its own identity provider, so this defaults to
+# --cloud and every existing invocation is unchanged.
+#
+# They differ in exactly one case, and it is the one ADR-0027 makes normal:
+# a SECONDARY cluster consuming the primary cloud's ZITADEL. Registering
+# gcp-0's clients into aws-0's directory needs the admin PAT from AWS and the
+# resulting client secrets in GCP, because that is where gcp-0's
+# ExternalSecrets read. One flag could not express that, which is why nothing
+# registered a consuming cluster's clients and its oauth2-proxy came up with
+# no secret at all.
+IDP_CLOUD="${IDP_CLOUD:-$CLOUD}"
+case "$IDP_CLOUD" in aws|gcp) ;; *) echo "--idp-cloud must be aws or gcp" >&2; exit 2 ;; esac
 
 # Provenance for secrets this script writes, read by cloud-secret-store.sh's
 # store_write. Preserves what this script wrote before the store/PAT logic
@@ -122,7 +145,21 @@ STORE_WRITE_LABEL="zitadel-oidc-clients"
 ZITADEL_PAT_DRY_RUN="true"
 [ "$APPLY" = "true" ] && ZITADEL_PAT_DRY_RUN="false"
 
+# zitadel-pat.sh and cloud-secret-store.sh both dispatch on the GLOBAL $CLOUD,
+# so the PAT is read with $CLOUD temporarily pointed at the IdP's cloud and the
+# value restored immediately afterwards -- every write below then lands in the
+# target cluster's store, which is the whole point of the split. $REGION and
+# $GCP_PROJECT need no swap: each is only read by its own cloud's branch, so
+# both can be supplied at once.
+#
+# When --idp-cloud differs from --cloud, point kubectl at the cluster that HOSTS
+# the identity provider. resolve_zitadel_pat falls back to reading the PAT from
+# the current context's Kubernetes Secret when the store has none, and on a
+# fresh primary that fallback is the only place the token exists yet.
+_target_cloud="$CLOUD"
+CLOUD="$IDP_CLOUD"
 PAT="$(resolve_zitadel_pat)" || exit 1
+CLOUD="$_target_cloud"
 
 # The IdP base URL. Derived the same way the platform derives it, so a mismatch
 # here is a mismatch everywhere.

--- a/scripts/zitadel-oidc-clients.sh
+++ b/scripts/zitadel-oidc-clients.sh
@@ -128,6 +128,32 @@ case "$CLOUD" in aws|gcp) ;; *) echo "--cloud must be aws or gcp" >&2; exit 2 ;;
 IDP_CLOUD="${IDP_CLOUD:-$CLOUD}"
 case "$IDP_CLOUD" in aws|gcp) ;; *) echo "--idp-cloud must be aws or gcp" >&2; exit 2 ;; esac
 
+# App names are per-CONSUMER (`harbor`, `grafana`, ...), which is unambiguous
+# only while one directory serves one cluster. It no longer does: ADR-0027 makes
+# a secondary cluster CONSUMING the primary's directory the normal arrangement,
+# and then two clusters want an app called `harbor` in the same project.
+#
+# Caught by a dry run on 2026-09-02, before anything was written:
+#
+#   [STALE  ] harbor  has:  https://harbor.priv.aws.ogenki.io/c/oidc/callback
+#                     want: https://harbor.priv.gcp.ogenki.io/c/oidc/callback
+#   created: 0, updated: 5
+#
+# Registering gcp-0 would not have created gcp-0's clients -- it would have
+# rewritten aws-0's redirect URIs to gcp-0's hostnames and broken SSO on the
+# cluster that hosts the directory.
+#
+# So a CONSUMING cluster's apps are suffixed with its cluster name. The hosting
+# cluster's are not, deliberately: its apps already exist under bare names, they
+# are carried in the database restore seed, and renaming them would orphan the
+# originals on every restore while rotating secrets on a running cluster.
+# Asymmetric, and the asymmetry is the point -- the host owns the plain names.
+if [ "$IDP_CLOUD" != "$CLOUD" ]; then
+    APP_SUFFIX="-${CLUSTER}"
+else
+    APP_SUFFIX=""
+fi
+
 # Provenance for secrets this script writes, read by cloud-secret-store.sh's
 # store_write. Preserves what this script wrote before the store/PAT logic
 # moved into shared libraries.
@@ -256,15 +282,19 @@ api_or_fail() {
 #   Grafana   /login/generic_oauth   (grafana.ini auth.generic_oauth)
 #   Headlamp  /oidc-callback         (headlamp chart)
 #   Flux UI   /oauth2/callback       (flux-operator web.config.authentication)
+# ${APP_SUFFIX} is empty for the cluster that HOSTS this directory and
+# "-<cluster>" for one consuming it, so two clusters never contend for the same
+# app name. The secret KEYS are deliberately not suffixed: they are per-cluster
+# already, living in that cluster's own secret store.
 CONSUMERS=(
-  "grafana|https://grafana.${PRIVATE_DOMAIN}/login/generic_oauth|observability-victoria-metrics-k8s-stack-grafana-envvars"
-  "headlamp|https://headlamp.${PRIVATE_DOMAIN}/oidc-callback|headlamp-envvars"
-  "flux-ui|https://flux-ui-${CLUSTER}.${PRIVATE_DOMAIN}/oauth2/callback|security-flux-ui-oidc"
+  "grafana${APP_SUFFIX}|https://grafana.${PRIVATE_DOMAIN}/login/generic_oauth|observability-victoria-metrics-k8s-stack-grafana-envvars"
+  "headlamp${APP_SUFFIX}|https://headlamp.${PRIVATE_DOMAIN}/oidc-callback|headlamp-envvars"
+  "flux-ui${APP_SUFFIX}|https://flux-ui-${CLUSTER}.${PRIVATE_DOMAIN}/oauth2/callback|security-flux-ui-oidc"
   # gcp-0 only in practice, and harmless on aws-0 where nothing consumes it.
   # GKE cannot be told to trust ZITADEL, so Headlamp there sits behind
   # oauth2-proxy and the PROXY holds the OIDC client -- a second client for the
   # same hostname, on the proxy's own callback path. ADR-0026.
-  "headlamp-proxy|https://headlamp.${PRIVATE_DOMAIN}/oauth2/callback|headlamp-oauth2-proxy"
+  "headlamp-proxy${APP_SUFFIX}|https://headlamp.${PRIVATE_DOMAIN}/oauth2/callback|headlamp-oauth2-proxy"
   # Harbor's callback is /c/oidc/callback -- Harbor's own path, not guessable
   # from the others. No second imperative step applies it: Harbor stores
   # auth config in its DATABASE rather than in the chart, but the chart's
@@ -273,7 +303,7 @@ CONSUMERS=(
   # client id/secret this script writes to the "harbor-oidc" store key reach
   # the HelmRelease via an ExternalSecret + valuesFrom, same as every other
   # consumer here. See ADR-0028.
-  "harbor|https://harbor.${PRIVATE_DOMAIN}/c/oidc/callback|harbor-oidc"
+  "harbor${APP_SUFFIX}|https://harbor.${PRIVATE_DOMAIN}/c/oidc/callback|harbor-oidc"
 )
 
 # The one non-secret OIDC field known to have drifted in practice: headlamp

--- a/security/gcp-0/zitadel/kustomization.yaml
+++ b/security/gcp-0/zitadel/kustomization.yaml
@@ -85,13 +85,19 @@ patches:
   #      (infrastructure/gcp-0/cloudnative-pg-barman-plugin) with a GCS egress
   #      allowlist in place of the base's AWS S3 one.
   #
-  #   4. instances stays at 1, where before it followed from having no backup.
-  #      The XRD's CEL rule -- `backup.schedule is required for multi-instance
-  #      clusters` -- is satisfied now, so 2 would be allowed. It is still 1
-  #      because this cluster is rebuilt from scratch and torn down after every
-  #      run, and a standby costs a second Postgres for availability nobody is
-  #      here to need. aws-0 keeps 2. Raising it here is a one-line change the
-  #      moment anything on gcp-0 becomes long-lived.
+  #   4. instances matches aws-0 at 2. It was 1 for as long as gcp-0's ZITADEL
+  #      was a duplicate of the real one -- a second directory on a throwaway
+  #      cluster, where a standby bought availability nobody needed.
+  #
+  #      ADR-0027 removed that situation: this instance only ever runs when GCP
+  #      is PRIMARY, and GCP being primary means a GCP-only platform, where this
+  #      is not a spare directory but THE directory. Every login on the platform
+  #      depends on it, so it gets the same durability as aws-0's.
+  #
+  #      It costs nothing the rest of the time: with AWS primary this whole
+  #      Kustomization is suspended, so the claim is never applied.
+  #      (The XRD's CEL rule -- `backup.schedule is required for multi-instance
+  #      clusters` -- is satisfied, since gcp-0 writes real backups now.)
   - target:
       group: cloud.ogenki.io
       kind: SQLInstance
@@ -102,7 +108,7 @@ patches:
         value: xsqlinstances-gcp.cloud.ogenki.io
       - op: replace
         path: /spec/instances
-        value: 1
+        value: 2
       - op: replace
         path: /spec/objectStoreRecovery/bucketName
         value: ${project_id}-ogenki-cnpg-backups

--- a/website/content/docs/decisions/0024-identity-provider-per-cloud.md
+++ b/website/content/docs/decisions/0024-identity-provider-per-cloud.md
@@ -3,7 +3,7 @@ title: The identity provider is deployable on either cloud, defaulting to AWS
 linkTitle: 0024 · IdP per cloud
 weight: 240
 description: ZITADEL becomes a per-cloud deployable component behind two gates rather than a singleton pinned to aws-0, so a GCP-only platform can authenticate without an AWS cluster running. It stays a singleton — one directory, hosted on the primary cloud, relocating rather than duplicating. Public DNS stays AWS-owned.
-lastVerified: 2026-08-30
+lastVerified: 2026-09-01
 ---
 
 **Status**: Accepted
@@ -45,7 +45,7 @@ unless deliberately turned on. Turning it on takes **two gates that must agree**
 
 | Gate | Where | Effect |
 |---|---|---|
-| `deploy_identity_provider = true` | `opentofu/gcp/gke/configure` | Derives `identity_provider_url` to `auth.<this cluster's public domain>` |
+| `deploy_identity_provider = true` | `opentofu/gcp/gke/configure` — **derived, not typed, since 2026-09-01** | Derives `identity_provider_url` to `auth.<this cluster's public domain>` |
 | `spec.suspend` removed / resumed | `clusters/gcp-0/security/zitadel.yaml` | Flux actually deploys it |
 
 Gate 1 alone points every consumer at a hostname the cluster does not serve.
@@ -53,6 +53,21 @@ Gate 2 alone runs an instance nothing is configured to use. Neither can enforce
 the other, so `identity_provider_url` is **derived from gate 1** rather than
 typed a second time — the literal is what let "which cloud hosts the IdP"
 become unanswerable from configuration in the first place.
+
+{{< callout type="info" >}}
+**Update (2026-09-01):** gate 1 is no longer typed by hand either. It is derived
+from `global.primary_cloud` (see
+[ADR-0027]({{< relref "/docs/decisions/0027-primary-cloud-provider.md" >}})) at
+every invocation site, so it cannot disagree with the declared topology. Gate 2
+remains committed Flux state — Flux never sees Terramate globals, and `postBuild`
+substitution cannot reach a Kustomization's own `spec` — so it is verified
+instead, by `./scripts/validate-idp-topology.sh` in CI.
+
+"Neither can enforce the other" is now **one derived, one verified**. The
+prediction above was borne out twice before that: this record's own gates were
+found disagreeing on 2026-08-29, and a dual-cloud bootstrap on 2026-09-01 ran
+two directories at once.
+{{< /callout >}}
 
 {{< callout type="warning" >}}
 **"Deployable on either cloud" is not "running on both at once."** ZITADEL stays a

--- a/website/content/docs/decisions/0027-primary-cloud-provider.md
+++ b/website/content/docs/decisions/0027-primary-cloud-provider.md
@@ -3,7 +3,7 @@ title: AWS is the primary cloud, and cross-cloud singletons live there
 linkTitle: 0027 · Primary cloud
 weight: 270
 description: Some services cannot sensibly exist twice — one public DNS zone, one identity directory, one federation trust. Naming AWS the primary cloud gives those a defined home, and gives a GCP-only platform a defined way to take it over.
-lastVerified: 2026-08-29
+lastVerified: 2026-09-01
 ---
 
 **Status**: Accepted
@@ -91,6 +91,23 @@ path as designed rather than proven.
 **What it does not change.** Nothing per-cloud. Both clusters keep their own
 OpenBao, secret store, state and backups, and neither depends on the other for
 them. This decision is only about the handful of things that cannot be two.
+
+**How it is enforced (2026-09-01).** The primary cloud is declared once, as
+`primary_cloud` in `opentofu/config.tm.hcl`. The OpenTofu gate that decides
+whether a cluster hosts ZITADEL is derived from it at every invocation site; the
+Flux gate, which cannot be derived because Flux never sees Terramate globals, is
+checked against it by `./scripts/validate-idp-topology.sh` in CI. The third state
+this record rules out — two clouds each hosting a singleton — now fails a
+required check rather than depending on someone remembering the rule.
+
+It was worth doing: this record was written on 2026-08-29 *because* two
+directories were running, and a dual-cloud bootstrap on 2026-09-01 produced the
+same state again, from configuration left over after the GCP validation work. A
+rule that only exists in prose is a rule the next rebuild can quietly break.
+
+A non-AWS primary while AWS is also deployed is rejected too:
+`opentofu/aws/eks/configure` hosts unconditionally, so supporting that
+combination would need an AWS-side toggle and a new decision.
 
 ## Alternatives considered
 

--- a/website/content/docs/guides/add-a-cloud-provider.md
+++ b/website/content/docs/guides/add-a-cloud-provider.md
@@ -113,6 +113,23 @@ consumed internally by the developer-facing compositions.
 works the case through `EPI`, whose central field — inline AWS IAM JSON — has
 no neutral form.
 
+## Where the cloud list is enumerated
+
+Three places name the clouds explicitly, and a new lane has to appear in all
+three or it half-works:
+
+| Place | What it drives |
+|---|---|
+| `global.stack_cloud` in `opentofu/config.tm.hcl` | which lane a stack belongs to, from its tags |
+| `--tm-check` in `scripts/tm-provisioner.sh` | whether `TM_CLOUD` selects that lane |
+| `KNOWN_CLOUDS` in `scripts/validate-idp-topology.sh` | which values `primary_cloud` may take |
+
+The third is the one that surprises: a new lane that is *not* primary must also
+have `spec.suspend: true` on its own `clusters/<cluster>/security/zitadel.yaml`,
+or the topology check fails — the identity provider is a primary-cloud
+singleton ([ADR-0027]({{< relref "/docs/decisions/0027-primary-cloud-provider.md" >}})),
+so a third cloud consumes it rather than running its own.
+
 ## What must not change
 
 `App` and `SQLInstance` claims are developer-facing and stay neutral. The

--- a/website/content/docs/guides/migrate-the-identity-provider.md
+++ b/website/content/docs/guides/migrate-the-identity-provider.md
@@ -164,16 +164,32 @@ not a flag flipped there.
 
 | Gate | Where | Target value for GCP-hosted |
 |---|---|---|
-| `deploy_identity_provider` | `opentofu/gcp/gke/configure/variables.tfvars` | `true` |
+| `primary_cloud` | `opentofu/config.tm.hcl` | `"gcp"` |
 | `spec.suspend` | `clusters/gcp-0/security/zitadel.yaml` | `false` |
 
-They must agree in the same commit — one alone points every consumer at a
-hostname nothing serves, or runs an instance nothing is configured to use, and
-neither half can detect the other is wrong.
+**Do not set `deploy_identity_provider` in `variables.tfvars`.** It is derived
+from `primary_cloud` and passed as a `-var` on every invocation, which wins over
+the file — re-adding the literal there changes nothing and reports no error.
+Setting `primary_cloud` is what flips it.
 
-Migrating back to AWS is the reverse: `deploy_identity_provider = false` and
+The two gates must still agree, in the same commit: one alone points every
+consumer at a hostname nothing serves, or runs an instance nothing is configured
+to use. The difference is that disagreement is now caught —
+`./scripts/validate-idp-topology.sh` fails in CI, rather than the platform
+failing silently at the authorize step.
+
+Migrating back to AWS is the reverse: `primary_cloud = "aws"` and
 `spec.suspend: true` on the GCP side; nothing to flip on AWS, since it has no
 gate to begin with.
+
+{{< callout type="warning" >}}
+**Suspending is not decommissioning.** `spec.suspend: true` stops Flux
+reconciling the outgoing instance; it does not remove what is already running.
+On a live migration, delete the outgoing cluster's ZITADEL release, its
+`SQLInstance` claim, TLSRoute and certificate after the new host is serving —
+otherwise two directories keep running while the topology check, which reads
+committed YAML rather than the cluster, reports "consistent".
+{{< /callout >}}
 
 ## 6. Deploy
 

--- a/website/content/docs/platform/foundations/cloud-support.md
+++ b/website/content/docs/platform/foundations/cloud-support.md
@@ -223,18 +223,26 @@ GCP-only platform can authenticate without an AWS cluster running. The accepted
 cost is one user directory per cloud, with no federation between them. Only
 public DNS stays AWS-owned ([ADR-0019](../../decisions/0019-cross-cloud-dns-federation.md)).
 
-`gcp-0` takes that opt-out today and runs its own instance. Doing so requires
-two gates that must agree, because neither can enforce the other:
+`gcp-0` does **not** take that opt-out: AWS is the primary cloud
+([ADR-0027](../../decisions/0027-primary-cloud-provider.md)), so `aws-0` hosts
+the one instance and `gcp-0` consumes it. The opt-out exists for a GCP-only
+platform, where the singleton relocates rather than being duplicated — two
+clouds each running a directory is ruled out, since a grant means nothing
+without knowing which directory issued it.
 
-| Gate | Where | Value on `gcp-0` |
+Placement has two halves, and only one of them is typed:
+
+| Gate | Where | Value today |
 |---|---|---|
-| 1 · which URL consumers read | `deploy_identity_provider` in `opentofu/gcp/gke/configure/variables.tfvars` | `true` |
-| 2 · whether an instance runs | `spec.suspend` in `clusters/gcp-0/security/zitadel.yaml` | `false` |
+| 1 · which URL consumers read | `deploy_identity_provider`, **derived** from `primary_cloud` in `opentofu/config.tm.hcl` | `false` on `gcp-0` |
+| 2 · whether an instance runs | `spec.suspend` in `clusters/gcp-0/security/zitadel.yaml` | `true` |
 
-Gate 1 alone points every consumer at a hostname nothing serves. Gate 2 alone
-runs an IdP no consumer is configured to use — and that half fails *silently*,
-since ZITADEL is up and every consumer is healthy while pointed at the other
-cluster. Flip them in the same commit.
+Gate 1 cannot disagree with the declaration, because it is the declaration.
+Gate 2 is committed Flux state — Flux never reads Terramate globals — so it is
+verified instead, by `./scripts/validate-idp-topology.sh` in CI. Changing which
+cloud hosts is a [migration]({{< relref "/docs/guides/migrate-the-identity-provider.md" >}}),
+not a toggle: the database seed, admin credential and OIDC clients travel with
+it.
 
 ## Adding a third cloud
 


### PR DESCRIPTION
**Regression fix for a bug that shipped in #1948** — found by running the registration for real rather than dry.

The app-name suffixing added in #1948 conflated two uses of one variable:

- `consumer` — the **dispatch key** matched literally inside `merge_secret`/`converge_secret`'s jq (`if $name == "grafana"`)
- `name` — the **ZITADEL app name**, which must be unique per cluster

With the `CONSUMERS` table suffixed, `$name` became `grafana-gcp-0`, matched no jq branch, fell to the `else` and emitted an empty document:

```
ERROR: (gcloud.secrets.versions.add) INVALID_ARGUMENT: Secret Payload cannot be empty.
```

That aborted the run **after** the app was created in ZITADEL — stranding a client secret ZITADEL returns only once, on an app the machine user has no permission to delete (403). A genuinely awkward state to land in.

**Fix:** the table keeps bare names; the loop derives the app name from them, so both come from one place. Plus `${APP_SUFFIX:-}` and a harness declaration, because the convergence suite lifts these functions out of the script and supplies globals by hand — which is how a new global silently broke four assertions.

## Evidence — live against aws-0's directory

```
created: 4, updated: 0, unchanged: 1, converged: 1
```

All four remaining apps created with secrets written to the GCP store, the Grafana admin credentials sharing one of those secrets preserved by the merge, and the stranded `grafana-gcp-0` repaired by regenerating its client secret (avoiding the delete permission gap). All 5 zitadel test suites pass; shellcheck clean.

**gcp-0's SSO now has a complete, matching set of OIDC clients in aws-0's directory** — the first time the consuming path has actually worked end to end.