### PR TITLE
chore(crossplane): bump the configuration package to v0.6.0

### DIFF
--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -219,7 +219,7 @@ spec:
         - clone
         - --depth=1
         - --single-branch
-        - --branch=v0.5.0
+        - --branch=v0.6.0
         - https://github.com/Smana/crossplane-configuration.git
         - /repo/crossplane-configuration
       securityContext:

--- a/infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml
@@ -12,4 +12,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-aws
 spec:
-  package: ghcr.io/smana/crossplane-configuration-aws:v0.5.0
+  package: ghcr.io/smana/crossplane-configuration-aws:v0.6.0

--- a/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
@@ -13,4 +13,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-gcp
 spec:
-  package: ghcr.io/smana/crossplane-configuration-gcp:v0.5.0
+  package: ghcr.io/smana/crossplane-configuration-gcp:v0.6.0


### PR DESCRIPTION
chore(crossplane): bump the configuration package to v0.6.0

Picks up the removal of the function dependsOn entries, which fixes #1971: the
packages no longer declare Composition functions, so they can no longer collide
with the Functions this repo pins in
infrastructure/base/crossplane/functions/.

That collision produced two Function resources for one package, and Crossplane
keys its dependency graph on package source -- two nodes with the same source
make the graph fail to initialise and every Configuration goes unhealthy. It is
a race, so it passed often enough to look fixed; it wedged a from-scratch
bootstrap on 2026-09-04 and took the whole platform with it, because no
Composition could run, so no EPI reconciled, so infrastructure never applied.

Minor rather than patch, upstream and here: the packages are no longer
self-contained. An adopter outside this repo must now install function-kcl,
function-auto-ready and function-environment-configs themselves. That costs this
repo nothing -- it already pins all three to EXACT versions, which is stricter
than the `>=` floors the packages declared -- but it is a real behaviour change
for anyone else and is documented in the package README.

Three pins move together, as always:

  infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml
  infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
  apps/platform/app-wizard/app.yaml   (clones the repo at this tag)

The wizard clone has no gate behind it; its comment requires checking
`git ls-tree <tag> apis/` whenever the tag moves. Checked: 52 files under apis/
at both v0.5.0 and v0.6.0, identical paths, no rename or addition.

./scripts/validate-manifests.sh: Valid: 2113, Invalid: 0, Skipped: 0
