### PR TITLE
fix(bootstrap): two blockers found by a from-scratch build — Cilium OOM and an external-dns webhook race

### DIFF
--- a/infrastructure/base/external-dns/helmrelease.yaml
+++ b/infrastructure/base/external-dns/helmrelease.yaml
@@ -4,6 +4,30 @@ metadata:
   name: external-dns
 spec:
   releaseName: external-dns
+  # Wait for the AWS Load Balancer Controller. This chart creates a Service, and
+  # any Service create is intercepted by the controller's MUTATING webhook
+  # (`mservice.elbv2.k8s.aws`). If the controller has no endpoints yet the API
+  # server cannot call it and the install fails outright:
+  #
+  #   server-side apply failed for object kube-system/external-dns Kind=Service:
+  #   failed calling webhook "mservice.elbv2.k8s.aws": no endpoints available
+  #   for service "aws-load-balancer-webhook-service"
+  #
+  # Measured 2026-09-04 on a from-scratch bootstrap: external-dns lost that race,
+  # burned all four Helm install retries before the controller finished starting,
+  # and went `Stalled=True RetriesExceeded`. Flux does not retry a stalled
+  # release, so it stayed failed permanently -- taking `infrastructure` with it,
+  # and with it `tooling`, `zitadel` and `apps`. ZITADEL never started, the
+  # OIDC registration timed out, and the platform came up with no identity
+  # provider. Recovering it needs `flux reconcile helmrelease external-dns
+  # --reset`, which nobody would guess from the symptom.
+  #
+  # dependsOn rather than more retries: retries make the race narrower, this
+  # makes it impossible. The controller is a hard prerequisite for creating any
+  # Service in this cluster, not merely something that is usually up first.
+  dependsOn:
+    - name: aws-load-balancer-controller
+      namespace: kube-system
   driftDetection:
     mode: enabled
   chart:

--- a/opentofu/aws/eks/init/helm_values/cilium.yaml
+++ b/opentofu/aws/eks/init/helm_values/cilium.yaml
@@ -66,10 +66,39 @@ prometheus:
   enabled: true
   serviceMonitor:
     enabled: false
+# The agent is OOM-KILLED at 256Mi on a cold start. Measured 2026-09-04 on a
+# from-scratch aws-0: both pods exitCode 137, one restart each, and the
+# DaemonSet only stabilised ~9 minutes into the rollout -- 40 seconds before
+# the recycle job's 10-minute wait expired, which failed the whole bootstrap.
+#
+# 256Mi is simply too small for what this agent is configured to do. It runs ENI
+# IPAM with prefix delegation (a large ipcache, and a per-node CRD it keeps in
+# sync), WireGuard encryption, kube-proxy replacement, and the Gateway API L7
+# proxy. Startup is the peak: the agent builds its BPF maps and reconciles the
+# full endpoint and identity state before it reports ready, so the ceiling has
+# to cover the spike, not the steady state.
+#
+# 512Mi is 2x the value that demonstrably failed, not a number chosen for
+# comfort. The measured evidence is only that 256Mi is too small -- how far the
+# agent overshot is unknown, because the metrics API was not available on the
+# cluster where this was found. So this is the smallest principled step: if the
+# agent OOMs again, raise it with a measurement rather than a guess.
+#
+# This is a LIMIT, not a request, and the agent is a DaemonSet -- so it applies
+# on every node but reserves nothing. Requests are deliberately left unset:
+# steady-state usage is far below the startup peak, and reserving the peak on
+# every node would cost real schedulable capacity to guard a transient.
+#
+# WHY THIS WENT UNNOTICED FOR SO LONG: the OOM kills were always happening, but
+# scripts/eks-recycle-bootstrap-nodes.sh used to read Cilium's ConfigMap BEFORE
+# waiting for Cilium, found the key unset, and exited 0. The wait never ran, so
+# a slow, crash-looping rollout looked like a healthy one and the damage
+# surfaced an hour later as IP exhaustion in an unrelated component. Fixing that
+# ordering (#1972) is what made this visible.
 resources:
   limits:
     cpu: 300m
-    memory: 256Mi
+    memory: 512Mi
 routingMode: native
 # Note: tunnelProtocol defaults to vxlan in Helm chart but is ignored in native routing mode.
 # ENI mode uses direct routing, no tunnel encapsulation is used regardless of this setting.


