### PR TITLE
fix(teardown): a stack whose target is already gone must not strand the rest

### DIFF
--- a/opentofu/aws/openbao/management/workflows.tm.hcl
+++ b/opentofu/aws/openbao/management/workflows.tm.hcl
@@ -96,7 +96,22 @@ script "destroy" {
       global.openbao_ca_cmd.args,
       # Same #3411 race on the way down — mounts and namespaces are deleted
       # concurrently otherwise. See the apply job below.
-      [global.provisioner, "destroy", "-auto-approve", "-parallelism=1", "-var-file=variables.tfvars"],
+      #
+      # Wrapped (#1964): every `vault_*` resource here lives INSIDE the OpenBao
+      # cluster, which opentofu/aws/openbao/cluster destroys immediately after
+      # this stack in the reverse walk. By then `bao.priv.aws.ogenki.io` no
+      # longer resolves, so the provider cannot delete them and terramate's
+      # --reverse walk halts — stranding the OpenBao cluster, the network and
+      # the shared stacks. Measured 2026-09-02: two teardowns reported success
+      # while a NAT gateway and two instances kept running.
+      #
+      # The wrapper only drops `vault_*` on failure. The aws_secretsmanager_*
+      # secrets and random_password in this same state are real resources, do
+      # not match, and tofu still has to delete them.
+      ["bash", "${terramate.root.path.fs.absolute}/scripts/tm-provisioner.sh", "--tm-run",
+        "bash", "${terramate.root.path.fs.absolute}/scripts/tofu-destroy-contained.sh",
+        "--contained-prefix", "vault_", "--",
+      "-auto-approve", "-parallelism=1", "-var-file=variables.tfvars"],
     ]
   }
 }

--- a/scripts/eks-prepare-destroy.sh
+++ b/scripts/eks-prepare-destroy.sh
@@ -239,12 +239,56 @@ if kubectl api-resources --api-group=karpenter.sh 2>/dev/null | grep -q nodepool
 		if [ "${remaining:-0}" = "0" ]; then
 			echo "All NodeClaims terminated."
 		else
