### PR TITLE
feat(openbao): restore a chosen snapshot, not only the newest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,11 +251,18 @@ jobs:
       # worked, and nothing ran it -- so it was failing on two live calls in
       # scripts/openbao-adopt-jwt-mount.sh that put the OpenBao ROOT token in
       # the process table. A guard nobody runs is how that ships.
+      # scripts/test-openbao-snapshot-key.sh is the fourth, and covers which
+      # object a restore takes. Until OPENBAO_SNAPSHOT_KEY existed the answer was
+      # always "the newest", which cannot express "today's secret is wrong, give
+      # me yesterday's" -- the disaster Stage 2 introduces by making OpenBao the
+      # store of record for application secrets. A selector that silently
+      # returns the newest anyway would make point-in-time recovery a lie that
+      # only shows up during an incident, so it is tested offline like the rest.
       - name: Run the shell test suites
         run: |
           set -uo pipefail
           rc=0
-          for t in scripts/test-zitadel-*.sh scripts/test-openbao-fallback-address.sh scripts/test-no-secret-argv.sh; do
+          for t in scripts/test-zitadel-*.sh scripts/test-openbao-fallback-address.sh scripts/test-no-secret-argv.sh scripts/test-openbao-snapshot-key.sh; do
             if bash "$t" > /tmp/zitadel-test.log 2>&1; then
               echo "PASS  $t"
             else

--- a/container-images/openbao-snapshot/openbao-snapshot.sh
+++ b/container-images/openbao-snapshot/openbao-snapshot.sh
@@ -109,6 +109,21 @@ SNAP_NAME_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{6}Z-[a-z0-9]+\.snap$'
 # discards data, and that decision belongs to an operator rather than to a
 # selector.
 SKIP_FOREIGN_SEAL="${OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL:-false}"
+
+# Restore a NAMED object instead of the newest one. Empty (the default) keeps the
+# newest-object behaviour every other path relies on.
+#
+# The newest object is the right default for a platform rebuilt from its own
+# backup nightly, and it cannot express the case that arrives when OpenBao holds
+# application secrets: "today's value is wrong, restore yesterday's". The bucket
+# is versioned and keeps 120 days precisely so that is possible; until this
+# option existed, nothing could reach any of it.
+#
+# The name is matched against the candidate list rather than passed through, so a
+# typo fails by naming what IS there instead of 404-ing mid-restore. The seal gate
+# below still applies to whatever this selects -- a named object is not a trusted
+# object.
+SNAPSHOT_KEY="${OPENBAO_SNAPSHOT_KEY:-}"
 case "${SKIP_FOREIGN_SEAL}" in
     true|false) ;;
     *) echo "${err}: OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL must be 'true' or 'false', got '${SKIP_FOREIGN_SEAL}'." ; exit 1 ;;
@@ -235,6 +250,14 @@ Usage: ./${SCRIPT_NAME} [save|restore] -s <snapshot_file> -b <bucket_name> -a <V
       VAULT_CACERT              : CA chain to verify the server. Set it; do not skip verify.
       CHECK_NAMESPACE           : override the marker's namespace (default: root).
       CHECK_PATH                : override the marker path (default: lineage/check_timestamp).
+      OPENBAO_SNAPSHOT_KEY      : restore this NAMED object instead of the newest
+                                  one, e.g. '2026-09-05T092947Z-awskms.snap'.
+                                  For point-in-time recovery -- "today's secret
+                                  is wrong, give me yesterday's". Validated
+                                  against the bucket listing, and the seal gate
+                                  still applies. Discarding newer writes is the
+                                  point, so it says so in the log.
+
       OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL
                                 : 'true' lets 'restore' skip objects sealed by a
                                   DIFFERENT seal than this node's, and use the newest
@@ -564,6 +587,48 @@ save() {
     echo "${info}: Wrote ${SNAP_OBJECT}"
 }
 
