### PR TITLE
fix(observability): pin victorialogs-datasource to a version that exists

### DIFF
--- a/observability/base/victoria-metrics-k8s-stack/vm-common-helm-values-configmap.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vm-common-helm-values-configmap.yaml
@@ -215,8 +215,22 @@ data:
         # path and the real plugin installs UNPINNED. Use "<id>@<version>".
         # renovate: datasource=github-releases depName=VictoriaMetrics/victoriametrics-datasource extractVersion=^v(?<version>.+)$
         - "victoriametrics-metrics-datasource@0.25.2"
+        # These pins are tracked from GITHUB RELEASES but installed from the
+        # GRAFANA.COM CATALOG, and the two publish independently -- a tag can
+        # exist on GitHub days before (or without ever) reaching the catalog.
+        # Renovate has no catalog datasource, so it cannot see the difference.
+        #
+        # 0.32.0 was merged that way (#1959) and the catalog did not have it:
+        #   failed to install plugin victoriametrics-logs-datasource@0.32.0:
+        #   [plugin.versionNotFound] ... was not returned by the Grafana.com catalog
+        # Grafana then refuses to start at all -- the plugin installer is a
+        # startup module, so this is CrashLoopBackOff rather than a missing
+        # datasource, and it takes observability -> tooling -> apps down with it.
+        #
+        # Before accepting a bump here, check the version is actually published:
+        #   curl -s https://grafana.com/api/plugins/<plugin-id>/versions | jq -r '.items[].version'
         # renovate: datasource=github-releases depName=VictoriaMetrics/victorialogs-datasource extractVersion=^v(?<version>.+)$
-        - "victoriametrics-logs-datasource@0.32.0"
+        - "victoriametrics-logs-datasource@0.31.0"
         - "marcusolsson-dynamictext-panel"
       "grafana.ini":
         feature_toggles:


### PR DESCRIPTION
## In one line

**`main` currently installs a Grafana plugin version that does not exist, and Grafana refuses to start rather than starting without it.** Pinned back to the newest version the Grafana.com catalog actually publishes.

## The failure

`victoriametrics-logs-datasource@0.32.0` has never been published to the catalog Grafana installs from:

```console
$ curl -s https://grafana.com/api/plugins/victoriametrics-logs-datasource/versions \
    | jq -r '.items[].version' | head -3
0.31.0
0.30.1
0.29.0
```

The plugin installer is a **startup module**, so a missing version is not a missing datasource — it is `CrashLoopBackOff`:

```
failed to install plugin victoriametrics-logs-datasource@0.32.0:
[plugin.versionNotFound] ... was not returned by the Grafana.com catalog
```

Grafana is a dependency of `observability`, which `tooling` and `apps` depend on, so the whole tail of the Flux graph stops with it.

## Why it merged green

Not a bad version — a **datasource mismatch**. These pins are:

| | |
|---|---|
| **tracked** from | GitHub releases (`renovate: datasource=github-releases`) |
| **installed** from | the Grafana.com catalog |

Those publish independently: a tag can exist on GitHub days before it reaches the catalog, or never reach it. Renovate has no catalog datasource, so it cannot see the difference — #1959 was correct about the GitHub tag and wrong about installability, and nothing in CI renders a Grafana that tries to start.

## The fix

Pin to `0.31.0`, and record the one-line check at the point where somebody will next be asked to accept a bump:

```bash
curl -s https://grafana.com/api/plugins/<plugin-id>/versions | jq -r '.items[].version'
```

Renovate will re-propose `0.32.0` as soon as it is tagged. The comment is what makes that reviewable rather than automatic — it will be right eventually, just not necessarily on the day it is proposed.

## Recovering a cluster already in this state

Worth writing down, because the crashloop blocks the obvious route and this cost a debugging cycle:

1. Pin the version (this PR).
2. `helm uninstall --no-hooks` — a plain uninstall stalls on a cleanup-hook Job whose generated name exceeds the 63-character limit.
3. Strip the VictoriaMetrics finalizers, or the namespace will not settle.

## Provenance

Found while deploying a feature branch on 2026-09-05. The same fix is on that branch, but it is carried here on its own so a one-line correction to `main` is not gated behind a large PR's review.

## Test Plan

| Check | Result |
|---|---|
| `./scripts/validate-manifests.sh` | **exit 0** — `2113 resources found in 276 files - Valid: 2113, Invalid: 0, Skipped: 0`, both gates passed |
| Catalog check for the pinned version | `0.31.0` present, `0.32.0` absent (command above) |

Not deployed to a live cluster from this branch — the platform was torn down after the session that found it. The failing state was observed live on 2026-09-05, and the fix was applied there and confirmed to recover Grafana.