-			echo "[warn] ${remaining} NodeClaim(s) still present. Their EC2 instances will"
-			echo "[warn] outlive the cluster and their ENIs will block security-group"
-			echo "[warn] deletion with DependencyViolation. After the destroy, sweep them:"
-			echo "[warn]   aws ec2 describe-instances --region <region> \\"
-			echo "[warn]     --filters Name=tag:kubernetes.io/cluster/<cluster>,Values=owned \\"
-			echo "[warn]               Name=instance-state-name,Values=running"
+			# Do the sweep rather than describing it (#1964).
+			#
+			# This branch used to print the exact command an operator should run
+			# afterwards -- and it correctly predicted the failure, right down to
+			# the DependencyViolation. It just did not act, so on 2026-09-02 a
+			# c5.xlarge outlived its control plane, held a Cilium ENI on two
+			# security groups, and `tofu destroy` died with
+			#
+			#   Error: deleting Security Group (sg-...): DependencyViolation
+			#
+			# halting the whole --reverse walk before the network, OpenBao and
+			# the entire GCP lane were reached. `aws eks list-clusters` was
+			# already empty: a node with no control plane, still billing.
+			echo "[warn] ${remaining} NodeClaim(s) did not terminate in time."
+			echo "[sweep] terminating their EC2 instances directly, or their ENIs"
+			echo "[sweep] will block security-group deletion with DependencyViolation."
+
+			orphans="$(${AWS_CMD} ec2 describe-instances \
+				--filters "Name=tag:kubernetes.io/cluster/${CLUSTER_NAME},Values=owned" \
+				"Name=instance-state-name,Values=running,pending,stopping,stopped" \
+				--query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null || true)"
+
+			if [ -z "${orphans}" ]; then
+				echo "[sweep] no orphaned instances found; nothing to terminate."
+			else
+				# shellcheck disable=SC2086 # deliberate word splitting: instance-ids takes a list
+				${AWS_CMD} ec2 terminate-instances --instance-ids ${orphans} \
+					--query 'TerminatingInstances[].InstanceId' --output text >/dev/null 2>&1 \
+					|| echo "[warn] terminate call failed; sweep them by hand."
+				echo "[sweep] terminating: ${orphans}"
+
+				# Wait on the ENIs, NOT on instance state. They detach
+				# asynchronously after the instance reaches `terminated`, so a
+				# destroy retried on instance state alone hits the SAME
+				# DependencyViolation -- observed 2026-09-03.
+				echo "[sweep] waiting for their ENIs to detach (up to 300s)..."
+				for _ in $(seq 1 60); do
+					enis="$(${AWS_CMD} ec2 describe-network-interfaces \
+						--filters "Name=tag:cluster.k8s.amazonaws.com/name,Values=${CLUSTER_NAME}" \
+						--query 'length(NetworkInterfaces)' --output text 2>/dev/null || echo 0)"
+					[ "${enis:-0}" = "0" ] && break
+					sleep 5
+				done
+				if [ "${enis:-0}" = "0" ]; then
+					echo "[sweep] ENIs released; the security groups can now be deleted."
+				else
+					echo "[warn] ${enis} ENI(s) still attached after 300s. The destroy may"
+					echo "[warn] still hit DependencyViolation; re-run it once they clear."
+				fi
+			fi
 		fi
 	fi
 else

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# The supported way to tear the platform down.
+#
+# WHY THIS EXISTS RATHER THAN `terramate script run --reverse destroy`
+#
+# Two things go wrong with the bare command, and both went wrong on 2026-09-02
+# (#1964):
+#
+#   1. The walk HALTS on the first failing stack. A stack that fails because its
+#      target is ALREADY GONE -- a vault whose DNS no longer resolves, a cluster
+#      whose credentials expired -- takes every downstream stack with it. Two
+#      teardowns left an AWS NAT gateway, two instances, and the entire gcp-0
+#      GKE cluster with three e2-standard-4 nodes running. gcp-0 survived three
+#      attempts.
+#
+#      terramate has `--continue-on-error` and nothing was passing it.
+#
+#   2. Success is reported by an exit code that does not mean what it looks
+#      like. The destroy can report success having destroyed nothing, and a
+#      wrapper that ends in `echo` returns the echo's status rather than
+#      terramate's. Both happened.
+#
+# So: continue past failures, then VERIFY AGAINST THE CLOUD rather than trusting
+# any exit code. Nothing here is finished because a command said so; it is
+# finished when the provider says there is nothing left.
+#
+# Usage:
+#   scripts/teardown.sh                 # aws (the TM_CLOUD default)
+#   TM_CLOUD=gcp     scripts/teardown.sh
+#   TM_CLOUD=all     scripts/teardown.sh
+#   scripts/teardown.sh --verify-only   # skip the destroy, just report what is left
+#
+# TM_DESTROY_CONFIRMED=true skips the interactive prompt, for unattended runs.
+set -o nounset
+set -o pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLOUDS="${TM_CLOUD:-aws}"
+VERIFY_ONLY=0
+[ "${1:-}" = "--verify-only" ] && VERIFY_ONLY=1
+
+wants() { # $1 = lane
+  case ",${CLOUDS// /}," in
+    *,all,*) return 0 ;;
+    *,"$1",*) return 0 ;;
+  esac
+  return 1
+}
+
+destroy_rc=0
+if [ "$VERIFY_ONLY" -eq 0 ]; then
+  echo "=== destroying (TM_CLOUD=${CLOUDS}) ==="
+  # --continue-on-error is the point: one stack whose target is already gone must
+  # not strand the stacks that still own billable resources.
+  ( cd "${ROOT}/opentofu" && terramate script run --reverse --continue-on-error destroy )
+  destroy_rc=$?
+  echo "=== terramate exit: ${destroy_rc} ==="
+  echo
+fi
+
+# ---------------------------------------------------------------------------
+# Verification. This is the part that matters -- see the header.
+# ---------------------------------------------------------------------------
+leftovers=0
+# Tracked separately from `leftovers`: "I checked and found things" and "I could
+# not check" are different facts, and reporting the second as the first is the
+# same conflation this whole script exists to stop. Both are non-zero exits --
+# neither is "clean" -- but the operator must be able to tell them apart.
+unverified=0
+
+report() { # $1 = label, $2 = value (empty/0 means clean)
+  if [ -z "${2//[[:space:]]/}" ] || [ "${2//[[:space:]]/}" = "0" ] || [ "${2//[[:space:]]/}" = "None" ]; then
+    printf '  ok   %-22s none\n' "$1"
+  else
+    printf '  LEFT %-22s %s\n' "$1" "$(printf '%s' "$2" | tr '\n' ' ')"
+    leftovers=$((leftovers + 1))
+  fi
+}
+
+if wants aws; then
+  region="${AWS_REGION:-eu-west-3}"
+  echo "=== AWS (${region}) — verified against the provider, not the exit code ==="
+  report "EC2 instances" "$(aws ec2 describe-instances --region "$region" \
+    --filters Name=instance-state-name,Values=running,pending,stopping,stopped \
+    --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null)"
+  report "EKS clusters" "$(aws eks list-clusters --region "$region" \
+    --query 'clusters' --output text 2>/dev/null)"
+  report "NAT gateways" "$(aws ec2 describe-nat-gateways --region "$region" \
+    --filter Name=state,Values=available,pending \
+    --query 'NatGateways[].NatGatewayId' --output text 2>/dev/null)"
+  report "Load balancers" "$(aws elbv2 describe-load-balancers --region "$region" \
+    --query 'LoadBalancers[].LoadBalancerName' --output text 2>/dev/null)"
+  report "Non-default VPCs" "$(aws ec2 describe-vpcs --region "$region" \
+    --query 'Vpcs[?IsDefault==`false`].VpcId' --output text 2>/dev/null)"
+  report "Available EBS volumes" "$(aws ec2 describe-volumes --region "$region" \
+    --filters Name=status,Values=available --query 'length(Volumes)' --output text 2>/dev/null)"
+  echo
+fi
+
+if wants gcp; then
+  project="${GCP_PROJECT:-ogenki-435905}"
+  echo "=== GCP (${project}) — verified against the provider, not the exit code ==="
+  # gcloud's auth expires mid-run more often than is comfortable, and an auth
+  # failure here must not read as "nothing left" -- that is the same
+  # empty-vs-failed conflation that #1963's promotion script had to fix.
+  if ! gcloud projects describe "$project" >/dev/null 2>&1; then
+    echo "  ?? cannot reach GCP (auth expired?) — CANNOT VERIFY. Run: gcloud auth login"
+    unverified=$((unverified + 1))
+  else
+    report "GKE clusters" "$(gcloud container clusters list --project "$project" \
+      --format='value(name)' 2>/dev/null)"
+    report "GCE instances" "$(gcloud compute instances list --project "$project" \
+      --format='value(name)' 2>/dev/null)"
+    report "Forwarding rules" "$(gcloud compute forwarding-rules list --project "$project" \
+      --format='value(name)' 2>/dev/null)"
+    report "Disks" "$(gcloud compute disks list --project "$project" \
+      --format='value(name)' 2>/dev/null)"
+  fi
+  echo
+fi
+
+echo "=== summary ==="
+[ "$destroy_rc" -eq 0 ] && echo "  terramate:  exit 0" || echo "  terramate:  exit ${destroy_rc} (some stacks failed; see above)"
+if [ "$leftovers" -eq 0 ] && [ "$unverified" -eq 0 ]; then
+  echo "  cloud:      clean"
+else
+  [ "$leftovers" -gt 0 ] && \
+    echo "  cloud:      ${leftovers} category(ies) still populated — NOT torn down"
+  [ "$unverified" -gt 0 ] && \
+    echo "  cloud:      ${unverified} cloud(s) COULD NOT BE CHECKED — status unknown, assume not torn down"
+fi
+
+# Exit non-zero if the destroy failed, OR anything is still standing, OR a cloud
+# could not be checked. A green exit here means the provider itself reports
+# nothing left -- not that a command returned 0.
+[ "$destroy_rc" -eq 0 ] && [ "$leftovers" -eq 0 ] && [ "$unverified" -eq 0 ]

