### PR TITLE
fix(teardown): sweep what the controllers created, then retry

### DIFF
--- a/scripts/aws-sweep-controller-orphans.sh
+++ b/scripts/aws-sweep-controller-orphans.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Sweep AWS resources created by IN-CLUSTER CONTROLLERS, which `tofu destroy`
+# cannot see and therefore cannot remove.
+#
+# WHY THIS EXISTS
+#
+# OpenTofu owns what OpenTofu created. It does not own the load balancer the
+# aws-load-balancer-controller created from a Gateway, the EC2 instance Karpenter
+# launched, the security group EKS attached, or the EBS volume the CSI driver
+# provisioned for a PVC. When the cluster is destroyed first -- which is the
+# order a teardown must use -- those resources are orphaned, and they hold ENIs
+# and subnets that block the network stack. `DependencyViolation` and
+# `HostedZoneNotEmpty` are what that looks like from the outside, and neither
+# names the controller that is actually responsible.
+#
+# Measured 2026-09-04 on a fully-reconciled aws-0. One teardown, five separate
+# orphan classes, five manual interventions:
+#
+#   2 Gateway API network load balancers   (aws-load-balancer-controller)
+#   2 Kubernetes nodes with no cluster     (Karpenter)
+#   30 Route53 records                     (ExternalDNS)
+#   5 security groups                      (EKS / controllers)
+#   2 EBS volumes                          (EBS CSI driver)
+#
+# The same teardown against a HALF-BUILT cluster had been clean first time,
+# because far fewer controller-created resources existed. The failure scales with
+# how completely the platform reconciled, which is the opposite of reassuring.
+#
+# WHY NOT IN eks-prepare-destroy.sh
+#
+# Three sweeps already existed and are wired as jobs inside eks/init's destroy.
+# That works only when the teardown succeeds on the first attempt. If it fails
+# partway, eks/init is already destroyed -- so the cleanup written for exactly
+# this situation can never run again, and every retry fails on leftovers that a
+# sweep would have handled. This script is callable independently, from
+# teardown.sh, keyed on what is actually in the cloud.
+#
+# SAFETY
+#
+# Refuses to run while the EKS cluster still exists. An orphan is only an orphan
+# once the thing that managed it is gone; before that, deleting a load balancer
+# or an instance would be destroying live infrastructure.
+#
+# Everything is scoped to the cluster's own VPC (`vpc-<region>-<env>`, matching
+# opentofu/aws/network/network.tf), discovered by tag rather than assumed. It
+# never touches the default VPC or its default security group.
+#
+# Dry-run unless --apply.
+#
+# Usage:
+#   aws-sweep-controller-orphans.sh --cluster-name aws-0 --region eu-west-3 [--vpc-id V] [--apply]
+set -o nounset
+set -o pipefail
+
+CLUSTER_NAME=""; REGION="${AWS_REGION:-}"; PROFILE=""; VPC_ID=""; APPLY="false"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --cluster-name) CLUSTER_NAME="$2"; shift 2 ;;
+        --region)       REGION="$2"; shift 2 ;;
+        --profile)      PROFILE="$2"; shift 2 ;;
+        --vpc-id)       VPC_ID="$2"; shift 2 ;;
+        --apply)        APPLY="true"; shift ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+[ -n "$CLUSTER_NAME" ] || { echo "--cluster-name is required" >&2; exit 2; }
+[ -n "$REGION" ] || { echo "--region is required (or set AWS_REGION)" >&2; exit 2; }
+
+AWS="aws --region ${REGION}"
+[ -n "$PROFILE" ] && AWS="${AWS} --profile ${PROFILE}"
+
+say() { if [ "$APPLY" = "true" ]; then echo "  [delete ] $*"; else echo "  [dry-run] would delete $*"; fi; }
+SWEPT=0
+
+# ---- refuse while the cluster is alive -------------------------------------
+if $AWS eks describe-cluster --name "$CLUSTER_NAME" >/dev/null 2>&1; then
+    echo "EKS cluster ${CLUSTER_NAME} still EXISTS." >&2
+    echo "Refusing to sweep: these resources are only orphans once their controllers are gone." >&2
+    exit 1
+fi
+echo "==> EKS cluster ${CLUSTER_NAME} is gone; its controllers cannot be managing anything."
+
+# ---- find the VPC -----------------------------------------------------------
+if [ -z "$VPC_ID" ]; then
+    VPC_ID="$($AWS ec2 describe-vpcs \
+        --filters "Name=tag:Name,Values=vpc-${REGION}-*" "Name=isDefault,Values=false" \
+        --query 'Vpcs[0].VpcId' --output text 2>/dev/null)"
+fi
+if [ -z "$VPC_ID" ] || [ "$VPC_ID" = "None" ]; then
+    echo "==> no non-default VPC found — nothing to sweep."
+    exit 0
+fi
+echo "==> scoping to ${VPC_ID}"
+
+# ---- 1. load balancers (aws-load-balancer-controller) -----------------------
+# First, because their ENIs hold the subnets everything else needs freed.
+echo
+echo "== Load balancers created from Gateway/Ingress resources"
+for arn in $($AWS elbv2 describe-load-balancers \
+        --query "LoadBalancers[?VpcId=='${VPC_ID}'].LoadBalancerArn" --output text 2>/dev/null); do
+    name="${arn##*/}"; name="${arn#*loadbalancer/}"; name="${name%/*}"
+    say "load balancer ${name}"
+    SWEPT=$((SWEPT + 1))
+    [ "$APPLY" = "true" ] && $AWS elbv2 delete-load-balancer --load-balancer-arn "$arn" >/dev/null 2>&1
+done
+
+# ---- 2. instances (Karpenter, or node groups whose cluster is gone) ---------
+echo
+echo "== EC2 instances with no cluster behind them"
+orphans="$($AWS ec2 describe-instances \
+    --filters "Name=vpc-id,Values=${VPC_ID}" \
+              "Name=instance-state-name,Values=running,pending,stopping,stopped" \
+    --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null)"
+if [ -n "$orphans" ]; then
+    for id in $orphans; do say "instance ${id}"; SWEPT=$((SWEPT + 1)); done
+    if [ "$APPLY" = "true" ]; then
+        # shellcheck disable=SC2086 # deliberate word splitting: takes a list
+        $AWS ec2 terminate-instances --instance-ids $orphans >/dev/null 2>&1
+    fi
+fi
+
+# ---- wait for ENIs, not for instance state ---------------------------------
+# They detach asynchronously. A destroy retried on instance state alone hits the
+# same DependencyViolation -- measured twice on 2026-09-03/04.
+if [ "$APPLY" = "true" ]; then
+    echo
+    echo "== waiting for ENIs to release from ${VPC_ID} (up to 300s)"
+    for _ in $(seq 1 30); do
+        n="$($AWS ec2 describe-network-interfaces --filters "Name=vpc-id,Values=${VPC_ID}" \
+             --query 'length(NetworkInterfaces)' --output text 2>/dev/null || echo 0)"
+        echo "   ENIs remaining: ${n}"
+        [ "${n:-0}" = "0" ] && break
+        sleep 10
+    done
+fi
+
+# ---- 3. security groups ----------------------------------------------------
+# Last: they can only go once nothing references them. Several passes because
+# groups reference each other and a single ordering can fail on that alone.
+echo
+echo "== non-default security groups"
+for pass in 1 2 3 4; do
+    ids="$($AWS ec2 describe-security-groups --filters "Name=vpc-id,Values=${VPC_ID}" \
+           --query 'SecurityGroups[?GroupName!=`default`].GroupId' --output text 2>/dev/null)"
+    [ -z "$ids" ] && break
+    if [ "$APPLY" != "true" ]; then
+        for id in $ids; do say "security group ${id}"; SWEPT=$((SWEPT + 1)); done
+        break
+    fi
+    for id in $ids; do
+        if $AWS ec2 delete-security-group --group-id "$id" >/dev/null 2>&1; then
+            echo "  [delete ] security group ${id} (pass ${pass})"
+            SWEPT=$((SWEPT + 1))
+        fi
+    done
+    left="$($AWS ec2 describe-security-groups --filters "Name=vpc-id,Values=${VPC_ID}" \
+            --query 'SecurityGroups[?GroupName!=`default`].GroupId' --output text 2>/dev/null)"
+    [ "$ids" = "$left" ] && { echo "  [warn   ] no progress; still held: ${left}"; break; }
+done
+
+echo
+if [ "$APPLY" = "true" ]; then
+    echo "==> swept ${SWEPT} controller-created resource(s)."
+else
+    echo "==> dry-run: ${SWEPT} item(s) would be swept. Re-run with --apply."
+fi

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -57,6 +57,51 @@ if [ "$VERIFY_ONLY" -eq 0 ]; then
   destroy_rc=$?
   echo "=== terramate exit: ${destroy_rc} ==="
   echo
