### PR TITLE
fix(openbao): the seal probe must follow --fallback-address, not just the snapshot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -245,6 +245,14 @@ jobs:
       # by widening the glob: it covers the pre-destroy snapshot's fallback
       # address, which is a different subsystem that happens to be testable the
       # same way (offline, every call stubbed, bash and jq only).
+      # scripts/test-openbao-seal-status-tls.sh is the fourth, and pairs with the
+      # fallback-address suite above: that one covers the SNAPSHOT following
+      # --fallback-address, this one the seal-status probe that runs first. On
+      # 2026-09-08 the fallback reached the node and the probe then asked for the
+      # bare IP, which the certificate cannot match -- so a teardown refused,
+      # left a node billing, and pushed the operator toward the escape hatch that
+      # discards an obtainable snapshot. Two correct-looking halves that did not
+      # meet.
       # scripts/test-no-secret-argv.sh is the third named addition, and the one
       # that most needed to be here: it scans every script for a credential-
       # shaped variable passed on argv, where `ps` reads it. It existed, it
@@ -255,7 +263,7 @@ jobs:
         run: |
           set -uo pipefail
           rc=0
-          for t in scripts/test-zitadel-*.sh scripts/test-openbao-fallback-address.sh scripts/test-no-secret-argv.sh; do
+          for t in scripts/test-zitadel-*.sh scripts/test-openbao-fallback-address.sh scripts/test-no-secret-argv.sh scripts/test-openbao-seal-status-tls.sh; do
             if bash "$t" > /tmp/zitadel-test.log 2>&1; then
               echo "PASS  $t"
             else