--- a/scripts/tofu-destroy-contained.sh
+++ b/scripts/tofu-destroy-contained.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# `tofu destroy`, but a stack whose only remaining blockers live INSIDE
+# infrastructure that is about to be destroyed anyway does not halt the sweep.
+#
+# THE PROBLEM THIS SOLVES
+#
+# Some stacks manage resources whose entire lifetime is contained by another
+# stack's infrastructure:
+#
+#   aws/openbao/management   vault_*           policies, mounts, approles, PKI
+#   gcp/openbao/management   vault_*           inside the OpenBao cluster
+#   gcp/gke/configure        kubectl_manifest  Gateway API CRDs, flux-system, vars
+#
+# In a `--reverse destroy` the very next stack destroys the vault or the cluster
+# that contains them. Deleting a Vault policy seconds before deleting the Vault
+# is meaningless work -- and it usually CANNOT be done, because by then the
+# endpoint is already unreachable:
+#
+#   Error: failed to lookup token ... dial tcp: lookup bao.priv.aws.ogenki.io
+#          on 127.0.0.53:53: no such host
+#   Error: gatewayclasses.gateway.networking.k8s.io failed to delete kubernetes
+#          resource: Unauthorized
+#
+# terramate's `--reverse` walk HALTS on that failure, so everything downstream --
+# the OpenBao cluster, the network, the shared stacks -- is never attempted.
+#
+# Measured 2026-09-02/03 (#1964): two full teardowns reported success while an
+# AWS NAT gateway, two t3.micro instances and the ENTIRE gcp-0 GKE cluster with
+# three e2-standard-4 nodes kept running. gcp-0 survived three attempts. The
+# manual unblock was three `tofu state rm` invocations reconstructed from error
+# messages.
+#
+# WHY FAILURE-DRIVEN RATHER THAN A REACHABILITY PROBE
+#
+# Probing "is the vault up?" first means writing a second, different piece of
+# logic that can disagree with what tofu actually experiences -- and a probe that
+# says "reachable" while the provider still fails leaves the halt in place.
+# The destroy attempt IS the probe: it uses the provider's own credentials, its
+# own endpoint resolution, its own timeouts.
+#
+# WHY THIS IS SAFE EVEN IF THE FAILURE HAD ANOTHER CAUSE
+#
+# Only the resource classes named by --contained-prefix are ever dropped, and
+# those are exactly the ones whose backing objects disappear with the next stack.
+# No real cloud resource is ever removed from state here: the AWS Secrets Manager
+# secrets in openbao/management, the Bucket in a cloudnative-pg claim, the EC2
+# instances -- none match, none are touched, and tofu must still delete them for
+# the retry to succeed. If the failure was something else entirely, the retry
+# fails again and the real error surfaces, with the same exit code it would have
+# had.
+#
+# Usage (through tm-provisioner.sh --tm-run, so it inherits the cloud gate):
+#   tofu-destroy-contained.sh --contained-prefix vault_ -- -auto-approve -var-file=variables.tfvars
+#   tofu-destroy-contained.sh --contained-prefix kubectl_manifest -- -auto-approve
+#
+# --contained-prefix may be repeated. Matching is on the START of the state
+# address, so `vault_` matches `vault_policy.admin` and
+# `module.x.vault_mount.y` is matched by `module.x.vault_` only -- deliberately
+# literal, because a regex here would eventually match something real.
+set -o nounset
+set -o pipefail
+
+PREFIXES=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --contained-prefix)
+      [ $# -ge 2 ] || { echo "--contained-prefix needs a value" >&2; exit 2; }
+      PREFIXES+=("$2"); shift 2 ;;
+    --)
+      shift; break ;;
+    *)
+      echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ "${#PREFIXES[@]}" -gt 0 ] || { echo "at least one --contained-prefix is required" >&2; exit 2; }
+[ $# -gt 0 ] || { echo "no destroy arguments given after --" >&2; exit 2; }
+
+echo "==> tofu destroy $*"
+tofu destroy "$@"
+rc=$?
+[ "$rc" -eq 0 ] && exit 0
+
+echo
+echo "[warn] destroy failed (exit ${rc})."
+echo "[warn] Checking whether the blockers are resources contained by infrastructure"
+echo "[warn] this sweep destroys next -- see the header of $(basename "$0")."
+
+# Collect the contained entries. A state-list failure is NOT "there are none":
+# treat it as a real failure and surface the original destroy error.
+if ! state_list="$(tofu state list 2>&1)"; then
+  echo "[error] could not read the state to look for contained resources:" >&2
+  printf '%s\n' "$state_list" >&2
+  exit "$rc"
+fi
+
+contained=()
+while IFS= read -r addr; do
+  [ -n "$addr" ] || continue
+  for p in "${PREFIXES[@]}"; do
+    case "$addr" in
+      "$p"*) contained+=("$addr"); break ;;
+    esac
+  done
+done <<< "$state_list"
+
+if [ "${#contained[@]}" -eq 0 ]; then
+  echo "[error] no contained resources in state (prefixes: ${PREFIXES[*]})."
+  echo "[error] This failure is not the one this wrapper handles. Original error stands."
+  exit "$rc"
+fi
+
+echo "[info ] dropping ${#contained[@]} contained resource(s) from state:"
+printf '         %s\n' "${contained[@]}"
+echo "[info ] their backing objects live inside infrastructure destroyed by the"
+echo "[info ] next stack in the reverse walk, so deleting them individually is"
+echo "[info ] both impossible now and unnecessary."
+
+# One call: each `state rm` rewrites and re-uploads state, and a partial sequence
+# interrupted halfway is a worse mess than the one being cleaned up.
+if ! tofu state rm "${contained[@]}"; then
+  echo "[error] failed to drop contained resources from state." >&2
+  exit "$rc"
+fi
+
+echo
+echo "==> retrying: tofu destroy $*"
+tofu destroy "$@"
+retry_rc=$?
+if [ "$retry_rc" -ne 0 ]; then
+  echo "[error] destroy still failing after dropping contained resources." >&2
+  echo "[error] The blocker is something else; this is the real error." >&2
+fi
+exit "$retry_rc"