+
+  # SWEEP AND RETRY, because tofu cannot remove what it did not create.
+  #
+  # A destroy that fails almost always fails on resources an IN-CLUSTER
+  # CONTROLLER created: a load balancer from a Gateway, a Karpenter instance, an
+  # ExternalDNS record, an EKS security group, a CSI volume. OpenTofu has no
+  # state for any of them, so it cannot delete them -- it just hits
+  # DependencyViolation or HostedZoneNotEmpty on whatever they are holding.
+  #
+  # Sweeps for three of these already existed, but were wired as jobs INSIDE
+  # eks/init's destroy. That works only if the teardown succeeds first time: once
+  # eks/init is destroyed, the cleanup written for exactly this situation can
+  # never run again, and every retry fails on leftovers a sweep would have
+  # handled.
+  #
+  # Measured 2026-09-04 on a fully-reconciled aws-0: five attempts, five manual
+  # interventions, five different orphan classes. The same teardown against a
+  # half-built cluster had been clean first time -- the failure scales with how
+  # completely the platform reconciled.
+  #
+  # So: if the cloud is not clean after the destroy, sweep what the controllers
+  # left and destroy once more. Sweeping runs only when the EKS cluster is
+  # already gone (the sweeps enforce that themselves), so this cannot touch live
+  # infrastructure.
+  if wants aws; then
+    _region="${AWS_REGION:-eu-west-3}"
+    _left="$(aws ec2 describe-vpcs --region "$_region" \
+      --query 'Vpcs[?IsDefault==`false`].VpcId' --output text 2>/dev/null)"
+    if [ -n "${_left//[[:space:]]/}" ]; then
+      echo "=== destroy left resources behind — sweeping controller-created orphans ==="
+      bash "${ROOT}/scripts/aws-sweep-teardown-blockers.sh" \
+        --cluster-name "${EKS_CLUSTER_NAME:-aws-0}" --region "$_region" --apply || true
+      bash "${ROOT}/scripts/aws-sweep-controller-orphans.sh" \
+        --cluster-name "${EKS_CLUSTER_NAME:-aws-0}" --region "$_region" --apply || true
+      bash "${ROOT}/scripts/aws-sweep-orphaned-volumes.sh" \
+        --cluster-name "${EKS_CLUSTER_NAME:-aws-0}" --region "$_region" --apply || true
+
+      echo
+      echo "=== retrying the destroy after the sweep ==="
+      ( cd "${ROOT}/opentofu" && terramate script run --reverse --continue-on-error destroy )
+      destroy_rc=$?
+      echo "=== terramate exit after retry: ${destroy_rc} ==="
+      echo
+    fi
+  fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
fix(teardown): sweep what the controllers created, then retry