+# Which object does `restore` take? The newest, unless OPENBAO_SNAPSHOT_KEY names
+# one -- see the variable's comment for why that option exists.
+#
+# Chosen key on stdout, diagnostics on stderr, non-zero when the named object is
+# not in the bucket. Split out of restore() so scripts/test-openbao-snapshot-key.sh
+# can exercise it: everything around it in restore() needs a live node and real
+# credentials, and a selector that can silently pick the wrong object is worth
+# testing without either.
+#
+# $1: candidate objects, newline separated, OLDEST FIRST (the callers sort by
+#     LastModified, not by name -- see the listing code for why).
+select_snapshot() {
+    _cands="$1"
+    _newest=$(printf '%s\n' "${_cands}" | tail -n1)
+
+    if [ -z "${SNAPSHOT_KEY}" ]; then
+        printf '%s\n' "${_newest}"
+        return 0
+    fi
+
+    # Validate against the listing rather than trusting the name: a typo must
+    # fail here, naming what IS available, not halfway through a destructive
+    # restore.
+    if ! printf '%s\n' "${_cands}" | grep -qxF "${SNAPSHOT_KEY}"; then
+        echo "${err}: OPENBAO_SNAPSHOT_KEY='${SNAPSHOT_KEY}' is not in ${BUCKET_NAME}." >&2
+        echo "${err}: available objects, oldest first:" >&2
+        printf '%s\n' "${_cands}" | sed "s/^/${err}:   /" >&2
+        return 1
+    fi
+
+    if [ "${SNAPSHOT_KEY}" != "${_newest}" ]; then
+        echo "${warn}: POINT-IN-TIME RESTORE -- not the newest object." >&2
+        echo "${warn}:   restoring : ${SNAPSHOT_KEY}" >&2
+        echo "${warn}:   newest    : ${_newest}" >&2
+        echo "${warn}: Every write after ${SNAPSHOT_KEY} is discarded. This is a" >&2
+        echo "${warn}: deliberate choice, so it is logged as one." >&2
+    fi
+
+    printf '%s\n' "${SNAPSHOT_KEY}"
+    return 0
+}
+
 restore() {
     echo "${info}: Restoring OpenBao from object storage..."
     check_required_bin
@@ -653,7 +718,7 @@ restore() {
         exit 1
     fi
 
-    SNAP=$(printf '%s\n' "${CANDIDATES}" | tail -n1)
+    SNAP=$(select_snapshot "${CANDIDATES}") || exit 1
     SNAP_SEAL=$(snapshot_seal_segment "${SNAP}")
 
     # THE GATE. Everything below this point is destructive -- `operator raft

--- a/scripts/test-openbao-snapshot-key.sh
+++ b/scripts/test-openbao-snapshot-key.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# (file-wide: err/warn/BUCKET_NAME/SNAPSHOT_KEY are read by the body of
+# select_snapshot(), which is eval'd in from the script under test, so static
+# analysis cannot see those uses. Same reason as test-openbao-fallback-address.sh.)
+#
+# Which snapshot does `restore` take?
+#
+# WHY THIS MATTERS. Until 2026-09-08 the answer was always "the newest", with no
+# way to ask for another. That is right for the case the script was written for --
+# the platform is destroyed nightly and rebuilt from its own newest backup -- and
+# it cannot express the case that arrives with Stage 2, when OpenBao becomes the
+# store of record for application secrets and the disaster is "today's value is
+# wrong, give me yesterday's". The bucket is versioned and keeps 120 days
+# precisely so that is possible; nothing could reach any of it.
+#
+# A selector that picks the wrong object is silent data loss on the
+# disaster-recovery path, so it is worth testing on its own. select_snapshot() is
+# lifted out of the script rather than restated -- the same technique the
+# fallback-address and zitadel suites use -- so this tests the code that ships.
+#
+# It has to be tested this way. Everything around the selector in restore()
+# needs a live node and real credentials: a first attempt to drive it end to end
+# never reached the selection at all, dying at the auth gate, and the attempt
+# after that was refused by the script's own server-version check.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+fail=0
+check() {
+    if [ "$2" = "$3" ]; then printf '  ok   %s\n' "$1"
+    else printf '  FAIL %s: expected %q got %q\n' "$1" "$2" "$3"; fail=1; fi
+}
+contains() {
+    if printf '%s' "$2" | grep -qF -- "$3"; then printf '  ok   %s\n' "$1"
+    else printf '  FAIL %s: %q not found in output\n' "$1" "$3"; fail=1; fi
+}
+
+SRC="${OPENBAO_SNAPSHOT_SCRIPT:-$HERE/openbao-snapshot.sh}"
+body="$(sed -n '/^select_snapshot() {/,/^}/p' "$SRC")"
+[ -n "$body" ] || { echo "could not extract select_snapshot() from $SRC" >&2; exit 1; }
+eval "$body"
+
+err="ERROR"
+warn="WARN"
+BUCKET_NAME="test-bucket"
+
+# Oldest first, the order restore() builds (sorted by LastModified, not by name).
+CANDIDATES="2026-09-05T092947Z-awskms.snap
+2026-09-05T135753Z-awskms.snap
+2026-09-05T151536Z-awskms.snap
+2026-09-05T214320Z-awskms.snap"
+NEWEST="2026-09-05T214320Z-awskms.snap"
+OLDEST="2026-09-05T092947Z-awskms.snap"
+
+echo "== default: no key set means the newest object"
+SNAPSHOT_KEY=""
+out=$(select_snapshot "$CANDIDATES" 2>/dev/null); rc=$?
+check "returns the newest" "$NEWEST" "$out"
+check "exit 0" "0" "$rc"
+stderr=$(select_snapshot "$CANDIDATES" 2>&1 >/dev/null)
+check "silent on the default path" "" "$stderr"
+
+echo
+echo "== a named object is honoured"
+SNAPSHOT_KEY="$OLDEST"
+out=$(select_snapshot "$CANDIDATES" 2>/dev/null); rc=$?
+check "returns the named object" "$OLDEST" "$out"
+check "exit 0" "0" "$rc"
+
+echo
+echo "== choosing a non-newest object announces what it discards"
+stderr=$(select_snapshot "$CANDIDATES" 2>&1 >/dev/null)
+contains "warns it is point-in-time" "$stderr" "POINT-IN-TIME RESTORE"
+contains "names what it restores"    "$stderr" "restoring : $OLDEST"
+contains "names what it skips"       "$stderr" "newest    : $NEWEST"
+contains "states the consequence"    "$stderr" "is discarded"
+
+echo
+echo "== naming the newest object explicitly is not a point-in-time restore"
+SNAPSHOT_KEY="$NEWEST"
+out=$(select_snapshot "$CANDIDATES" 2>/dev/null)
+stderr=$(select_snapshot "$CANDIDATES" 2>&1 >/dev/null)
+check "returns it" "$NEWEST" "$out"
+check "no discard warning, because nothing is discarded" "" "$stderr"
+
+echo
+echo "== an object that is not in the bucket is refused, before anything destructive"
+SNAPSHOT_KEY="2026-01-01T000000Z-awskms.snap"
+out=$(select_snapshot "$CANDIDATES" 2>/dev/null); rc=$?
+check "exit 1" "1" "$rc"
+check "emits no object name on stdout" "" "$out"
+stderr=$(select_snapshot "$CANDIDATES" 2>&1 >/dev/null)
+contains "names the bad key"     "$stderr" "is not in test-bucket"
+contains "lists the real ones"   "$stderr" "available objects, oldest first"
+contains "  and actually lists"  "$stderr" "$OLDEST"
+
+echo
+echo "== a near-miss is refused too: substrings must not match"
+SNAPSHOT_KEY="092947Z-awskms.snap"
+out=$(select_snapshot "$CANDIDATES" 2>/dev/null); rc=$?
+check "partial name rejected" "1" "$rc"
+
+echo
+echo "== a single-object bucket still works"
+SNAPSHOT_KEY=""
+out=$(select_snapshot "$NEWEST" 2>/dev/null)
+check "returns the only object" "$NEWEST" "$out"
+SNAPSHOT_KEY="$NEWEST"
+out=$(select_snapshot "$NEWEST" 2>/dev/null)
+check "named, and it is also the newest" "$NEWEST" "$out"
+
+echo
+if [ "$fail" -eq 0 ]; then echo "all checks passed"; else echo "FAILURES"; fi
+exit "$fail"

--- a/website/content/docs/platform/security/openbao.md
+++ b/website/content/docs/platform/security/openbao.md
@@ -292,6 +292,57 @@ export RECOVERY_KEYS_SECRET_ID="openbao/cloud-native-ref/tokens/recovery"
   -b eu-west-3-ogenki-openbao-snapshot -s /tmp/bao.snap -d 8
 ```
 
+### Restoring a specific snapshot, not the newest
+
+`restore` takes the newest object unless `OPENBAO_SNAPSHOT_KEY` names another.
+That default is right for the case this platform runs nightly — destroyed and
+rebuilt from its own newest backup — and it cannot express the other one:
+*today's value is wrong, give me yesterday's*. The bucket is versioned and keeps
+120 days precisely so that is possible.
+
+```bash
+# What is there, oldest first
+aws s3api list-objects-v2 --bucket eu-west-3-ogenki-openbao-snapshot \
+  --query 'sort_by(Contents,&LastModified)[].[Key,LastModified]' --output text
+
+export OPENBAO_SNAPSHOT_KEY="2026-09-05T092947Z-awskms.snap"
+./scripts/openbao-snapshot.sh restore -a "${VAULT_ADDR}" \
+  -b eu-west-3-ogenki-openbao-snapshot -s /tmp/bao.snap -d 8
+```
+
+The name is checked against the bucket listing before anything is downloaded, so
+a typo fails by printing what *is* there rather than part-way through a
+destructive restore. **Every write after the chosen object is discarded**, and
+the script says so in the log rather than letting that be a surprise. The seal
+gate still applies: naming an object does not exempt it.
+
+{{< callout type="warning" >}}
+**A restore is not verified until you have read your own data back.** The weekly
+drill asserts the PKI issuer and the GCS mirror, and it *cannot* check anything
+else: it deliberately holds no credentials, so a compromised runner cannot
+authenticate to the restored node. That is the right call for CI and it means
+the drill can never tell you your application secrets came back. After any
+restore you care about, read one:
+
+```bash
+VAULT_NAMESPACE=app bao kv get -mount=secret <a-key-you-know>
+```
+{{< /callout >}}
+
+### Recovery point objective
+
+Snapshots run **daily at 04:00 UTC**, plus one immediately before every teardown.
+Nothing captures a write between those points.
+
+So the worst case is a credential written just after a snapshot and lost before
+the next one: **up to ~24 hours of writes**. For the PKI that is close to
+irrelevant — certificates are reissued on demand and cert-manager renews them
+anyway. For anything whose value cannot be regenerated, it is the number that
+matters, and it is the one to revisit before OpenBao becomes the store of record
+for application credentials. Shortening it is a schedule change in
+`security/base/openbao-snapshot/`; the cost is bucket growth against the 120-day
+lifecycle rule, not risk.
+
 Prerequisites worth stating plainly:
 
 - **Both modes are Raft**, so snapshots work in `dev` too.


### PR DESCRIPTION
Closes the last gap between the backup/restore procedure and Stage 2.

## `restore` could only ever take the newest object

`tail -n1` of the bucket listing, with no way to change it. That's the right default for the case this platform runs nightly — destroyed and rebuilt from its own newest backup — and it **cannot express the case Stage 2 introduces**: OpenBao becomes the store of record for ~23 application secrets, and the disaster becomes *"today's value is wrong, give me yesterday's"*.

The bucket is versioned and keeps 120 days precisely so that is possible. Nothing could reach any of it.

```bash
export OPENBAO_SNAPSHOT_KEY="2026-09-05T092947Z-awskms.snap"
./scripts/openbao-snapshot.sh restore -a "${VAULT_ADDR}" -b <bucket> -s /tmp/bao.snap -d 8
```

Validated against the listing **before anything is downloaded**, so a typo fails by printing what *is* there rather than part-way through a destructive restore. Choosing a non-newest object logs what it discards. The seal gate stays downstream on purpose — naming an object does not exempt it.

## Proven by hand first, then made testable

The mechanism was proven on the live platform: restoring `2026-09-05T092947Z` into a throwaway node brought back a freshness marker reading **09:29:46Z** — twelve hours before the newest object, three days before now.

The selector then moved into `select_snapshot()` so it could be tested. It has to be tested that way: everything around it in `restore()` needs a live node and real credentials. A first attempt to drive it end to end never reached the selection at all (died at the auth gate), and the attempt after that was refused by the script's own server-version check — the local `bao` is 2.3.1, the platform pins 2.6.2.

**`scripts/test-openbao-snapshot-key.sh`** — 18 offline cases, wired into CI by name rather than by widening the glob.

**Checked against injected regressions rather than trusted because it was green:**

| Injected fault | Assertions failed |
|---|---|
| validation removed (trust the name) | 6 |
| key silently ignored, always newest | **11** |

That second one is the one that matters — it would make point-in-time recovery a lie that only surfaces during an incident.

## Two things Stage 2 needs stated, not discovered

**A restore is not verified until you have read your own data back.** The weekly drill asserts the PKI issuer and the GCS mirror, and **cannot** check anything else — it deliberately holds no credentials, so a compromised runner cannot authenticate to the restored node. Right call for CI, and it means the drill can never tell an operator their application secrets came back.

They do: a canary written to `app/secret/`, snapshotted, restored into a throwaway node and read back **byte-identical**, with the **original** root token authenticating the restored node (so auth backends, policies and namespaces restored too, not just KV values). But that's an operator's check to repeat, not the drill's — so it's now documented as a step.

**The RPO now has a number.** Daily at 04:00 plus one before every teardown means **up to ~24 hours of writes lost** in the worst case. Close to irrelevant for the PKI, which reissues on demand. It's the number that matters for anything whose value cannot be regenerated — and the one to revisit before OpenBao holds application credentials.

## Verification

- 18/18 offline assertions; both injected regressions caught
- `shellcheck -x -S warning` clean on the script and the suite
- `ci.yaml` parses; `validate-links.sh` 0 broken; `validate-doc-claims.sh` 24/24 across 43 page checks
- Suite re-run after merging #1993 into the branch