### PR DESCRIPTION
Two independent bootstrap blockers, both found by running a from-scratch build
rather than by review. Each one stopped the platform dead, and neither was
visible in any gate.

## 1. The Cilium agent is OOM-killed at 256Mi

Measured on a from-scratch `aws-0`: both agent pods `exitCode 137`, one restart
each, and the DaemonSet only stabilised about nine minutes into the rollout —
40 seconds before the recycle job's 10-minute wait expired, which failed the
whole deploy.

256Mi is too small for what this agent is configured to do: ENI IPAM with prefix
delegation (a large ipcache plus a per-node CRD kept in sync), WireGuard
encryption, kube-proxy replacement, and the Gateway API L7 proxy. Startup is the
peak — it builds its BPF maps and reconciles full endpoint and identity state
before reporting ready — so the ceiling has to cover the spike, not the steady
state.

**512Mi is 2× the value that demonstrably failed, not a number chosen for
comfort.** The only measurement available is that 256Mi is too small; how far
the agent overshot is unknown, because the metrics API was not up on the cluster
where this surfaced. If it OOMs again, raise it from a measurement.

It is a **limit, not a request**, on a DaemonSet — it applies on every node but
reserves nothing. Requests stay unset deliberately: reserving a startup peak on
every node would cost real schedulable capacity to guard a transient.

**Why this hid for so long.** The OOM kills were always happening.
`eks-recycle-bootstrap-nodes.sh` used to read Cilium's ConfigMap *before*
waiting for Cilium, find the key unset, and exit 0 — so the wait never ran, a
crash-looping rollout was indistinguishable from a healthy one, and the damage
surfaced an hour later as IP exhaustion in an unrelated component. Fixing that
ordering (#1972) is what made this visible: the first bootstrap afterwards
failed loudly here instead of silently later.

Confirmed fixed on a fresh build — `Cilium is ready`, no OOM, and the recycle
then ran inside a bootstrap for the first time: `prefixes=1 ✅`, `prefixes=3 ✅`.

## 2. external-dns loses a webhook race and stalls permanently

external-dns creates a `Service`, and every Service create is intercepted by the
AWS Load Balancer Controller's **mutating** webhook. When the controller has no
endpoints yet, the API server cannot call it and the install fails outright:

```
server-side apply failed for object kube-system/external-dns Kind=Service:
failed calling webhook "mservice.elbv2.k8s.aws": no endpoints available
for service "aws-load-balancer-webhook-service"
```

On a from-scratch build external-dns lost that race, burned all four Helm
install retries before the controller finished starting, and went
`Stalled=True RetriesExceeded`. **Flux does not retry a stalled release**, so it
stayed failed permanently — taking `infrastructure` with it, and with it
`tooling`, `zitadel` and `apps`. ZITADEL never started, stage 4's OIDC
registration timed out after 45 minutes, and the platform came up with no
identity provider.

The symptom names a webhook in `kube-system`; the cause is an ordering race four
Kustomizations away; and recovery needs `flux reconcile helmrelease external-dns
--reset`, because a stalled release ignores ordinary reconciliation. Nobody
would derive that from the symptom.

`dependsOn` rather than more retries: **retries make the race narrower, this
makes it impossible.** The controller is a hard prerequisite for creating any
Service in this cluster, not merely something that is usually up first.

## Verification

Both fixes were exercised on a real from-scratch bootstrap, not reasoned about:

- `Cilium is ready` — wait passed rather than timing out
- recycle ran and converted both nodes: `prefixes=1 ✅`, `prefixes=3 ✅`
- all three CNPG clusters healthy on fresh per-generation prefixes
  (`...-f836dc3c`, `...-d38f92c1`, `...-04ffbd74`), harbor coming up against 43
  untouched leftover objects in its old prefix
- ZITADEL restored from `zitadel-20260904`; OIDC registration reported
  `created: 0, updated: 0, unchanged: 5`

`./scripts/validate-manifests.sh`: `Valid: 2113, Invalid: 0, Skipped: 0`.

## Honest status

The bootstrap that found these still needed **one** manual intervention — the
`--reset` above — before the platform came up. That cause is fixed here, but
this PR has not itself been proven by a zero-intervention run. That takes
another from-scratch build.