`tofu destroy` owns what OpenTofu created. It does not own the load balancer the
aws-load-balancer-controller made from a Gateway, the instance Karpenter
launched, the Route53 record ExternalDNS wrote, the security group EKS attached,
or the EBS volume the CSI driver provisioned. The cluster has to be destroyed
before the network, so all of those become orphans -- and they hold the ENIs and
subnets the network stack needs freed. What surfaces is DependencyViolation or
HostedZoneNotEmpty, neither of which names the controller responsible.

Measured 2026-09-04 tearing down a fully-reconciled aws-0. FIVE attempts, five
manual interventions, five orphan classes:

  2 Gateway API network load balancers   aws-load-balancer-controller
  2 Kubernetes nodes with no cluster     Karpenter
  30 Route53 records                     ExternalDNS
  5 security groups                      EKS / controllers
  2 EBS volumes                          EBS CSI driver

The same teardown against a HALF-BUILT cluster had been clean on the first
attempt. The failure scales with how completely the platform reconciled, which
is the opposite of reassuring: the better the bootstrap works, the worse the
teardown behaves.

WHY THE EXISTING SWEEPS DID NOT HELP

Three of these already had sweeps -- and all three are wired as jobs inside
eks/init's destroy. That works when the teardown succeeds first time. It is
exactly wrong when it does not: eks/init is destroyed early in the reverse walk,
so by the time you retry, the cleanup written for this situation is unreachable.
Every retry then fails on leftovers a sweep would have handled, and the operator
has to know those scripts exist and run them by hand. That is what happened five
times tonight.

WHAT CHANGES

scripts/aws-sweep-controller-orphans.sh is new: load balancers, then instances,
then (after waiting for ENIs to detach) non-default security groups, in that
order because each holds the next. Multiple passes on the security groups, since
they reference each other and one ordering can fail on that alone.

teardown.sh now checks whether a non-default VPC survived the destroy, and if so
sweeps -- blockers, controller orphans, volumes -- and destroys once more. This
makes teardown IDEMPOTENT: safe to re-run from any partial state, which is the
property it needed and did not have. #1970 fixed the halting problem; this fixes
recovery.

SAFETY

The sweeps refuse to run while the EKS cluster still exists: a resource is only
an orphan once the thing managing it is gone. Everything is scoped to the
cluster's own VPC, discovered by tag (vpc-<region>-<env>, matching
opentofu/aws/network/network.tf), never the default VPC or its default security
group. Dry-run unless --apply.

Verified: shellcheck -x -S warning clean on both scripts; the new sweep dry-runs
correctly against an empty account ("EKS cluster aws-0 is gone" then "no
non-default VPC found -- nothing to sweep"); teardown.sh --verify-only still
exits 0 against the now-clean cloud.

Not yet verified: the sweep-and-retry path itself, which needs a teardown that
actually fails. The next one will exercise it.
