### PR TITLE
fix(bootstrap): terraform and Flux both owned flux-operator, and could not

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -181,15 +181,6 @@
         "line_number": 11
       }
     ],
-    "opentofu/aws/openbao/management/variables.tfvars": [
-      {
-        "type": "Secret Keyword",
-        "filename": "opentofu/aws/openbao/management/variables.tfvars",
-        "hashed_secret": "6b3c30169f984dc4950c87bf87730518db25da78",
-        "is_verified": false,
-        "line_number": 5
-      }
-    ],
     "opentofu/config.tm.hcl": [
       {
         "type": "Secret Keyword",
@@ -291,5 +282,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-05T12:09:57Z"
+  "generated_at": "2026-09-08T10:50:06Z"
 }

--- a/opentofu/aws/eks/configure/main.tf
+++ b/opentofu/aws/eks/configure/main.tf
@@ -124,7 +124,29 @@ resource "kubectl_manifest" "disable_kube_proxy" {
 # =============================================================================
 # Step 5: Install Flux Operator
 # =============================================================================
+
+# Is flux-operator already installed? See the lifecycle comment on the resource
+# below, and scripts/helm-release-present.sh, for why terraform stops tracking
+# this release and why that makes the check necessary.
+#
+# Never fails: an unreachable cluster answers "false", terraform attempts the
+# create, and helm reports any genuine conflict itself.
+data "external" "flux_operator_release" {
+  program = ["bash", "${path.module}/../../../../scripts/helm-release-present.sh"]
+
+  query = {
+    name      = "flux-operator"
+    namespace = "flux-system"
+  }
+}
+
 resource "helm_release" "flux_operator" {
+  # Bootstrap only. Zero when Flux already has the release -- which is every
+  # deploy after the first, because the workflow drops it from state once the
+  # FluxInstance is Ready. This can never destroy the operator: terraform has
+  # already forgotten it, so count=0 has nothing in state to remove.
+  count = data.external.flux_operator_release.result.present == "true" ? 0 : 1
+
   depends_on = [
     kubectl_manifest.disable_kube_proxy,
     kubectl_manifest.flux_system_namespace, # flux-system namespace must exist first
@@ -151,6 +173,23 @@ resource "helm_release" "flux_operator" {
   # purpose (see the comment there).
   atomic          = true
   cleanup_on_fail = true
+
+  # Terraform BOOTSTRAPS this release; Flux owns it from the first reconcile.
+  #
+  # flux/operator/helmrelease.yaml re-manages the same Helm release, adding the
+  # Web UI and its OIDC configuration -- none of which is declared here. Without
+  # this, every apply reads Flux's values as drift and tries to revert them, and
+  # an apply that lands mid-upgrade fails with "release: already exists" (hit on
+  # 2026-09-08: revisions 23-27 inside 25 minutes).
+  #
+  # The version is Flux's too. `var.flux_operator_version` is the bootstrap
+  # version only; flux/sources/ocirepo-flux-operator.yaml floats
+  # `>=0.43.0 <1.0.0`, so bumping the global will NOT move a running cluster --
+  # and without this block it would try to downgrade one.
+  lifecycle {
+    ignore_changes = all
+  }
+
 }
 
 # =============================================================================

--- a/opentofu/aws/eks/configure/versions.tf
+++ b/opentofu/aws/eks/configure/versions.tf
@@ -2,6 +2,13 @@ terraform {
   required_version = ">= 1.5"
 
   required_providers {
+    # The flux-operator bootstrap guard in main.tf shells out through
+    # scripts/helm-release-present.sh to ask whether Flux already owns the
+    # release.
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3"
+    }
     aws = {
       source  = "hashicorp/aws"
       version = "~> 6.0"

--- a/opentofu/aws/eks/configure/workflows.tm.hcl
+++ b/opentofu/aws/eks/configure/workflows.tm.hcl
@@ -58,6 +58,21 @@ script "deploy" {
         "-var=gateway_api_version=${global.gateway_api_version}",
         "-var=flux_operator_version=${global.flux_operator_version}",
       "-var=flux_instance_version=${global.flux_instance_version}"],
+      # Hand flux-operator to Flux. Terraform bootstrapped the release; from
+      # the first reconcile flux/operator/helmrelease.yaml owns it, adding the
+      # Web UI and its OIDC configuration and tracking the floating version in
+      # flux/sources/ocirepo-flux-operator.yaml.
+      #
+      # Terraform must forget it, or every later plan fails in the READ: Flux
+      # upgrades the release to flux-operator-0.59.0+ae962f87e043, the provider
+      # writes that into its own `version`, and no plan can resolve it again --
+      # `+` is not legal in an OCI tag. Hit on 2026-09-08, after 29 revisions of
+      # the two owners overwriting each other.
+      #
+      # Idempotent: a no-op once the resource is already out of state.
+      ["bash", "${terramate.root.path.fs.absolute}/scripts/tm-provisioner.sh", "--tm-run", "bash", "-c",
+      "tofu state rm helm_release.flux_operator 2>/dev/null || true"],
+
     ]
   }
 }

--- a/opentofu/aws/openbao/management/secrets.tf
+++ b/opentofu/aws/openbao/management/secrets.tf
@@ -32,6 +32,7 @@ resource "aws_secretsmanager_secret" "admin_credentials" {
   #checkov:skip=CKV2_AWS_57:Rotation happens by re-running this stack, which generates a fresh password. A Secrets Manager rotation Lambda cannot rotate an OpenBao userpass credential - it has no way to talk to OpenBao.
   name                    = var.admin_credentials_secret_name
   recovery_window_in_days = 0
+  tags                    = var.tags
 }
 
 resource "aws_secretsmanager_secret_version" "admin_credentials" {

--- a/opentofu/aws/openbao/management/variables.tf
+++ b/opentofu/aws/openbao/management/variables.tf
@@ -154,3 +154,9 @@ variable "openbao_oidc_issuer" {
   type        = string
   default     = ""
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/opentofu/aws/openbao/management/variables.tfvars
+++ b/opentofu/aws/openbao/management/variables.tfvars
@@ -1,10 +1,9 @@
-region                           = "eu-west-3"
-openbao_root_token_secret_id     = "openbao/cloud-native-ref/tokens/root"
-domain_name                      = "priv.aws.ogenki.io"
-intermediate_ca_secret_name      = "certificates/priv.aws.ogenki.io/intermediate-ca" # pragma: allowlist secret
-openbao_certificates_secret_name = "certificates/priv.aws.ogenki.io/openbao"
-pki_country                      = "France"
-pki_organization                 = "Ogenki"
+region                       = "eu-west-3"
+openbao_root_token_secret_id = "openbao/cloud-native-ref/tokens/root"
+domain_name                  = "priv.aws.ogenki.io"
+intermediate_ca_secret_name  = "certificates/priv.aws.ogenki.io/intermediate-ca" # pragma: allowlist secret
+pki_country                  = "France"
+pki_organization             = "Ogenki"
 # Both private domains: the active OpenBao issues for both clusters (design,
 # "PKI"), so a gcp-0 Certificate signed here must be allowed. cluster.local
 # covers in-cluster Service names.

--- a/opentofu/gcp/gke/configure/main.tf
+++ b/opentofu/gcp/gke/configure/main.tf
@@ -57,7 +57,29 @@ resource "helm_release" "cilium" {
   timeout = 600
 }
 
+
+# Is flux-operator already installed? See the lifecycle comment on the resource
+# below, and scripts/helm-release-present.sh, for why terraform stops tracking
+# this release and why that makes the check necessary.
+#
+# Never fails: an unreachable cluster answers "false", terraform attempts the
+# create, and helm reports any genuine conflict itself.
+data "external" "flux_operator_release" {
+  program = ["bash", "${path.module}/../../../../scripts/helm-release-present.sh"]
+
+  query = {
+    name      = "flux-operator"
+    namespace = "flux-system"
+  }
+}
+
 resource "helm_release" "flux_operator" {
+  # Bootstrap only. Zero when Flux already has the release -- which is every
+  # deploy after the first, because the workflow drops it from state once the
+  # FluxInstance is Ready. This can never destroy the operator: terraform has
+  # already forgotten it, so count=0 has nothing in state to remove.
+  count = data.external.flux_operator_release.result.present == "true" ? 0 : 1
+
   depends_on = [
     helm_release.cilium,
     kubectl_manifest.flux_system_namespace,
@@ -81,6 +103,23 @@ resource "helm_release" "flux_operator" {
   # do NOT copy it to helm_release.cilium, which sets wait=false on purpose.
   atomic          = true
   cleanup_on_fail = true
+
+  # Terraform BOOTSTRAPS this release; Flux owns it from the first reconcile.
+  #
+  # flux/operator/helmrelease.yaml re-manages the same Helm release, adding the
+  # Web UI and its OIDC configuration -- none of which is declared here. Without
+  # this, every apply reads Flux's values as drift and tries to revert them, and
+  # an apply that lands mid-upgrade fails with "release: already exists" (hit on
+  # 2026-09-08: revisions 23-27 inside 25 minutes).
+  #
+  # The version is Flux's too. `var.flux_operator_version` is the bootstrap
+  # version only; flux/sources/ocirepo-flux-operator.yaml floats
+  # `>=0.43.0 <1.0.0`, so bumping the global will NOT move a running cluster --
+  # and without this block it would try to downgrade one.
+  lifecycle {
+    ignore_changes = all
+  }
+
 }
 
 resource "helm_release" "flux_instance" {

--- a/opentofu/gcp/gke/configure/versions.tf
+++ b/opentofu/gcp/gke/configure/versions.tf
@@ -2,6 +2,13 @@ terraform {
   required_version = "~> 1.5"
 
   required_providers {
+    # The flux-operator bootstrap guard in main.tf shells out through
+    # scripts/helm-release-present.sh to ask whether Flux already owns the
+    # release.
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3"
+    }
     google = {
       source  = "hashicorp/google"
       version = "~> 7.17"

--- a/opentofu/gcp/gke/configure/workflows.tm.hcl
+++ b/opentofu/gcp/gke/configure/workflows.tm.hcl
@@ -70,6 +70,21 @@ script "deploy" {
         ${global.provisioner} apply -auto-approve -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='gateway_api_version=${global.gateway_api_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}' -var='deploy_identity_provider=${global.deploy_identity_provider_gcp}'
       BASH
       ],
+      # Hand flux-operator to Flux. Terraform bootstrapped the release; from
+      # the first reconcile flux/operator/helmrelease.yaml owns it, adding the
+      # Web UI and its OIDC configuration and tracking the floating version in
+      # flux/sources/ocirepo-flux-operator.yaml.
+      #
+      # Terraform must forget it, or every later plan fails in the READ: Flux
+      # upgrades the release to flux-operator-0.59.0+ae962f87e043, the provider
+      # writes that into its own `version`, and no plan can resolve it again --
+      # `+` is not legal in an OCI tag. Hit on 2026-09-08, after 29 revisions of
+      # the two owners overwriting each other.
+      #
+      # Idempotent: a no-op once the resource is already out of state.
+      ["bash", "${terramate.root.path.fs.absolute}/scripts/tm-provisioner.sh", "--tm-run", "bash", "-c",
+      "tofu state rm helm_release.flux_operator 2>/dev/null || true"],
+
     ]
   }
 }

--- a/scripts/helm-release-present.sh
+++ b/scripts/helm-release-present.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# helm-release-present.sh — a `data "external"` helper: is a Helm release installed?
+#
+# Reads {"name": "...", "namespace": "..."} on stdin, prints {"present":"true"}
+# or {"present":"false"}.
+#
+# Why this exists: terraform BOOTSTRAPS flux-operator on a bare cluster and then
+# hands the release to Flux, which re-manages it from flux/operator/. Terraform
+# drops it from state at the end of the deploy (see the eks/configure and
+# gke/configure workflows), because the two owners cannot share it -- Flux
+# upgrades the release to a chart whose version carries build metadata
+# (0.59.0+ae962f87e043), terraform's provider writes that string back into its
+# own `version` attribute, and no later plan can resolve it: `+` is not legal in
+# an OCI tag. Every apply then dies in the read, before any diff.
+#
+# Once terraform has forgotten the release, a deploy against a LIVE cluster would
+# try to create it again and hit "cannot re-use a name that is still in use".
+# This check is what makes that a no-op instead.
+#
+# It NEVER fails. A broken kubeconfig, a missing helm, an unreachable API server
+# -- all answer "false", which makes terraform attempt the create and lets helm
+# itself report a real conflict with a real message. Failing here would block a
+# plan on a diagnostic, which is the wrong place to learn about it.
+set -uo pipefail
+
+# `cat`, not `read`: terraform sends the query JSON with NO trailing newline,
+# so `read` returns non-zero at EOF even though it populated the variable --
+# and any `|| default` then throws the real input away. Manual tests with
+# `echo` pass, because echo adds the newline. Cost an hour on 2026-09-08.
+input=$(cat)
+
+name=$(printf '%s' "$input" | jq -r '.name // empty' 2>/dev/null)
+namespace=$(printf '%s' "$input" | jq -r '.namespace // empty' 2>/dev/null)
+
+if [ -z "$name" ] || [ -z "$namespace" ]; then
+    printf '{"present":"false"}\n'
+    exit 0
+fi
+
+if command -v helm >/dev/null 2>&1 && helm status "$name" -n "$namespace" >/dev/null 2>&1; then
+    printf '{"present":"true"}\n'
+else
+    printf '{"present":"false"}\n'
+fi


### PR DESCRIPTION
The 2026-09-08 deploy exited **1** at `eks/configure` with `Upgrade failed: release: already exists` — on a cluster that was otherwise completely healthy (FluxInstance `Ready`, every Kustomization `Ready` except the deliberately-suspended `llm-platform`). That combination is what makes it easy to miss: **the platform converges anyway**.

## Two owners, one Helm release

Terraform installs `helm_release.flux_operator` to bootstrap a bare cluster. `flux/operator/helmrelease.yaml` then re-manages **the same release**, adding the Web UI and its OIDC configuration — none of which terraform declares.

So every apply read Flux's values as drift and tried to revert them: **revisions 23 → 45 in under two hours**, still climbing while I was diagnosing it.

Version policy disagreed too, and that half is a certainty rather than a race:

| | |
|---|---|
| terraform | exact pin from `globals.flux_operator_version` |
| Flux | `>=0.43.0 <1.0.0` — floating |

## Why `ignore_changes` cannot fix it

Flux upgrades the release to a chart whose version carries **build metadata** — `0.59.0+ae962f87e043` — and the helm provider writes that string into terraform's *own top-level* `version` attribute. No later plan can resolve it, because `+` is not legal in an OCI tag:

```
Error: Error locating chart ... Unable to locate chart
ghcr.io/controlplaneio-fluxcd/charts/flux-operator:0.59.0_ae962f87e043: not found
```

Every plan then dies in the **read**, before any diff exists to ignore.

## Flux owns it; terraform bootstraps and forgets

- **`lifecycle { ignore_changes = all }`** — states the intent the design already had, stops terraform reverting Flux's values.
- **`tofu state rm helm_release.flux_operator`** after the apply, in the deploy workflow — so the poisoned version can never enter state at all.
- **A `count` guard** fed by a new `scripts/helm-release-present.sh` — makes the *next* deploy a no-op instead of `cannot re-use a name that is still in use`. It can never destroy the operator: terraform has already forgotten it, so `count=0` has nothing in state to remove. An unreachable cluster answers `"false"`, terraform attempts the create, and helm reports any real conflict itself — a diagnostic must not block a plan.

**Both clouds carried the same shape; both are fixed.**

## Also: two undeclared variables

Different mistakes, different fixes:

- **`openbao_certificates_secret_name`** — referenced nowhere in the management stack (copied from the *cluster* stack, where it is declared and used). Removed.
- **`tags`** — real intent. The stack creates a Secrets Manager secret and tagged it with nothing, while every sibling stack declares and applies `tags`. Declared and wired.

Not cosmetic: one deploy log carried **91 error and warning lines**, which is how a genuine failure sat unread until the exit code was checked.

## Verification

Against the live cluster that was failing:

| | |
|---|---|
| before | `Error locating chart ... 0.59.0_ae962f87e043: not found` |
| after | **`No changes. Your infrastructure matches the configuration.`** |

The poisoned state entry was removed to recover this cluster; the release kept running under Flux throughout (`deployed`, revision 45). `tofu validate` and `fmt` clean on all three stacks, terramate parses all 16, shellcheck clean, tflint satisfied (`hashicorp/external` now declared).

## Not yet exercised

**The cold-bootstrap path**, where `count=1` creates the release on a bare cluster. That needs a teardown and rebuild — it's the first thing to watch on the next one.

One bug worth recording from writing the helper: `data "external"` sends its query JSON with **no trailing newline**, so `read -r` returns non-zero at EOF even though it populated the variable — and `|| default` then throws the real input away. Manual tests with `echo` pass, because `echo` adds the newline. The script uses `cat` and says so in a comment.