--- a/container-images/openbao-snapshot/openbao-snapshot.sh
+++ b/container-images/openbao-snapshot/openbao-snapshot.sh
@@ -120,15 +120,40 @@ esac
 # ONE argv element when quoted and an empty word when unset -- the exact trap
 # already documented in verify_pki_present() in scripts/openbao-config.sh.
 seal_status_raw() {
-    if [ -n "${VAULT_CACERT:-}" ] && [ -n "${VAULT_SKIP_VERIFY:-}" ]; then
-        curl -sS -k --cacert "${VAULT_CACERT}" "${VAULT_ADDR}/v1/sys/seal-status"
-    elif [ -n "${VAULT_CACERT:-}" ]; then
-        curl -sS --cacert "${VAULT_CACERT}" "${VAULT_ADDR}/v1/sys/seal-status"
-    elif [ -n "${VAULT_SKIP_VERIFY:-}" ]; then
-        curl -sS -k "${VAULT_ADDR}/v1/sys/seal-status"
-    else
-        curl -sS "${VAULT_ADDR}/v1/sys/seal-status"
+    # VAULT_TLS_SERVER_NAME set means VAULT_ADDR holds an ADDRESS and the
+    # certificate carries a NAME -- the split scripts/openbao-config.sh's
+    # --fallback-address installs when the DNS record is gone but the node is
+    # not. curl does not read VAULT_TLS_SERVER_NAME, so without this it asks for
+    # the bare IP and fails verification against a certificate that has no IP
+    # SAN by design: a handshake failure dressed as an unreachable node.
+    #
+    # --resolve is curl's form of the same thing. Request the NAME, pin it to the
+    # ADDRESS, and SNI and verification both stay intact.
+    _ss_url="${VAULT_ADDR}/v1/sys/seal-status"
+    _ss_resolve=""
+    if [ -n "${VAULT_TLS_SERVER_NAME:-}" ]; then
+        _ss_hp=${VAULT_ADDR#*://}
+        _ss_hp=${_ss_hp%%/*}
+        _ss_addr=${_ss_hp%%:*}
+        _ss_port=${_ss_hp##*:}
+        [ "${_ss_port}" = "${_ss_hp}" ] && _ss_port=8200
+        if [ "${_ss_addr}" != "${VAULT_TLS_SERVER_NAME}" ]; then
+            _ss_url="https://${VAULT_TLS_SERVER_NAME}:${_ss_port}/v1/sys/seal-status"
+            _ss_resolve="${VAULT_TLS_SERVER_NAME}:${_ss_port}:${_ss_addr}"
+        fi
     fi
+
+    # Flags through the positional parameters. This is NOT the trap the previous
+    # comment here warned about -- that was word-splitting an unquoted variable
+    # holding several flags, where `--cacert /path` arrives as one argv element
+    # when quoted and as nothing when empty. "$@" expands each element
+    # separately and drops cleanly when empty, which is the POSIX equivalent of
+    # an array. The function takes no arguments, so `set --` clobbers nothing.
+    set --
+    [ -n "${_ss_resolve}" ] && set -- --resolve "${_ss_resolve}"
+    [ -n "${VAULT_CACERT:-}" ] && set -- "$@" --cacert "${VAULT_CACERT}"
+    [ -n "${VAULT_SKIP_VERIFY:-}" ] && set -- "$@" -k
+    curl -sS "$@" "${_ss_url}"
 }
 
 # The seal this node actually runs, on stdout; empty and non-zero when it

--- a/scripts/test-openbao-seal-status-tls.sh
+++ b/scripts/test-openbao-seal-status-tls.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# (file-wide: VAULT_ADDR/VAULT_CACERT/VAULT_TLS_SERVER_NAME/VAULT_SKIP_VERIFY are
+# read by the body of seal_status_raw(), which is eval'd in from the script under
+# test, so static analysis cannot see those uses.)
+#
+# Regression test: the seal-status probe must follow --fallback-address.
+#
+# THE BUG THIS EXISTS FOR, measured on the 2026-09-08 teardown.
+#
+# A destroy removes the Route53 record before the reverse walk reaches OpenBao,
+# so it arrives with the name gone and the node still up -- exactly what
+# --fallback-address is for. It engaged correctly, and then the seal read went to
+# the bare IP:
+#
+#   [WARN] https://bao.priv.aws.ogenki.io:8200 did not answer (HTTP 000);
+#          retrying at the fixed address 10.0.15.250.
+#   [INFO] Reached OpenBao at 10.0.15.250 presenting bao.priv.aws.ogenki.io:
+#          the name is gone, the node is not.
+#   ERROR: could not read https://10.0.15.250:8200/v1/sys/seal-status.
+#
+# The certificate carries no IP SAN by design, so that is a TLS hostname
+# mismatch, not an unreachable node. pre_destroy_snapshot() refused, the teardown
+# stopped with a node still billing, and the documented escape
+# (TM_OPENBAO_SKIP_SNAPSHOT=true) would have discarded a snapshot that was
+# obtainable the whole time -- the exact data loss the fallback prevents.
+#
+# The parent's $CURL_HOME/.curlrc does not cover it: it holds
+# `resolve = <name>:<port>:<address>`, which only fires when curl looks up the
+# NAME, and the parent has already rewritten VAULT_ADDR to the ADDRESS.
+#
+# This asserts the ARGUMENTS, not a live call: what matters is that curl is told
+# to ask for the name and pin it to the address. A stub captures them.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+fail=0
+check() {
+    if [ "$2" = "$3" ]; then printf '  ok   %s\n' "$1"
+    else printf '  FAIL %s:\n       expected %q\n       got      %q\n' "$1" "$2" "$3"; fail=1; fi
+}
+contains() {
+    if printf '%s' "$2" | grep -qF -- "$3"; then printf '  ok   %s\n' "$1"
+    else printf '  FAIL %s: %q not in %q\n' "$1" "$3" "$2"; fail=1; fi
+}
+absent() {
+    if printf '%s' "$2" | grep -qF -- "$3"; then printf '  FAIL %s: %q unexpectedly in %q\n' "$1" "$3" "$2"; fail=1
+    else printf '  ok   %s\n' "$1"; fi
+}
+
+SRC="${OPENBAO_SNAPSHOT_SCRIPT:-$HERE/openbao-snapshot.sh}"
+body="$(sed -n '/^seal_status_raw() {/,/^}/p' "$SRC")"
+[ -n "$body" ] || { echo "could not extract seal_status_raw() from $SRC" >&2; exit 1; }
+eval "$body"
+
+# The assertion point: record what curl was asked to do, run nothing.
+curl() { printf '%s\n' "$*"; }
+
+NAME=bao.priv.aws.ogenki.io
+IP=10.0.15.250
+
+echo "== the fallback case: address in VAULT_ADDR, name in VAULT_TLS_SERVER_NAME"
+VAULT_ADDR="https://${IP}:8200"
+VAULT_TLS_SERVER_NAME="$NAME"
+VAULT_CACERT=/tmp/ca.pem
+VAULT_SKIP_VERIFY=""
+out=$(seal_status_raw)
+contains "asks for the NAME, not the address" "$out" "https://${NAME}:8200/v1/sys/seal-status"
+contains "pins the name to the address"       "$out" "--resolve ${NAME}:8200:${IP}"
+absent   "does not request the bare IP URL"   "$out" "https://${IP}:8200/v1/sys/seal-status"
+contains "still presents the CA"              "$out" "--cacert /tmp/ca.pem"
+
+echo
+echo "== the ordinary case: no fallback, so nothing changes"
+VAULT_ADDR="https://${NAME}:8200"
+VAULT_TLS_SERVER_NAME=""
+out=$(seal_status_raw)
+contains "uses VAULT_ADDR as given" "$out" "https://${NAME}:8200/v1/sys/seal-status"
+absent   "adds no --resolve"        "$out" "--resolve"
+
+echo
+echo "== name set but equal to the address: still no --resolve"
+VAULT_ADDR="https://${NAME}:8200"
+VAULT_TLS_SERVER_NAME="$NAME"
+out=$(seal_status_raw)
+absent "no pointless --resolve" "$out" "--resolve"
+
+echo
+echo "== a non-default port is carried through"
+VAULT_ADDR="https://${IP}:9200"
+VAULT_TLS_SERVER_NAME="$NAME"
+out=$(seal_status_raw)
+contains "port preserved in the URL"     "$out" "https://${NAME}:9200/v1/sys/seal-status"
+contains "port preserved in --resolve"   "$out" "--resolve ${NAME}:9200:${IP}"
+
+echo
+echo "== VAULT_SKIP_VERIFY still reaches curl alongside the resolve"
+VAULT_ADDR="https://${IP}:8200"
+VAULT_TLS_SERVER_NAME="$NAME"
+VAULT_SKIP_VERIFY=true
+out=$(seal_status_raw)
+contains "keeps -k"        "$out" "-k"
+contains "keeps --resolve" "$out" "--resolve ${NAME}:8200:${IP}"
+
+echo
+echo "== no CA and no skip: bare call, no empty arguments"
+VAULT_ADDR="https://${NAME}:8200"
+VAULT_TLS_SERVER_NAME=""
+VAULT_CACERT=""
+VAULT_SKIP_VERIFY=""
+out=$(seal_status_raw)
+check "exactly -sS and the URL, no empty args" "-sS https://${NAME}:8200/v1/sys/seal-status" "$out"
+
+echo
+if [ "$fail" -eq 0 ]; then echo "all checks passed"; else echo "FAILURES"; fi
+exit "$fail"


### PR DESCRIPTION
Found by running into it, in the one path that had never been exercised.

## What happened

A destroy removes the Route53 record before the reverse walk reaches OpenBao, so it arrives with the **name gone and the node still up** — exactly what `--fallback-address` exists for. It engaged, correctly:

```
[WARN] https://bao.priv.aws.ogenki.io:8200 did not answer (HTTP 000);
       retrying at the fixed address 10.0.15.250.
[INFO] Reached OpenBao at 10.0.15.250 presenting bao.priv.aws.ogenki.io:
       the name is gone, the node is not.
ERROR: could not read https://10.0.15.250:8200/v1/sys/seal-status.
ERROR: that endpoint needs no token, so this is the node or the TLS trust,
ERROR: not a credential.
```

The message is right, and points at the wrong one of its own two options. The server certificate carries **no IP SAN by design**, so this is the TLS trust — a handshake failure dressed as an unreachable node. Taking the snapshot by hand with `--resolve` worked first try, **72,737 bytes**, from the same shell seconds later.

## What it cost

`pre_destroy_snapshot()` refused. The teardown stopped with an OpenBao instance **still running and billing**, and the documented escape (`TM_OPENBAO_SKIP_SNAPSHOT=true`) would have discarded three days of writes that were obtainable the whole time.

That is the exact data loss `--fallback-address` exists to prevent, reached *through* the mechanism meant to prevent it.

## Why the parent's `.curlrc` didn't cover it

`pre_destroy_snapshot()` writes `resolve = <name>:<port>:<address>` into `$CURL_HOME/.curlrc` and exports `CURL_HOME`, so the child **does** inherit it. But it also rewrites `VAULT_ADDR` to the **address** — and a resolve entry only fires when curl looks up the **name**. The child asks for the IP, so the entry never applies.

Two correct-looking halves that don't meet — the same shape as the bug `cedcbda8` fixed, which taught the **Go client** the address/name split and left this `curl` call behind.

## The fix

`seal_status_raw()` now honours `VAULT_TLS_SERVER_NAME` the way curl expresses it: request the **name**, pin it to the **address** with `--resolve`. SNI and verification both stay intact.

Flags moved into the positional parameters. That is **not** the trap the comment there warned about — that was word-splitting an unquoted variable holding several flags, where `--cacert /path` arrives as one argv element when quoted and as nothing when empty. `"$@"` expands each element separately and drops cleanly when empty, which is the POSIX equivalent of an array.

## The test

`scripts/test-openbao-seal-status-tls.sh` asserts the **arguments**, not a live call — the whole bug was which host curl was told to ask for. 14 cases, wired into the CI shell-test job by name.

| | |
|---|---|
| against the fix | **14/14 pass** |
| against pre-fix `HEAD` | **6 failures**, naming `https://10.0.15.250:8200/v1/sys/seal-status` |

It covers the ordinary path too (no fallback → no `--resolve`), a name equal to the address (no pointless `--resolve`), non-default ports, and `VAULT_SKIP_VERIFY` alongside the resolve.

## Not covered

**The live path itself.** Proving it needs another teardown that finds the record gone and the node up. This session got there by accident, which is the only way anyone has so far.