### PR DESCRIPTION
fix(teardown): a stack whose target is already gone must not strand the rest

Closes #1964.

On 2026-09-02/03 two full teardowns reported success having destroyed almost
nothing. Afterwards an AWS NAT gateway, an NLB and two t3.micro instances were
still running, and the entire gcp-0 GKE cluster with three e2-standard-4 nodes
had never been touched. gcp-0 survived three attempts.

`terramate script run --reverse destroy` halts on the first failing stack, and
the stacks that fail during a teardown are usually the ones whose target is
ALREADY GONE -- a vault whose DNS no longer resolves, a cluster whose token has
expired. Everything downstream, including the stacks that own the billable
compute, is never reached.

The interesting part is that GCP had already solved this and AWS had not.
`gcp/gke/configure` and `gcp/openbao/management` are both deliberately tolerant,
the former's header saying so in capitals. The pattern simply never crossed the
lane boundary, so the same hole stayed open on the other cloud.

Three changes.

AWS's openbao/management destroy is wrapped by a new
scripts/tofu-destroy-contained.sh. Every `vault_*` resource in that stack lives
inside the OpenBao cluster destroyed immediately afterwards, so when the endpoint
is unreachable those resources cannot be deleted and are not worth deleting. The
wrapper retries the destroy once with only those resource classes dropped from
state. It is failure-driven rather than probe-driven: the destroy attempt uses
the provider's own credentials and endpoint resolution, so it cannot disagree
with a separate reachability check. Real resources in that same state -- the
aws_secretsmanager_* secrets, random_password -- do not match the declared
prefixes, are never dropped, and must still be deleted for the retry to pass. If
the failure had another cause the retry fails again and the original error
surfaces unchanged.

eks-prepare-destroy.sh now sweeps orphaned Karpenter nodes instead of printing
the command to do it by hand. That branch already predicted the exact failure
("their ENIs will block security-group deletion with DependencyViolation") and
then did nothing about it, so a c5.xlarge outlived its control plane, held a
Cilium ENI on two security groups, and killed the run with
`DependencyViolation`. `aws eks list-clusters` was already empty at that point:
a node with no control plane, still billing. The sweep waits on ENI DETACHMENT
rather than instance state, because they release asynchronously and a destroy
retried on instance state alone hits the same error.

scripts/teardown.sh is a supported entrypoint. It passes --continue-on-error,
which terramate has always had and nothing was using, and then VERIFIES AGAINST
THE CLOUD -- instances, clusters, NAT gateways, load balancers, VPCs, volumes --
because the exit code lied twice and the log had to be read to find out. It
exits non-zero if the destroy failed, if anything is still standing, or if a
cloud could not be checked at all; "I could not check" is tracked separately
from "I checked and found things", since reporting the first as the second is
the same conflation the rest of this change removes.

Not fixed, because it does not exist: #1964's second finding claimed a repo
wrapper swallowed terramate's exit code via a trailing `echo`. No script in this
repo runs `terramate script run --reverse destroy`; that bug was in throwaway
scratch scripts used during the incident. The issue is corrected rather than the
phantom fixed.

Verified:
  shellcheck -x -S warning on all three scripts -- exit 0
  tofu-destroy-contained.sh against a stub tofu -- destroy-succeeds leaves state
    untouched; destroy-fails-with-contained drops only the vault_* entries and
    retries; destroy-fails-with-none drops nothing and surfaces the original exit
  teardown.sh --verify-only against real AWS -- reports clean, exit 0
  teardown.sh --verify-only against GCP with expired auth -- refuses to report
    clean, names the reason, exit 1
  terramate list -- 14 stacks, parses
