### PR TITLE
fix(openbao): a documented restore that strands the node, and six more from a full review

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -266,11 +266,20 @@ jobs:
       # store of record for application secrets. A selector that silently
       # returns the newest anyway would make point-in-time recovery a lie that
       # only shows up during an incident, so it is tested offline like the rest.
+      # scripts/test-openbao-root-token-probe.sh is the fifth, and guards the
+      # single function two branches now use to decide whether a deploy says
+      # "restored, continue" or "destroy the cluster with
+      # TM_OPENBAO_SKIP_SNAPSHOT=true". The second discards every write since the
+      # restore AND suppresses the pre-destroy snapshot, so a false negative here
+      # is unrecoverable data loss. Those branches are only reachable on a real
+      # cluster in a state that takes a full bootstrap to produce, which is
+      # precisely how their predecessor shipped: the claim was asserted in prose
+      # and never once executed.
       - name: Run the shell test suites
         run: |
           set -uo pipefail
           rc=0
-          for t in scripts/test-zitadel-*.sh scripts/test-openbao-fallback-address.sh scripts/test-no-secret-argv.sh scripts/test-openbao-snapshot-key.sh scripts/test-openbao-seal-status-tls.sh; do
+          for t in scripts/test-zitadel-*.sh scripts/test-openbao-fallback-address.sh scripts/test-no-secret-argv.sh scripts/test-openbao-snapshot-key.sh scripts/test-openbao-seal-status-tls.sh scripts/test-openbao-root-token-probe.sh; do
             if bash "$t" > /tmp/zitadel-test.log 2>&1; then
               echo "PASS  $t"
             else

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -275,11 +275,20 @@ jobs:
       # cluster in a state that takes a full bootstrap to produce, which is
       # precisely how their predecessor shipped: the claim was asserted in prose
       # and never once executed.
+      # scripts/test-openbao-pki-verify.sh is the sixth, and pins the three-way
+      # contract those branches read: 0 present-and-chains, 2 a clean 404, 1
+      # everything else. The case it exists for is an issuer that parses
+      # perfectly but chains to a DIFFERENT root -- a node holding the wrong
+      # lineage's data, invisible to every other signal, because the node is up,
+      # unsealed, serving a valid certificate, and the stored root token
+      # authenticates against it. It needs openssl, which the runner image
+      # already has; it generates its own throwaway CAs rather than stubbing the
+      # verify, since a stub would be assuming the very answer under test.
       - name: Run the shell test suites
         run: |
           set -uo pipefail
           rc=0
-          for t in scripts/test-zitadel-*.sh scripts/test-openbao-fallback-address.sh scripts/test-no-secret-argv.sh scripts/test-openbao-snapshot-key.sh scripts/test-openbao-seal-status-tls.sh scripts/test-openbao-root-token-probe.sh; do
+          for t in scripts/test-zitadel-*.sh scripts/test-openbao-fallback-address.sh scripts/test-no-secret-argv.sh scripts/test-openbao-snapshot-key.sh scripts/test-openbao-seal-status-tls.sh scripts/test-openbao-root-token-probe.sh scripts/test-openbao-pki-verify.sh; do
             if bash "$t" > /tmp/zitadel-test.log 2>&1; then
               echo "PASS  $t"
             else

--- a/.github/workflows/openbao-restore-drill.yml
+++ b/.github/workflows/openbao-restore-drill.yml
@@ -391,9 +391,19 @@ jobs:
             echo "::error::no OIDC request context on this runner -- the workflow needs permissions: id-token: write"
             exit 1
           fi
+          # The request token goes in a -K config file, never on argv: it mints
+          # OIDC tokens for ARBITRARY audiences, so anything able to read
+          # /proc/<pid>/cmdline during this job -- a third-party action, a build
+          # dependency -- could assume the drill role, which holds s3:GetObject
+          # and kms:Decrypt on the seal key. Same pattern as
+          # scripts/zitadel-oidc-clients.sh.
+          CFG=$(mktemp); chmod 600 "$CFG"
+          trap 'rm -f "$CFG"' EXIT
+          printf 'header = "Authorization: bearer %s"\n' "${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" > "$CFG"
           # The URL already carries ?api-version=, hence & and not ?.
-          token=$(curl -fsS -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+          token=$(curl -fsS -K "$CFG" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com" | jq -r '.value')
+          rm -f "$CFG"
           if [ -z "$token" ] || [ "$token" = "null" ]; then
             echo "::error::the OIDC endpoint returned no token value"
             exit 1

--- a/container-images/openbao-snapshot/README.md
+++ b/container-images/openbao-snapshot/README.md
@@ -64,8 +64,8 @@ object `-shamir` on both clouds would hide the mixed-seal hazard again.
 
 ### `restore` refuses a mismatch, before anything destructive
 
-`restore` selects the **newest** object and compares its seal segment with the node's own seal.
-On a mismatch it refuses — before the download, before `operator init`, before
+`restore` selects the **newest** object — unless `OPENBAO_SNAPSHOT_KEY` names one, see
+below — and compares its seal segment with the node's own seal. On a mismatch it refuses — before the download, before `operator init`, before
 `snapshot restore -force` — and prints both seals plus a count of what the bucket holds. The
 gate is duplicated in [`scripts/openbao-config.sh`](../../scripts/openbao-config.sh)
 (`rehydrate`), on purpose: that script has to decide **before** its own `bao operator init`, and
@@ -76,6 +76,34 @@ Set `OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL=true` to restore the newest object the n
 for a failback, where the foreign-sealed objects are not coming back. If no object carries the
 node's seal, the run still refuses rather than falling through to a plain init, which would
 overwrite the lineage's stored root token and recovery keys.
+
+### `OPENBAO_SNAPSHOT_KEY` restores a named object, not the newest
+
+The newest object cannot express *"today's is wrong, give me yesterday's"*, which is the
+whole shape of a secrets-store recovery: the bad write is already in the newest snapshot.
+`OPENBAO_SNAPSHOT_KEY=<object>` restores that object instead.
+
+- The name is validated **against the listing**, not trusted. A typo fails before anything
+  destructive, printing what the bucket actually holds — not halfway through a restore.
+- Choosing anything but the newest is logged as `POINT-IN-TIME RESTORE`, naming both
+  objects and stating that every write after the chosen one is discarded. It is a
+  deliberate act, so it leaves a deliberate trace.
+- `scripts/openbao-config.sh` forwards it to this script **explicitly** rather than relying
+  on inheritance, and gates on the *named* object rather than the newest. Unexported, it
+  used to be ignored by both and the point-in-time request became a silent no-op.
+
+**It refuses to combine with `OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL=true`, and that refusal is
+the point.** The hatch substitutes the newest object this node's seal can unwrap, and
+"newest" is the exact opposite of what a named key asks for. On a mixed-seal bucket — the
+only state where the hatch is legitimate at all — the two features silently cancelled, and
+the one that won was the one that discards data. So the script refuses and says which
+object it could not use: an operator who named one can name another, but the script must
+not choose for them.
+
+> **Retention is not reach.** The AWS bucket transitions objects to GLACIER at 30 days
+> while retaining them for 120, so naming an object older than 30 days fails with
+> `InvalidObjectState` until it is restored out of Glacier. Check the `StorageClass` in the
+> listing before planning a recovery around an old object.
 
 ### Objects with no seal segment are never selected
 

--- a/container-images/openbao-snapshot/openbao-snapshot.sh
+++ b/container-images/openbao-snapshot/openbao-snapshot.sh
@@ -604,6 +604,18 @@ save() {
     # DST change. The timestamp stays FIRST and fixed-width so `sort | tail -n1`
     # remains chronological even in a bucket holding two seals.
     SNAP_OBJECT="$(date -u +"%Y-%m-%dT%H%M%SZ")-${SEAL_TYPE}.snap"
+    # An empty or truncated snapshot uploads perfectly well, becomes the
+    # lineage's NEWEST object, and leaves OpenBaoSnapshotStale green -- a fresh
+    # object exists. It then surfaces at the next rehydrate, which is the one
+    # moment this file IS the store of record. hashicorp/vault#15258 ("incomplete
+    # snapshot, unable to read SHA256SUMS.sealed") is this failure on this path.
+    if [ ! -s "${SNAPSHOT_FILE}" ]; then
+        echo "${err}: the snapshot at ${SNAPSHOT_FILE} is empty; refusing to upload it."
+        echo "${err}: An empty object would become the newest in ${BUCKET_NAME} and the"
+        echo "${err}: staleness alert would go quiet while the lineage held nothing."
+        exit 1
+    fi
+
     if [ "${CLOUD}" = "gcp" ]; then
         gcloud storage cp "${SNAPSHOT_FILE}" "gs://${BUCKET_NAME}/${SNAP_OBJECT}"
     else

--- a/container-images/openbao-snapshot/openbao-snapshot.sh
+++ b/container-images/openbao-snapshot/openbao-snapshot.sh
@@ -654,6 +654,45 @@ select_snapshot() {
     return 0
 }
 
+# Which object does the foreign-seal escape hatch fall back to?
+#
+# Only reached when OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL=true and the selected
+# object's seal is not this node's. Prints the object on stdout, diagnostics on
+# stderr, non-zero to refuse.
+#
+# It REFUSES when the operator named an object with OPENBAO_SNAPSHOT_KEY. The
+# hatch substitutes the newest same-seal object, and the newest is the precise
+# opposite of what a named key asks for -- so on a mixed-seal bucket the two
+# features silently cancelled, and the one that won was the one that discards
+# data. The operator who named an object can name a different one; the script
+# must not choose for them.
+#
+# $1 candidates, oldest first.  $2 this node's seal type.
+foreign_seal_fallback() {
+    _fsf_cands="$1"
+    _fsf_seal="$2"
+
+    if [ -n "${SNAPSHOT_KEY}" ]; then
+        echo "${err}: OPENBAO_SNAPSHOT_KEY names '${SNAPSHOT_KEY}', which this node's" >&2
+        echo "${err}: '${_fsf_seal}' seal cannot unwrap, and" >&2
+        echo "${err}: OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL=true is set." >&2
+        echo "${err}: REFUSING rather than substituting. The hatch restores the NEWEST" >&2
+        echo "${err}: object this node can unwrap, which is the opposite of what naming an" >&2
+        echo "${err}: object asks for -- restoring it would discard everything the named" >&2
+        echo "${err}: snapshot was chosen to recover." >&2
+        echo "${err}: Objects this node CAN unwrap, oldest first:" >&2
+        printf '%s\n' "${_fsf_cands}" \
+            | { grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{6}Z-${_fsf_seal}\.snap$" || true; } \
+            | sed "s/^/${err}:   /" >&2
+        echo "${err}: Name one of those, or unset OPENBAO_SNAPSHOT_KEY to take the newest." >&2
+        return 1
+    fi
+
+    printf '%s\n' "${_fsf_cands}" \
+        | { grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{6}Z-${_fsf_seal}\.snap$" || true; } \
+        | tail -n1
+}
+
 restore() {
     echo "${info}: Restoring OpenBao from object storage..."
     check_required_bin
@@ -792,7 +831,7 @@ restore() {
             exit 1
         fi
 
-        SNAP=$(printf '%s\n' "${CANDIDATES}" | { grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{6}Z-${SEAL_TYPE}\.snap$" || true; } | tail -n1)
+        SNAP=$(foreign_seal_fallback "${CANDIDATES}" "${SEAL_TYPE}") || exit 1
         if [ -z "${SNAP}" ]; then
             # Self-contained: this is now the first thing printed on this path.
             echo "${err}: SEAL MISMATCH, and OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL=true cannot help --"
@@ -810,7 +849,7 @@ restore() {
         # Also self-contained, and it says PROCEEDING rather than refusing.
         echo "${warn}: SEAL MISMATCH, and OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL=true -- PROCEEDING."
         echo "${warn}:   this node's seal : ${SEAL_TYPE}"
-        echo "${warn}:   newest object    : ${NEWEST} (${found}) -- SKIPPED"
+        echo "${warn}:   selected object  : ${NEWEST} (${found}) -- SKIPPED"
         echo "${warn}:   restoring instead: ${SNAP}, the newest of the ${n_mine} object(s) this node can unwrap"
         echo "${warn}:   in ${BUCKET_NAME}: ${n_all} snapshot object(s), $((n_all - n_tagged)) with no seal segment"
         echo "${warn}: Whatever was written after ${NEWEST} is NOT in this restore."

--- a/container-images/openbao-snapshot/openbao-snapshot.sh
+++ b/container-images/openbao-snapshot/openbao-snapshot.sh
@@ -129,11 +129,16 @@ case "${SKIP_FOREIGN_SEAL}" in
     *) echo "${err}: OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL must be 'true' or 'false', got '${SKIP_FOREIGN_SEAL}'." ; exit 1 ;;
 esac
 
-# GET /v1/sys/seal-status, honouring the same TLS choices as everything else
-# here. Built as explicit branches rather than by word-splitting a variable of
-# flags: `"${VAULT_CACERT:+--cacert $VAULT_CACERT}"` passes `--cacert /path` as
-# ONE argv element when quoted and an empty word when unset -- the exact trap
-# already documented in verify_pki_present() in scripts/openbao-config.sh.
+# GET /v1/sys/seal-status, honouring the same TLS choices as everything else here.
+#
+# Flags are accumulated in the POSITIONAL PARAMETERS and expanded as "$@". That
+# is deliberately not the trap documented in verify_pki_present() in
+# scripts/openbao-config.sh: word-splitting an unquoted variable that holds
+# several flags, where `"${VAULT_CACERT:+--cacert $VAULT_CACERT}"` passes
+# `--cacert /path` as ONE argv element when quoted and an empty word when unset.
+# "$@" expands each element separately and disappears cleanly when empty, which
+# is the POSIX equivalent of an array. This function takes no arguments, so
+# `set --` clobbers nothing.
 seal_status_raw() {
     # VAULT_TLS_SERVER_NAME set means VAULT_ADDR holds an ADDRESS and the
     # certificate carries a NAME -- the split scripts/openbao-config.sh's
@@ -158,12 +163,7 @@ seal_status_raw() {
         fi
     fi
 
-    # Flags through the positional parameters. This is NOT the trap the previous
-    # comment here warned about -- that was word-splitting an unquoted variable
-    # holding several flags, where `--cacert /path` arrives as one argv element
-    # when quoted and as nothing when empty. "$@" expands each element
-    # separately and drops cleanly when empty, which is the POSIX equivalent of
-    # an array. The function takes no arguments, so `set --` clobbers nothing.
+    # See the header above for why these go through the positional parameters.
     set --
     [ -n "${_ss_resolve}" ] && set -- --resolve "${_ss_resolve}"
     [ -n "${VAULT_CACERT:-}" ] && set -- "$@" --cacert "${VAULT_CACERT}"

--- a/opentofu/aws/openbao/cluster/README.md
+++ b/opentofu/aws/openbao/cluster/README.md
@@ -18,7 +18,7 @@ Deploy a OpenBao instance following HashiCorp's best practices. Complete these s
 | Disk type            | gp3 (root)   | NVMe instance store   |
 | OpenBao storage type | raft (single node) | raft                  |
 | Instance type(s)     | t3.micro     | mixed (lower-price)   |
-| Capacity type        | on-demand    | spot                  |
+| Capacity type        | on-demand    | 3 on-demand + 2 ~95% spot |
 
 Both modes are Raft since the lineage design (2026-09): a `file` backend cannot take
 or receive a snapshot, and the node is rebuilt from the lineage's newest snapshot on
@@ -42,9 +42,15 @@ This cluster is torn down and reprovisioned on every platform test, and points 3
 above are priced for that. **Do not carry them into a long-lived deployment.** Concretely,
 in `ha` mode:
 
-- **The Raft quorum runs on spot capacity.** `on_demand_base_capacity = 0` with
-  `on_demand_percentage_above_base_capacity = 5` means effectively every voter is
-  interruptible. A correlated reclamation across pools takes out quorum.
+- **Two of the five voters run on spot.** `on_demand_base_capacity = 3`
+  (`autoscaling_group.tf`) pins the quorum majority to on-demand, and
+  `on_demand_percentage_above_base_capacity = 5` leaves the two nodes above that base
+  ~95% spot. So a correlated reclamation costs fault tolerance, not the leader election
+  — but the cluster then runs with no margin, and the ephemeral data path below is what
+  makes that matter. This bullet said `on_demand_base_capacity = 0` and "every voter is
+  interruptible" until 2026-09-08; that was the shape before the 2026-08-19 HA bring-up
+  failed on `InsufficientInstanceCapacity`, and the comment above the setting records
+  why it changed.
 - **The Raft data path is ephemeral.** `/opt/openbao/data` is a RAID-0 of instance-store
   NVMe (`scripts/setup-local-disks.sh`). Instance store does not survive a stop/start or a
   replacement, and RAID-0 means a single failed device loses that node's entire store.
@@ -57,9 +63,10 @@ in `ha` mode:
   (`observability/base/victoria-metrics-k8s-stack/vmrules/openbao.yaml`) is what tells you
   this is happening.
 
-For a deployment meant to stay up, change all three: on-demand capacity, encrypted gp3
-EBS for the Raft path, and a lifecycle hook that deregisters the peer before the instance
-goes away.
+For a deployment meant to stay up: take the last two voters off spot as well, put the
+Raft path on encrypted gp3 EBS, and add a lifecycle hook that deregisters the peer before
+the instance goes away. The first of those is already half done — the quorum majority is
+on-demand — which is why it is one item here rather than three.
 
 ## 🔭 Observability
 
@@ -79,13 +86,25 @@ swap the static target for an `ec2SDConfigs` block filtered on `tag:app=openbao`
 
 ## 🔒 Security Considerations
 
-* Keep the Root CA offline. ⚠️ Not currently the case — see the note in
-  [management/README.md](../management/README.md).
+* Keep the Root CA offline. ✅ It is. One offline root signed each cloud's intermediate
+  once, only the intermediate's cert+key is imported into the `pki` mount, and the
+  Secrets Manager entry that used to hold the root key is deleted — see the note in
+  [management/README.md](../management/README.md), which this line contradicted until
+  2026-09-08. The weekly restore drill re-checks the chain against the committed root
+  certificate on every run.
 * Use hardened AMIs, such as those built with [this project](https://github.com/konstruktoid/hardened-images) from @konstruktoid. An Ubuntu AMI from Canonical is used by default.
 * Disable SSM once the cluster is operational and an Identity provider is configured.
-* Implement MFA for authentication. ⚠️ Not currently the case: the only identity is the
-  root token in Secrets Manager. Zitadel is deployed in the cluster but no OIDC auth
-  method is configured on OpenBao, and the `admin` policy is bound to nothing.
+* Implement MFA for authentication. ⚠️ Still not enforced — but not for the reason this
+  line used to give. It claimed "the only identity is the root token in Secrets Manager",
+  that no OIDC method was configured, and that the `admin` policy was "bound to nothing".
+  All three are false: human login is ZITADEL OIDC
+  (`management/oidc.tf`, [ADR-0034](https://cnref.ogenki.io/docs/decisions/0034-openbao-oidc-via-zitadel-project-roles/),
+  conditional only on the ZITADEL client id and issuer being set), the `userpass` admin
+  (`management/auth.tf`) survives deliberately as break-glass carrying the `admin` and
+  `pki-admin` policies, and machines authenticate through the per-cluster JWT mounts.
+  What remains true is narrower: routing human login through OIDC makes MFA a ZITADEL
+  **login-policy** setting rather than an OpenBao one, and nothing in this repo sets it.
+  The break-glass `userpass` credential would sit outside it either way.
 
 ### Secrets never travel in user-data
 

--- a/opentofu/aws/openbao/cluster/scripts/startup_script.sh
+++ b/opentofu/aws/openbao/cluster/scripts/startup_script.sh
@@ -14,9 +14,14 @@ echo "OpenBao init"
 
 export DEBIAN_FRONTEND=noninteractive
 
+# The IMDSv2 session token below is marked `argv-ok` for
+# scripts/test-no-secret-argv.sh. It is credential-SHAPED but not a credential
+# worth hiding here: it only authorises reads of THIS instance's metadata, and
+# anyone able to read another process's argv on this host can mint their own with
+# a single PUT. Hiding it would buy nothing and cost legibility in a boot script.
 IMDS_TOKEN=$(curl -fsS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-INSTANCE_ID=$(curl -fsS -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
-PRIVATE_IP=$(curl -fsS -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)
+INSTANCE_ID=$(curl -fsS -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/instance-id)  # argv-ok: IMDSv2 session token
+PRIVATE_IP=$(curl -fsS -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)  # argv-ok: IMDSv2 session token
 
 # Install OpenBao
 # ---------------

--- a/opentofu/aws/openbao/lineage/github-oidc.tf
+++ b/opentofu/aws/openbao/lineage/github-oidc.tf
@@ -6,15 +6,19 @@
 # and nothing else. In particular it does NOT get the recovery keys: the drill
 # proves restorability through unauthenticated endpoints, and a CI runner
 # holding the material that mints a root token would be a standing exposure.
-data "tls_certificate" "github" {
-  url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
-}
-
 resource "aws_iam_openid_connect_provider" "github" {
-  url             = "https://token.actions.githubusercontent.com"
-  client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = [data.tls_certificate.github.certificates[0].sha1_fingerprint]
-  tags            = var.tags
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  # NO thumbprint_list, deliberately -- the same decision, and the same reasoning,
+  # as opentofu/shared/aws-gcp-federation/google-identity.tf. It used to pin
+  # certificates[0], which is the LEAF, and GitHub rotates it: the pin produces
+  # recurring drift that means nothing. AWS ignores thumbprints for an IdP whose
+  # root it already trusts, so pinning bought no security to begin with.
+  #
+  # `certificates[length-1]` is not the fix either: the chain is not reliably
+  # ordered leaf-last, and picking by index is how the leaf got pinned here in
+  # the first place.
+  tags = var.tags
 }
 
 data "aws_iam_policy_document" "drill_assume" {

--- a/opentofu/aws/openbao/management/pki.tf
+++ b/opentofu/aws/openbao/management/pki.tf
@@ -16,24 +16,26 @@ resource "vault_mount" "pki" {
 # on a networked system, which the PKI & Secrets page carried as an accepted
 # trade-off for a reference platform.
 #
-# WRITTEN FOR THE OFFLINE SHAPE, WHICH HAS NOT HAPPENED YET on AWS. This code
-# reads a pre-signed intermediate from `certificates/priv.aws.ogenki.io/
-# intermediate-ca`, a secret the offline ceremony creates -- Task 14 of the
-# Stage 1 plan, still unrun. Until it does:
+# THE OFFLINE SHAPE, AND IT IS THE LIVE ONE. This code reads a pre-signed
+# intermediate from `certificates/priv.aws.ogenki.io/intermediate-ca` and
+# generates nothing inside OpenBao, so the mount's issuer is the intermediate the
+# offline ceremony signed. Verified 2026-09-08 against the live account:
 #
-#   * this stack cannot apply, because that secret does not exist;
-#   * `certificates/priv.aws.ogenki.io/root-ca`, which holds the root PRIVATE
-#     KEY, is still in Secrets Manager, and the live mount's issuer is still
-#     the one OpenBao generated and signed for itself;
-#   * so the root key IS on a networked system today. Task 17 Step 2 deletes
-#     that secret, deliberately only after the new chain has issued a
-#     certificate.
+#   * `certificates/priv.aws.ogenki.io/intermediate-ca` exists and this stack
+#     applies from it;
+#   * `certificates/priv.aws.ogenki.io/root-ca`, which used to hold the root
+#     PRIVATE KEY, is deleted -- no cloud store holds it;
+#   * a node rehydrated from the newest snapshot serves an issuer that
+#     `openssl verify -CAfile .github/openbao-root-ca.pem` accepts, and the
+#     weekly restore drill asserts exactly that on every run.
 #
-# An earlier version of this comment said the deletion had already happened.
-# It had not, and stating a security improvement in the past tense before it is
-# made is the worst direction for the error -- it retires the warning while the
-# exposure is still there. The PKI & Secrets page carries the same gating in a
-# warning callout; the two are meant to agree.
+# An earlier version of this comment said the deletion had already happened
+# before it had, and the version after it went on saying the opposite once it
+# had. Both directions mislead: one retires a warning over a live exposure, the
+# other leaves a warning standing over a closed one, and a reader cannot tell
+# which they are looking at. Hence the date and the re-check above -- the claim
+# is falsifiable rather than asserted. The PKI & Secrets page carries the same
+# statement; the two are meant to agree.
 #
 # After the ceremony: the root signs each cloud's intermediate offline, only the
 # intermediate's cert+key bundle reaches a networked store, and tailnet clients

--- a/opentofu/gcp/openbao/lineage/github-wif.tf
+++ b/opentofu/gcp/openbao/lineage/github-wif.tf
@@ -33,5 +33,23 @@ resource "google_iam_workload_identity_pool_provider" "github" {
 resource "google_service_account_iam_member" "drill_wif" {
   service_account_id = google_service_account.openbao_drill.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repository}"
+
+  # `principal://.../subject/<sub>`, not `principalSet://.../attribute.repository/<repo>`.
+  #
+  # The repository form admits every ref and every pull request in the repo, and
+  # leaves the refs/heads/main pin living ONLY in the provider's
+  # attribute_condition one level up. That is a single point of failure in two
+  # directions: a second provider added to this pool would inherit this binding
+  # with no ref constraint at all, and relaxing that one condition would
+  # immediately admit every branch and PR to openbao-drill -- which can list the
+  # entire snapshot mirror. The subject form pins the same identity the AWS role
+  # pins in opentofu/aws/openbao/lineage/github-oidc.tf, so both clouds now
+  # express one decision in their own syntax rather than two different ones.
+  #
+  # COUPLED TO THE WORKFLOW'S `environment:`. GitHub's `sub` is
+  # `repo:<repo>:ref:refs/heads/main` only while the drill job declares no
+  # environment; adding one changes it to `repo:<repo>:environment:<name>` and
+  # this binding stops matching. If the drill is ever scoped to a GitHub
+  # environment, this string and the AWS role's `sub` condition move together.
+  member = "principal://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/subject/repo:${var.github_repository}:ref:refs/heads/main"
 }

--- a/scripts/openbao-config.sh
+++ b/scripts/openbao-config.sh
@@ -462,6 +462,30 @@ secret_read() {
     fi
 }
 
+# Does the LINEAGE's root token work on this node right now?
+#
+# The one fact that separates a node stranded on throwaway keys from one that
+# restored correctly but whose snapshot predates the PKI mount. Asserting the
+# difference rather than testing it is how the 200-with-no-PKI branch below came
+# to recommend destroying a perfectly good node with its snapshot suppressed.
+#
+# Quiet and non-fatal: returns 1 for "no", including when the secret cannot be
+# read at all, because every caller wants to keep going and say something more
+# useful than the caller could without it.
+stored_root_token_works() {
+    local _srtw_token
+    [ -n "${ROOT_TOKEN_SECRET_NAME}" ] || return 1
+    _srtw_token=$(secret_read "${ROOT_TOKEN_SECRET_NAME}" 2>/dev/null) || return 1
+    # `.token`, the shape the writer above produces (`jq -Rs '{"token": .}'`)
+    # and the shape the only other reader in this file expects. Not a wider
+    # `.root_token // .token // .`: a bare-string secret makes jq error on the
+    # first index anyway, so the extra alternatives buy nothing and imply
+    # shapes nothing writes.
+    _srtw_token=$(printf '%s' "${_srtw_token}" | jq -r '.token // empty' 2>/dev/null) || return 1
+    [ -n "${_srtw_token}" ] || return 1
+    VAULT_TOKEN="${_srtw_token}" bao token lookup >/dev/null 2>&1
+}
+
 # Environment the sibling snapshot script needs. It is POSIX sh and calls the
 # cloud CLIs bare, so the region/profile/ADC choices made here have to reach it
 # through the environment rather than flags.
@@ -935,8 +959,22 @@ rehydrate_openbao() {
                 log_message "WARN" "the apply after this step is what creates the PKI."
                 exit 0
             fi
+            # Test the claim before making it. A node that restored a snapshot
+            # taken before the PKI mount existed looks identical from here, and
+            # for that node the advice below is catastrophic: it destroys a
+            # correctly restored node with its pre-destroy snapshot suppressed.
+            if stored_root_token_works; then
+                log_message "WARN" "OpenBao is initialized and unsealed with NO PKI mount, and ${SNAPSHOT_BUCKET}"
+                log_message "WARN" "holds ${_latest} -- but the lineage's stored root token AUTHENTICATES here."
+                log_message "WARN" "So this node is RESTORED, not stranded: the snapshot it came from was taken"
+                log_message "WARN" "before the PKI mount existed. Do NOT destroy it, and do NOT pass"
+                log_message "WARN" "TM_OPENBAO_SKIP_SNAPSHOT=true -- that would discard every write since."
+                log_message "WARN" "The management apply that follows is what creates the PKI. Continuing."
+                exit 0
+            fi
             log_message "ERROR" "OpenBao is initialized and unsealed but has NO PKI mount, while ${SNAPSHOT_BUCKET}"
-            log_message "ERROR" "holds ${_latest}. This is the state a failed restore leaves behind: the node holds"
+            log_message "ERROR" "holds ${_latest}, AND the lineage's stored root token does not authenticate."
+            log_message "ERROR" "That combination is the state a failed restore leaves behind: the node holds"
             log_message "ERROR" "throwaway keys that were never stored, so nothing can authenticate to it. Destroy"
             log_message "ERROR" "and redeploy the cluster stack with TM_OPENBAO_SKIP_SNAPSHOT=true -- there is"
             log_message "ERROR" "nothing on this node worth snapshotting."
@@ -1153,8 +1191,21 @@ rehydrate_openbao() {
     fi
     unset root_token
 
+    # The child exited 0, so the restore itself SUCCEEDED. A missing PKI mount
+    # past this point means the snapshot predates it -- not that anything failed.
+    # Saying "exit 1" and nothing else is what fed the next deploy into the
+    # 200-with-no-PKI branch above, whose advice destroys the node.
     if ! verify_pki_present; then
-        exit 1
+        if stored_root_token_works; then
+            log_message "WARN" "Restore SUCCEEDED, but the snapshot carries no PKI mount: ${SNAPSHOT_BUCKET}'s"
+            log_message "WARN" "newest object predates it. The lineage's root token authenticates, so this node"
+            log_message "WARN" "holds the lineage's data. The management apply that follows creates the PKI."
+            log_message "WARN" "Do NOT destroy this node, and do NOT pass TM_OPENBAO_SKIP_SNAPSHOT=true."
+        else
+            log_message "ERROR" "Restore reported success, but the node has no PKI mount AND the lineage's root"
+            log_message "ERROR" "token does not authenticate. Treat this as a failed restore."
+            exit 1
+        fi
     fi
     # Deliberately not naming ${latest}: the child re-lists and selects
     # independently, so its own "Restoring snapshot ..." line is the

--- a/scripts/openbao-config.sh
+++ b/scripts/openbao-config.sh
@@ -91,6 +91,10 @@ usage() {
     echo "  --freshness-days <N>                      Age past which a restored snapshot is reported as old (default: ${FRESHNESS_DAYS})"
     echo ""
     echo "Environment:"
+    echo "  OPENBAO_SNAPSHOT_KEY=<object>             Rehydrate from a NAMED object instead of the"
+    echo "                                             newest. Forwarded to the restore child and"
+    echo "                                             gated here, so the seal checked before the"
+    echo "                                             irreversible init is the one being restored."
     echo "  OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL=true   Let 'rehydrate' skip snapshots sealed by a"
     echo "                                             DIFFERENT seal than this node's, and restore"
     echo "                                             the newest one this node's seal can unwrap."
@@ -1004,6 +1008,13 @@ rehydrate_openbao() {
     if ! node_seal=$(node_seal_type); then
         exit 1
     fi
+    # Gate the object that will ACTUALLY be restored. The child honours
+    # OPENBAO_SNAPSHOT_KEY, so gating latest_snapshot() here would clear a seal
+    # for one object and then restore another -- after the irreversible init.
+    if [ -n "${OPENBAO_SNAPSHOT_KEY:-}" ]; then
+        log_message "INFO" "OPENBAO_SNAPSHOT_KEY names ${OPENBAO_SNAPSHOT_KEY}; gating that, not the newest."
+        latest="${OPENBAO_SNAPSHOT_KEY}"
+    fi
     snap_seal=$(snapshot_seal_segment "$latest")
     log_message "INFO" "This node's seal is '${node_seal}'; ${latest} carries '${snap_seal:-none}'."
 
@@ -1121,9 +1132,16 @@ rehydrate_openbao() {
     # exported one would otherwise get a parent that skipped past the foreign
     # seal and a child that refused -- after the init, which is the one place
     # this must not happen.
+    # OPENBAO_SNAPSHOT_KEY rides along for the same reason, and it needs it more:
+    # the gate above inspects latest_snapshot(), while the child re-lists and
+    # selects independently. If the key names a different object, the parent
+    # cleared a seal it was not about to restore -- and it cleared it just before
+    # `bao operator init`, which is irreversible. Unexported, it was ignored by
+    # both and the point-in-time request became a silent no-op.
     if ! VAULT_TOKEN="$root_token" RECOVERY_KEYS_SECRET_ID="$RECOVERY_KEYS_SECRET_NAME" \
         ROOT_TOKEN_SECRET_ID="$ROOT_TOKEN_SECRET_NAME" \
         OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL="${OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL:-false}" \
+        OPENBAO_SNAPSHOT_KEY="${OPENBAO_SNAPSHOT_KEY:-}" \
         sh "$(dirname "$0")/openbao-snapshot.sh" restore \
             -a "$OPENBAO_URL" -b "$SNAPSHOT_BUCKET" -s "$scratch/bao.snap" \
             -d "$FRESHNESS_DAYS" --freshness warn; then

--- a/scripts/openbao-config.sh
+++ b/scripts/openbao-config.sh
@@ -483,7 +483,16 @@ stored_root_token_works() {
     # shapes nothing writes.
     _srtw_token=$(printf '%s' "${_srtw_token}" | jq -r '.token // empty' 2>/dev/null) || return 1
     [ -n "${_srtw_token}" ] || return 1
-    VAULT_TOKEN="${_srtw_token}" bao token lookup >/dev/null 2>&1
+    # VAULT_TOKEN= as a command PREFIX, not an export: the token stays in this
+    # one process's environment rather than argv or the caller's shell. Both
+    # callers run mid-deploy, so exporting it would silently re-authenticate
+    # everything after this probe as root.
+    #
+    # `|| return 1` normalises the answer. Without it the function returns bao's
+    # own exit code -- 2 for a rejected token, 127 if bao is not on PATH -- and
+    # while every `if` treats those as false, the contract above says 1 and a
+    # future caller reading it with `case $?` would be wrong.
+    VAULT_TOKEN="${_srtw_token}" bao token lookup >/dev/null 2>&1 || return 1
 }
 
 # Environment the sibling snapshot script needs. It is POSIX sh and calls the

--- a/scripts/openbao-config.sh
+++ b/scripts/openbao-config.sh
@@ -753,6 +753,20 @@ latest_snapshot_sealed() {
 # rehydrate can assert without a token: if it answers with a certificate that
 # chains to the CA we already trust, the barrier unwrapped and the mount came
 # back.
+# THREE outcomes, not two, and the callers act differently on each:
+#
+#   0  the mount is there and its issuer chains to this lineage's root
+#   2  a clean 404 -- the mount is genuinely absent, which a snapshot taken
+#      before the PKI existed produces legitimately
+#   1  anything else: unreachable, sealed, non-2xx, not a certificate, or --
+#      the dangerous one -- an issuer that does NOT chain to this lineage's CA
+#
+# 1 and 2 were the same answer until 2026-09-08, and collapsing them is unsafe
+# in one specific direction. A restore that comes back under a DIFFERENT root is
+# a node full of the wrong lineage's data; a caller that reads "failed" as "no
+# mount yet, carry on" waves it through, and one that reads it as "nothing here
+# worth keeping" advises destroying it with the snapshot suppressed. Both are
+# data loss, in opposite directions, from the same missing distinction.
 verify_pki_present() {
     # argv built as an ARRAY. `"${VAULT_CACERT:+--cacert $VAULT_CACERT}"` looks
     # right and is not: quoted, it passes `--cacert /path` as ONE argv element
@@ -778,8 +792,11 @@ verify_pki_present() {
     case "$http_code" in
         200) ;;
         404)
+            # 2, not 1: a clean 404 is the ONE failure a caller may legitimately
+            # continue past, because a snapshot predating the PKI mount produces
+            # exactly this. Every other branch below stays 1.
             log_message "ERROR" "pki_private_issuer is not mounted on this node (HTTP 404)."
-            return 1 ;;
+            return 2 ;;
         '')
             log_message "ERROR" "Could not reach $OPENBAO_URL at all -- TLS trust or the node itself, not the PKI mount."
             return 1 ;;
@@ -920,9 +937,24 @@ rehydrate_openbao() {
             # lineage data. Exiting 0 on the strength of a 200 alone would turn
             # a loud failure into a silent success on the next deploy, and the
             # management stack would then run against an empty store.
-            if verify_pki_present; then
+            local _idem_rc=0
+            verify_pki_present || _idem_rc=$?
+            if [ "$_idem_rc" -eq 0 ]; then
                 log_message "INFO" "OpenBao is already initialized, unsealed, and holds the PKI -- nothing to rehydrate"
                 exit 0
+            fi
+            # Everything below reasons about a node with NO PKI mount, and ends
+            # in advice to destroy it. Only a clean 404 (rc 2) means that. rc 1
+            # is unreachable, sealed, a non-2xx, or an issuer under a DIFFERENT
+            # root -- and that last one is a node holding the wrong lineage's
+            # data, which the destroy advice below would discard along with the
+            # pre-destroy snapshot. Stop here and say which it was instead.
+            if [ "$_idem_rc" -ne 2 ]; then
+                log_message "ERROR" "OpenBao is initialized and unsealed, but the PKI check failed for a reason that"
+                log_message "ERROR" "is NOT a missing mount -- see the line above. Do NOT read this as an empty node:"
+                log_message "ERROR" "an issuer under a different root means this node holds data, just not this"
+                log_message "ERROR" "lineage's. Resolve that before destroying anything."
+                exit 1
             fi
             # No PKI. Two very different situations look identical from here,
             # and the BUCKET is what separates them:
@@ -1204,7 +1236,21 @@ rehydrate_openbao() {
     # past this point means the snapshot predates it -- not that anything failed.
     # Saying "exit 1" and nothing else is what fed the next deploy into the
     # 200-with-no-PKI branch above, whose advice destroys the node.
-    if ! verify_pki_present; then
+    #
+    # Only a 404 (rc 2) is tolerable here. rc 1 covers "the issuer does not
+    # chain to this lineage's root", and the stored root token would happily
+    # authenticate to such a node -- the token store restored fine, it is the
+    # ROOT that is wrong -- so testing the token alone would wave through a
+    # restore from the wrong lineage.
+    local _pki_rc=0
+    verify_pki_present || _pki_rc=$?
+    if [ "$_pki_rc" -eq 1 ]; then
+        log_message "ERROR" "Restore reported success, but the PKI check failed for a reason that is NOT a"
+        log_message "ERROR" "missing mount -- see the line above. An issuer under a different root, an"
+        log_message "ERROR" "unreachable or sealed node: none of those are 'the snapshot predates the PKI'."
+        exit 1
+    fi
+    if [ "$_pki_rc" -eq 2 ]; then
         if stored_root_token_works; then
             log_message "WARN" "Restore SUCCEEDED, but the snapshot carries no PKI mount: ${SNAPSHOT_BUCKET}'s"
             log_message "WARN" "newest object predates it. The lineage's root token authenticates, so this node"

--- a/scripts/test-no-secret-argv.sh
+++ b/scripts/test-no-secret-argv.sh
@@ -76,6 +76,14 @@ CRED_TOKENS="secret|password|passwd|token|credential|cookie|pat|apikey|privateke
 # Flags that put their VALUE on a cloud CLI's argv. Long forms only, and both
 # `--flag value` and `--flag=value` are matched -- the AWS CLI accepts either
 # and gcloud is written the second way by convention.
+# NOT here yet: `-otp` / `-decode`. `bao operator generate-root -decode <encoded>
+# -otp <otp>` is a local XOR, so both halves on one argv reconstruct the root
+# token for the life of the call (container-images/openbao-snapshot/
+# openbao-snapshot.sh, in generate_root_token). Adding them here flags it
+# correctly and there is no verified stdin form for either flag, so the fix has
+# to be designed rather than guessed. Latent today: generate-root/attempt returns
+# 405 on an auto-unsealed node, so the line is unreachable outside the Shamir/DR
+# path. Tracked, not forgotten.
 VALUE_FLAGS="--secret-string|--secret-binary|--value|--password"
 
 is_cred_shaped() { # $1: variable name
@@ -112,6 +120,13 @@ scan_dir_for_argv_leaks() {
 
         while IFS=: read -r lineno line; do
             [ -z "${lineno:-}" ] && continue
+            # An explicit, reasoned exemption. Same spirit as detect-secrets'
+            # `pragma: allowlist secret`, which this repo already uses: the
+            # escape exists so a true positive with no impact cannot make the
+            # gate permanently red, which is how gates get switched off. The
+            # reason belongs on the line.
+            case "$line" in *"argv-ok:"*) continue ;; esac
+
             # Skip comment lines -- a fix's own explanation quoting the old,
             # now-removed pattern verbatim as documentation is not a leak
             # (same convention this repo's other file-scoped argv-leak
@@ -137,6 +152,12 @@ scan_dir_for_argv_leaks() {
 
         while IFS=: read -r lineno line; do
             [ -z "${lineno:-}" ] && continue
+            # An explicit, reasoned exemption -- same spirit as detect-secrets'
+            # `pragma: allowlist secret`, which this repo already uses. It exists so a
+            # true positive with NO impact cannot make the gate permanently red, which
+            # is how gates get switched off. The reason belongs on the line itself.
+            case "$line" in *"argv-ok:"*) continue ;; esac
+
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
             while IFS= read -r hit; do
@@ -169,6 +190,12 @@ scan_dir_for_argv_leaks() {
         # a space or an `=`, so the quote is optional on both sides here.
         while IFS=: read -r lineno line; do
             [ -z "${lineno:-}" ] && continue
+            # An explicit, reasoned exemption -- same spirit as detect-secrets'
+            # `pragma: allowlist secret`, which this repo already uses. It exists so a
+            # true positive with NO impact cannot make the gate permanently red, which
+            # is how gates get switched off. The reason belongs on the line itself.
+            case "$line" in *"argv-ok:"*) continue ;; esac
+
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
             while IFS= read -r hit; do
@@ -183,7 +210,14 @@ scan_dir_for_argv_leaks() {
                 "(${VALUE_FLAGS})(=|[[:space:]]+)\"?\\\$\\{?[A-Za-z_][A-Za-z0-9_]*" \
                 <<< "$line")
         done < <(grep -nE -- "(${VALUE_FLAGS})(=|[[:space:]])" "$file")
-    done < <(find "$dir" -maxdepth 1 -name '*.sh' -print0 2>/dev/null; find "$dir/lib" -maxdepth 1 -name '*.sh' -print0 2>/dev/null)
+    # Scan roots matter as much as the patterns. Rooted at scripts/ alone, this
+    # guard never saw .github/workflows or the per-stack scripts under opentofu/,
+    # both of which handle credentials -- which is how an ID-token request header
+    # on curl's argv reached main unnoticed.
+    done < <(find "$dir" -maxdepth 1 -name '*.sh' -print0 2>/dev/null; \
+             find "$dir/lib" -maxdepth 1 -name '*.sh' -print0 2>/dev/null; \
+             find "$dir/../.github/workflows" -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \) -print0 2>/dev/null; \
+             find "$dir/../opentofu" -name '*.sh' -print0 2>/dev/null)
 
     return "$found"
 }

--- a/scripts/test-openbao-pki-verify.sh
+++ b/scripts/test-openbao-pki-verify.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC2329
+# (file-wide: OPENBAO_URL/VAULT_CACERT/HTTP_CODE/PEM_BODY are read, and curl()
+# and log_message() are called, only from the body of verify_pki_present(),
+# which is eval'd in from the script under test. Static analysis cannot see
+# across the eval and reports all of them as dead.)
+#
+# Contract tests for verify_pki_present()'s THREE return codes.
+#
+# WHY THIS EXISTS. The function used to answer 0 or 1, and two callers in
+# rehydrate_openbao() acted on "1" as though it meant "no PKI mount yet". It
+# does not. It also means unreachable, sealed, non-2xx, not-a-certificate, and
+# -- the one that matters -- an issuer that parses perfectly but chains to a
+# DIFFERENT root than this lineage's.
+#
+# That last case is a node full of the WRONG lineage's data, and it is invisible
+# to every other signal: the node is up, unsealed, serving a valid certificate,
+# and the lineage's stored root token authenticates against it, because the
+# token store restored fine and it is the ROOT that is wrong. A caller reading
+# "1" as "predates the PKI" waves it through; one reading it as "empty node"
+# advises destroying it with the pre-destroy snapshot suppressed. Opposite
+# directions, same missing distinction, both data loss.
+#
+# So 404 now returns 2 and everything else returns 1, and this suite pins that
+# down with REAL certificates rather than stubbed openssl -- the dangerous case
+# is precisely the one where the bytes are a valid certificate, so a stub that
+# says "valid" or "invalid" would be assuming the answer under test.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+fail=0
+check() { if [ "$2" = "$3" ]; then printf '  ok   %s\n' "$1"
+          else printf '  FAIL %s: expected %q got %q\n' "$1" "$2" "$3"; fail=1; fi }
+
+SRC="${OPENBAO_CONFIG_SCRIPT:-$HERE/openbao-config.sh}"
+body="$(sed -n '/^verify_pki_present() {/,/^}/p' "$SRC")"
+[ -n "$body" ] || {
+    echo "could not extract verify_pki_present() from $SRC" >&2
+    echo "(renamed or reformatted? this suite asserts nothing if it cannot find it)" >&2
+    exit 1
+}
+eval "$body"
+declare -f verify_pki_present >/dev/null || {
+    echo "verify_pki_present did not define after eval" >&2; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Two independent CAs, each with an intermediate. EC rather than RSA purely for
+# speed -- four keypairs on every CI run.
+mkca() { # mkca <prefix> <cn>
+    openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+        -keyout "$TMP/$1.key" -out "$TMP/$1.pem" -days 1 -subj "/CN=$2" \
+        -addext "basicConstraints=critical,CA:TRUE" >/dev/null 2>&1
+}
+mkint() { # mkint <prefix> <cn> <ca-prefix>
+    openssl req -new -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+        -keyout "$TMP/$1.key" -out "$TMP/$1.csr" -subj "/CN=$2" >/dev/null 2>&1
+    printf 'basicConstraints=critical,CA:TRUE\n' > "$TMP/$1.ext"
+    openssl x509 -req -in "$TMP/$1.csr" -CA "$TMP/$3.pem" -CAkey "$TMP/$3.key" \
+        -CAcreateserial -out "$TMP/$1.pem" -days 1 -extfile "$TMP/$1.ext" >/dev/null 2>&1
+}
+mkca  lineage_root "Lineage Root CA"
+mkint lineage_int  "Lineage Intermediate CA" lineage_root
+mkca  foreign_root "Some Other Root CA"
+mkint foreign_int  "Some Other Intermediate CA" foreign_root
+
+# Sanity: the fixtures themselves must behave, or every case below is vacuous.
+openssl verify -CAfile "$TMP/lineage_root.pem" "$TMP/lineage_int.pem" >/dev/null 2>&1 || {
+    echo "fixture broken: lineage intermediate does not verify against lineage root" >&2; exit 1; }
+openssl verify -CAfile "$TMP/lineage_root.pem" "$TMP/foreign_int.pem" >/dev/null 2>&1 && {
+    echo "fixture broken: foreign intermediate verifies against lineage root" >&2; exit 1; }
+
+log_message() { :; }
+OPENBAO_URL="https://bao.example.invalid:8200"
+
+# The function calls `curl ... -w '\n%{http_code}' <url>`, then splits the last
+# line off as the status. The stub reproduces exactly that shape.
+curl() { printf '%s\n%s\n' "${PEM_BODY-}" "${HTTP_CODE-}"; }
+
+run() { verify_pki_present; echo $?; }
+
+echo "== 200, issuer chains to this lineage's root"
+VAULT_CACERT="$TMP/lineage_root.pem"; HTTP_CODE=200; PEM_BODY="$(cat "$TMP/lineage_int.pem")"
+check "returns 0"                          0 "$(run)"
+
+echo "== 404, the mount is genuinely absent -- the only continuable failure"
+VAULT_CACERT="$TMP/lineage_root.pem"; HTTP_CODE=404; PEM_BODY=""
+check "returns 2, NOT 1"                   2 "$(run)"
+
+echo "== 200, a VALID issuer under a DIFFERENT root -- the wrong-lineage restore"
+# The case the split exists for. Everything looks healthy: node up, unsealed,
+# serving a well-formed CA certificate. Only the chain says otherwise, and the
+# stored root token would authenticate here quite happily.
+VAULT_CACERT="$TMP/lineage_root.pem"; HTTP_CODE=200; PEM_BODY="$(cat "$TMP/foreign_int.pem")"
+check "returns 1, NOT 2"                   1 "$(run)"
+
+echo "== 200, but the body is not a certificate"
+VAULT_CACERT="$TMP/lineage_root.pem"; HTTP_CODE=200; PEM_BODY="this is not a certificate"
+check "returns 1"                          1 "$(run)"
+
+echo "== unreachable: no status code at all"
+VAULT_CACERT="$TMP/lineage_root.pem"; HTTP_CODE=""; PEM_BODY=""
+check "returns 1"                          1 "$(run)"
+
+echo "== 503, a sealed or unhealthy node"
+VAULT_CACERT="$TMP/lineage_root.pem"; HTTP_CODE=503; PEM_BODY=""
+check "returns 1"                          1 "$(run)"
+
+echo "== 200 with no --ca-file: the chain check is skipped, not failed"
+# Deliberate: with nothing to verify against, "does it chain" has no answer.
+# The foreign intermediate is used to prove the skip is real rather than
+# accidentally passing.
+unset VAULT_CACERT; HTTP_CODE=200; PEM_BODY="$(cat "$TMP/foreign_int.pem")"
+check "returns 0"                          0 "$(run)"
+
+echo
+if [ "$fail" -eq 0 ]; then echo "all checks passed"; else echo "FAILURES"; fi
+exit "$fail"

--- a/scripts/test-openbao-root-token-probe.sh
+++ b/scripts/test-openbao-root-token-probe.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC2329
+# (file-wide, and for the same reason test-openbao-fallback-address.sh carries
+# the first of these: ROOT_TOKEN_SECRET_NAME/SECRET_PAYLOAD/SECRET_RC are read,
+# and secret_read() is called, only from the body of stored_root_token_works(),
+# which is eval'd in from the script under test. Static analysis cannot see
+# across the eval, so it reports every one of them as dead.)
+#
+# Offline tests for stored_root_token_works() in openbao-config.sh.
+#
+# WHY THIS EXISTS. Two branches now decide, from this one function's answer,
+# whether a deploy tells the operator "your node restored correctly, continue"
+# or "destroy the cluster with TM_OPENBAO_SKIP_SNAPSHOT=true". The second of
+# those discards every write since the restore and suppresses the pre-destroy
+# snapshot, so there is nothing to go back to. A wrong answer here is data loss,
+# and the two callers are only reachable on a real cluster in a state that takes
+# a full bootstrap to produce -- which is exactly how the bug these branches
+# replace shipped: the claim was asserted in prose and never executed.
+#
+# So the function is driven directly, offline. It is lifted out of the script
+# rather than restated (the technique the fallback-address and zitadel suites
+# use) so this tests the code that ships.
+#
+# The failure mode being guarded is asymmetric and the tests are weighted for
+# it: a FALSE POSITIVE -- claiming the lineage's token works when it does not --
+# waves through a genuinely stranded node, but a FALSE NEGATIVE sends a
+# correctly restored node to be destroyed. Every "must return 1" case below is
+# therefore a case where returning 0 would be the dangerous direction, and the
+# single "must return 0" case is pinned down to the exact argv and environment.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+fail=0
+check() { if [ "$2" = "$3" ]; then printf '  ok   %s\n' "$1"
+          else printf '  FAIL %s: expected %q got %q\n' "$1" "$2" "$3"; fail=1; fi }
+
+SRC="${OPENBAO_CONFIG_SCRIPT:-$HERE/openbao-config.sh}"
+body="$(sed -n '/^stored_root_token_works() {/,/^}/p' "$SRC")"
+[ -n "$body" ] || {
+    echo "could not extract stored_root_token_works() from $SRC" >&2
+    echo "(renamed or reformatted? this suite asserts nothing if it cannot find it)" >&2
+    exit 1
+}
+eval "$body"
+# An eval that silently produced no function would let every case below "pass".
+declare -f stored_root_token_works >/dev/null || {
+    echo "stored_root_token_works did not define after eval" >&2; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+# `bao` stub. Records the token it was handed IN THE ENVIRONMENT and its full
+# argv, so the success case can assert both what it received and what it did
+# not. Exits per $TMP/bao.rc, which each case sets.
+cat > "$TMP/bin/bao" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "${VAULT_TOKEN-<unset>}" > "$BAO_ENV_LOG"
+printf '%s\n' "$*" > "$BAO_ARGV_LOG"
+exit "$(cat "$BAO_RC")"
+STUB
+chmod +x "$TMP/bin/bao"
+export PATH="$TMP/bin:$PATH"
+export BAO_ENV_LOG="$TMP/bao.env" BAO_ARGV_LOG="$TMP/bao.argv" BAO_RC="$TMP/bao.rc"
+
+# Each case sets SECRET_PAYLOAD / SECRET_RC; secret_read replays them and
+# records that it ran, so "never called" is testable rather than assumed.
+secret_read() {
+    printf 'called\n' >> "$TMP/secret_read.calls"
+    [ "${SECRET_RC:-0}" = 0 ] || return "${SECRET_RC}"
+    printf '%s' "${SECRET_PAYLOAD-}"
+}
+
+reset() {
+    : > "$TMP/secret_read.calls"; rm -f "$TMP/bao.env" "$TMP/bao.argv"
+    echo 0 > "$BAO_RC"
+    ROOT_TOKEN_SECRET_NAME="openbao/cloud-native-ref/root-token"  # pragma: allowlist secret
+    SECRET_PAYLOAD=''; SECRET_RC=0
+}
+run() { stored_root_token_works; echo $?; }
+calls() { wc -l < "$TMP/secret_read.calls" | tr -d ' '; }
+
+echo "== the secret name is unset: refuse without calling anything"
+reset; ROOT_TOKEN_SECRET_NAME=""
+check "returns 1"                    1 "$(run)"
+check "secret_read never called"     0 "$(calls)"
+check "bao never invoked"            "absent" "$([ -f "$TMP/bao.argv" ] && echo present || echo absent)"
+
+echo "== the secret cannot be read (deleted, denied, wrong region)"
+reset; SECRET_RC=1
+check "returns 1"                    1 "$(run)"
+check "bao never invoked"            "absent" "$([ -f "$TMP/bao.argv" ] && echo present || echo absent)"
+
+echo "== the secret is not JSON"
+reset; SECRET_PAYLOAD='not-json-at-all'  # pragma: allowlist secret
+check "returns 1"                    1 "$(run)"
+check "bao never invoked"            "absent" "$([ -f "$TMP/bao.argv" ] && echo present || echo absent)"
+
+echo "== the secret is JSON but carries no .token key"
+reset; SECRET_PAYLOAD='{"recovery_keys":["a","b"]}'
+check "returns 1"                    1 "$(run)"
+check "bao never invoked"            "absent" "$([ -f "$TMP/bao.argv" ] && echo present || echo absent)"
+
+echo "== .token is present but empty"
+reset; SECRET_PAYLOAD='{"token":""}'
+check "returns 1"                    1 "$(run)"
+check "bao never invoked"            "absent" "$([ -f "$TMP/bao.argv" ] && echo present || echo absent)"
+
+echo "== .token is JSON null"
+reset; SECRET_PAYLOAD='{"token":null}'
+check "returns 1"                    1 "$(run)"
+check "bao never invoked"            "absent" "$([ -f "$TMP/bao.argv" ] && echo present || echo absent)"
+
+echo "== a real token the node REJECTS -- the genuinely stranded node"
+reset; SECRET_PAYLOAD='{"token":"hvs.stale"}'; echo 2 > "$BAO_RC"  # pragma: allowlist secret
+check "returns 1"                    1 "$(run)"
+check "bao was actually consulted"   "token lookup" "$(cat "$TMP/bao.argv")"
+
+echo "== a real token the node ACCEPTS -- restored, snapshot predates the PKI"
+reset; SECRET_PAYLOAD='{"token":"hvs.good"}'  # pragma: allowlist secret
+check "returns 0"                    0 "$(run)"
+check "secret_read called once"      1 "$(calls)"
+check "bao token lookup, nothing more" "token lookup" "$(cat "$TMP/bao.argv")"
+check "token reached bao by ENV"     "hvs.good" "$(cat "$TMP/bao.env")"
+
+echo "== the token never lands on bao's argv"
+# Same class of leak scripts/test-no-secret-argv.sh guards repo-wide: anything
+# on argv is readable via /proc/<pid>/cmdline by any process on the box for as
+# long as the command runs. VAULT_TOKEN= as a command prefix keeps it in the
+# environment, which is per-process.
+reset; SECRET_PAYLOAD='{"token":"hvs.secret-value"}'  # pragma: allowlist secret
+run > /dev/null
+check "argv carries no token"        "clean" \
+    "$(grep -q 'hvs.secret-value' "$TMP/bao.argv" && echo LEAKED || echo clean)"
+
+echo "== the caller's VAULT_TOKEN is not clobbered"
+# Both callers run mid-deploy; a probe that exported VAULT_TOKEN would silently
+# re-authenticate everything after it as root.
+reset; SECRET_PAYLOAD='{"token":"hvs.probe"}'  # pragma: allowlist secret
+VAULT_TOKEN="hvs.caller"  # pragma: allowlist secret
+run > /dev/null
+check "VAULT_TOKEN unchanged after"  "hvs.caller" "${VAULT_TOKEN}"
+
+echo
+if [ "$fail" -eq 0 ]; then echo "all checks passed"; else echo "FAILURES"; fi
+exit "$fail"

--- a/scripts/test-openbao-snapshot-key.sh
+++ b/scripts/test-openbao-snapshot-key.sh
@@ -34,6 +34,18 @@ contains() {
     if printf '%s' "$2" | grep -qF -- "$3"; then printf '  ok   %s\n' "$1"
     else printf '  FAIL %s: %q not found in output\n' "$1" "$3"; fail=1; fi
 }
+absent() {
+    if printf '%s' "$2" | grep -qF -- "$3"; then printf '  FAIL %s: %q unexpectedly present\n' "$1" "$3"; fail=1
+    else printf '  ok   %s\n' "$1"; fi
+}
+
+# A missing helper printed "command not found", left `fail` untouched, and the
+# suite reported "all checks passed" with an assertion that never ran. An ERR
+# trap is the wrong guard here -- this suite deliberately runs commands that
+# return non-zero -- so assert the harness itself is complete instead.
+for _h in check contains absent; do
+    declare -F "$_h" >/dev/null || { echo "harness incomplete: $_h() is not defined" >&2; exit 2; }
+done
 
 SRC="${OPENBAO_SNAPSHOT_SCRIPT:-$HERE/openbao-snapshot.sh}"
 body="$(sed -n '/^select_snapshot() {/,/^}/p' "$SRC")"
@@ -108,6 +120,38 @@ check "returns the only object" "$NEWEST" "$out"
 SNAPSHOT_KEY="$NEWEST"
 out=$(select_snapshot "$NEWEST" 2>/dev/null)
 check "named, and it is also the newest" "$NEWEST" "$out"
+
+echo
+echo "== THE GATE: a named key must never be silently replaced (regression, F1)"
+# select_snapshot() alone could not catch this. The gate runs AFTER it, and under
+# OPENBAO_SNAPSHOT_SKIP_FOREIGN_SEAL=true it used to re-select `... | tail -n1`,
+# throwing the operator's named object away and restoring the NEWEST -- the exact
+# opposite of what naming one asks for. On a mixed-seal bucket, which is the only
+# state where the hatch is legitimate, the two features silently cancelled.
+gate_body="$(sed -n '/^foreign_seal_fallback() {/,/^}/p' "$SRC")"
+[ -n "$gate_body" ] || { echo "could not extract foreign_seal_fallback() from $SRC" >&2; exit 1; }
+eval "$gate_body"
+
+MIXED="2026-08-01T000000Z-gcpckms.snap
+2026-08-15T000000Z-awskms.snap
+2026-09-05T214320Z-awskms.snap"
+
+SNAPSHOT_KEY="2026-08-01T000000Z-gcpckms.snap"
+out=$(foreign_seal_fallback "$MIXED" awskms 2>/dev/null); rc=$?
+check "refuses when the named object is foreign-sealed" "1" "$rc"
+check "emits no substitute on stdout" "" "$out"
+stderr=$(foreign_seal_fallback "$MIXED" awskms 2>&1 >/dev/null)
+contains "names the object it will not substitute" "$stderr" "2026-08-01T000000Z-gcpckms.snap"
+contains "explains the newest is the opposite"     "$stderr" "opposite of what naming an"
+contains "lists what this node CAN unwrap"         "$stderr" "2026-08-15T000000Z-awskms.snap"
+absent   "does NOT quietly return the newest"      "$out"    "2026-09-05T214320Z-awskms.snap"
+
+echo
+echo "== the hatch still works when NO key was named"
+SNAPSHOT_KEY=""
+out=$(foreign_seal_fallback "$MIXED" awskms 2>/dev/null); rc=$?
+check "exit 0" "0" "$rc"
+check "returns the newest object this seal can unwrap" "2026-09-05T214320Z-awskms.snap" "$out"
 
 echo
 if [ "$fail" -eq 0 ]; then echo "all checks passed"; else echo "FAILURES"; fi

--- a/security/base/epis/openbao-snapshot.yaml
+++ b/security/base/epis/openbao-snapshot.yaml
@@ -51,18 +51,6 @@ spec:
             "Version": "2012-10-17",
             "Statement": [
                 {
-                    "Sid": "ReadPermissions",
-                    "Effect": "Allow",
-                    "Action": [
-                        "s3:GetObject",
-                        "s3:ListBucket"
-                    ],
-                    "Resource": [
-                        "arn:aws:s3:::${openbao_snapshot_bucket}",
-                        "arn:aws:s3:::${openbao_snapshot_bucket}/*"
-                    ]
-                },
-                {
                     "Sid": "WritePermissions",
                     "Effect": "Allow",
                     "Action": [

--- a/website/content/docs/decisions/0033-openbao-store-of-record-lineage.md
+++ b/website/content/docs/decisions/0033-openbao-store-of-record-lineage.md
@@ -3,7 +3,7 @@ title: OpenBao is the store of record, durable as a snapshot lineage, active on 
 linkTitle: 0033 · OpenBao lineage
 weight: 330
 description: OpenBao's storage becomes derived state rebuilt from its newest Raft snapshot on every boot; what persists is a lineage — one multi-region KMS seal key, five bootstrap secrets, a snapshot bucket. One instance becomes active on AWS and serves both clusters; a GCP standby restores the mirrored snapshot under the same AWS seal. Stage 1 is per-cloud; Stage 2 converges it. Chosen over per-cloud authoritative instances, an instance with no fallback, a Shamir-sealed standby, the clouds' managed CAs and cert-manager's CA issuer.
-lastVerified: 2026-09-02
+lastVerified: 2026-09-08
 ---
 
 **Status**: Accepted
@@ -156,10 +156,21 @@ failover — while leaving in place:
 
 So "one instance active on AWS serving both clusters" is the decision's end
 state, not Stage 1's. Stage 2 is what converges it: it repoints the
-`ClusterSecretStore` and migrates about 36 secrets, and it is also where `gcp-0`
+`ClusterSecretStore` and migrates about 20 secrets, and it is also where `gcp-0`
 switches to the remote endpoint form and stops being authoritative for itself.
 Until then the two clouds run the same design twice, which is why the residual
 drift in the Negatives below is real rather than theoretical.
+
+That count is derivable rather than remembered, because it said "about 36" until
+2026-09-08 and nothing in the repo produced that figure. Recount it as: the
+distinct `remoteRef`/`dataFrom` keys across every committed `ExternalSecret`
+(19, in 25 manifests, all against `clustersecretstore`), **minus** the two
+CA-chain entries — `certificates/<domain>/ca-chain` and
+`openbao-priv-gcp-ca-chain` — which have to stay in the cloud store, since
+nothing can fetch OpenBao's own CA *from* OpenBao. Add the few an `App` or
+`SQLInstance` claim renders and it lands around 20. It is a Stage 2 planning
+number, so being out by 16 is the difference between a session's work and a
+project.
 
 ## Consequences
 

--- a/website/content/docs/platform/security/openbao.md
+++ b/website/content/docs/platform/security/openbao.md
@@ -189,7 +189,7 @@ path "sys/storage/raft/snapshot" {
 
 # The freshness marker (mounts.tf, `lineage/`). kv-v2 puts data under /data/.
 path "lineage/data/check_timestamp" {
-  capabilities = ["create", "update", "read"]
+  capabilities = ["create", "update"]
 }
 ```
 
@@ -269,8 +269,11 @@ kubectl create job --namespace security --from=cronjob/openbao-snapshot manual-o
 **Restore.** `scripts/openbao-snapshot.sh` (`restore` subcommand) fetches
 the newest snapshot from the bucket, authenticates — a supplied `VAULT_TOKEN`
 wins, otherwise it mints a temporary root token from the recovery key —
-restores, mints a *second* root token (a Raft restore replaces the token store,
-so the first one no longer exists), and checks `lineage/check_timestamp`.
+restores, then reads the lineage's **stored** root token from
+`ROOT_TOKEN_SECRET_ID` — a Raft restore replaces the token store, so the
+snapshot's own root token is the valid one again by construction — and checks
+`lineage/check_timestamp`. It falls back to minting one only when that variable
+is unset, and that fallback cannot succeed on an auto-unsealed node (405).
 
 That check is an **alarm, not a gate**. The marker lives inside the snapshot,
 so it can only be read once the restore has already been applied: it reports
@@ -286,8 +289,15 @@ exported here, not assumed left over from the Operator Login section above:
 ```bash
 export VAULT_ADDR="https://bao.priv.aws.ogenki.io:8200"
 export VAULT_CACERT=opentofu/aws/openbao/management/.tls/ca.pem
-export VAULT_TOKEN=...   # admin or root; the script also accepts a JWT or AppRole
+export VAULT_TOKEN=...   # the ROOT token. `admin` cannot restore: neither
+                         # admin.hcl nor pki-admin.hcl grants sys/storage/raft/*
 export RECOVERY_KEYS_SECRET_ID="openbao/cloud-native-ref/tokens/recovery"
+# REQUIRED. Without it the post-restore step falls through to
+# `bao operator generate-root -init`, which returns 405 on an auto-unsealed
+# node -- every node in this design -- and the run dies under `set -e` with the
+# Raft restore ALREADY APPLIED. `rehydrate` works only because
+# scripts/openbao-config.sh passes this for you.
+export ROOT_TOKEN_SECRET_ID="openbao/cloud-native-ref/tokens/root"
 ./scripts/openbao-snapshot.sh restore -a "${VAULT_ADDR}" \
   -b eu-west-3-ogenki-openbao-snapshot -s /tmp/bao.snap -d 8
 ```
@@ -298,12 +308,22 @@ export RECOVERY_KEYS_SECRET_ID="openbao/cloud-native-ref/tokens/recovery"
 That default is right for the case this platform runs nightly — destroyed and
 rebuilt from its own newest backup — and it cannot express the other one:
 *today's value is wrong, give me yesterday's*. The bucket is versioned and keeps
-120 days precisely so that is possible.
+120 days.
+
+{{< callout type="warning" >}}
+**Only about the first 30 days are directly restorable.**
+`opentofu/aws/openbao/lineage/s3.tf` transitions objects to **GLACIER** at 30
+days, and `aws s3 cp` on one fails `InvalidObjectState` — it has to be restored
+out of Glacier first, which takes hours. The 120 days is retention, not reach.
+Add `StorageClass` to the listing below before choosing an old object, and note
+that the `-d 8` in the example also fails anything older than 8 days under the
+default `--freshness fail`.
+{{< /callout >}}
 
 ```bash
 # What is there, oldest first
 aws s3api list-objects-v2 --bucket eu-west-3-ogenki-openbao-snapshot \
-  --query 'sort_by(Contents,&LastModified)[].[Key,LastModified]' --output text
+  --query 'sort_by(Contents,&LastModified)[].[Key,LastModified,StorageClass]' --output text
 
 export OPENBAO_SNAPSHOT_KEY="2026-09-05T092947Z-awskms.snap"
 ./scripts/openbao-snapshot.sh restore -a "${VAULT_ADDR}" \

--- a/website/content/docs/platform/security/pki-and-secrets.md
+++ b/website/content/docs/platform/security/pki-and-secrets.md
@@ -1,8 +1,8 @@
 ---
 title: PKI & Secrets
 weight: 20
-description: The three-tier PKI chain OpenBao issues from, how cert-manager and External Secrets pull from it, and how the chain rotates. One offline root for both clouds is the target; on AWS the ceremony has not run yet.
-lastVerified: 2026-09-02
+description: The three-tier PKI chain OpenBao issues from, how cert-manager and External Secrets pull from it, and how the chain rotates. One offline root signs both clouds' intermediates; its private key has never been in either cloud.
+lastVerified: 2026-09-08
 ---
 
 Every internal TLS certificate on this platform — Gateway API listeners,
@@ -23,36 +23,29 @@ Intermediate is what OpenBao's `pki_private_issuer` mount imports as its
 signing certificate and uses to issue every leaf, which keeps
 revocation/rotation scoped to the tier that actually changed.
 
-{{< callout type="warning" >}}
-**The AWS root CA private key has not been taken offline yet.** It is present in
-the AWS `pki_private_issuer` mount as this platform last deployed it — imported
-there inside a bundle from `certificates/priv.aws.ogenki.io/root-ca`, a secret
-that still exists. This is an accepted trade-off **for this reference
-platform**; do not carry it into a deployment where the root CA matters.
+{{< callout type="info" >}}
+**The signing ceremony has run on both clouds.** One offline root now signs both
+intermediates, and its private key has never been in either cloud.
 
-**On GCP it already is offline.** The 2026-08-25 ceremony signed
-`openbao-priv-gcp-intermediate-ca` under a root whose private key never entered
-GCP (`docs/gcp-bootstrap.md`, *What is NOT a prerequisite*).
+What that means concretely, and how to check it rather than take it on trust:
 
-`opentofu/aws/openbao/management/pki.tf` is already written for the offline
-shape — it imports an intermediate bundle as the mount's issuer and generates
-nothing inside OpenBao — but the secret it reads does not exist yet. Two
-hand-performed steps close the gap, both documented below, and **neither has run
-on AWS**:
+- `.github/openbao-root-ca.pem` holds the root **certificate** and nothing else —
+  `openssl x509 -in .github/openbao-root-ca.pem -noout -subject` prints
+  `CN=Ogenki Root CA`, and the file carries no private key.
+- `certificates/priv.aws.ogenki.io/root-ca`, the entry that used to carry the
+  root **key**, has been deleted. `pki.tf` reads the *intermediate* bundle.
+- The [weekly restore drill](https://github.com/Smana/cloud-native-ref/actions/workflows/openbao-restore-drill.yml)
+  verifies the **AWS** issuer against that committed root on every run — under
+  `set -euo pipefail` with no `continue-on-error`, so a chain that does not
+  verify fails the job.
+- The **GCP** intermediate came out of the same 2026-08-25 ceremony, under the
+  same root: the committed certificate's `notBefore` is `Aug 24 21:58:25 2026`.
+  Nothing re-checks that continuously the way the drill does for AWS — to
+  confirm it by hand, chain `openbao-priv-gcp-ca-chain` against the same file.
 
-| Step | What it does | Where |
-|---|---|---|
-| The signing ceremony | Signs an AWS intermediate under the offline root, issues a new server certificate, and stores both — then commits the root *certificate* as `openbao-root-ca.pem` in `.github/`, which does not exist until this runs | [Building the chain](#building-the-chain), [Storing the chain](#storing-the-chain), [Committing the root certificate](#committing-the-root-certificate) |
-| Retiring the old root | Deletes `certificates/priv.aws.ogenki.io/root-ca` — one `aws secretsmanager delete-secret`, and only once the new chain has issued a certificate. Nothing reads that secret after the ceremony: `pki.tf` reads the intermediate | — |
-
-Until both are done, read every "one offline root for both clouds" statement
-below as what the ceremony produces, not as the current state. The AWS root and
-the GCP root are also not yet the same root — signing the AWS intermediate with
-the key the GCP ceremony produced is the step that makes them one.
-
-If you are standing this platform up yourself, none of this is a caveat: you
-perform the ceremony once, before the first deploy, and start from the offline
-shape.
+The sections below are the ceremony as performed, kept because it has to be
+repeated when the intermediate expires and because anyone standing this platform
+up performs it once before the first deploy.
 {{< /callout >}}
 
 ### Building the chain


### PR DESCRIPTION
A complete review of the OpenBao lineage change (#1960, 212 files) plus this session's follow-ups, across security, script correctness and doc accuracy. Every finding acted on below was re-verified against the code first — one reviewer had a separate finding inverted and caught it themselves, which is why.

**Both validators pass and cover none of this.** `validate-doc-claims.sh` 24/24 across 43 page checks, `validate-links.sh` 0 broken. They only check the claims someone remembered to pin.

---

## The dangerous one: a documented restore that strands the node

`openbao.md`'s operator restore block calls itself *"self-contained — every variable the script needs is exported here"* and **omits `ROOT_TOKEN_SECRET_ID`**.

Without it, `restore()` takes the `else` branch into `generate_root_token()` → `bao operator generate-root -init`, which the script's **own comment** records as returning 405 on every auto-unsealed node — every node in this design. Under `set -e` the run dies **with the Raft restore already applied**. `rehydrate` works only because `openbao-config.sh` passes the variable for you.

The same block said `# admin or root`. Verified: neither `admin.hcl` nor `pki-admin.hcl` grants `sys/storage/raft/*` — zero matches — so an admin token reaches `snapshot restore -force` and is denied.

## Glacier caps the feature documented three commits ago

The `OPENBAO_SNAPSHOT_KEY` section invited operators into the bucket's 120-day retention. `s3.tf` transitions objects to **GLACIER at 30 days**, so `aws s3 cp` past that fails `InvalidObjectState`. **Retention is not reach.** Now a warning callout, `StorageClass` in the listing, and a note that the example's `-d 8` also fails anything older than 8 days.

## Rehydrate gated one object and restored another

The parent gates `latest_snapshot()`; the child re-lists and honours `OPENBAO_SNAPSHOT_KEY`, which `openbao-config.sh` had never heard of.

| | |
|---|---|
| key exported, foreign-sealed | parent's gate passes on the newest → `bao operator init` runs (**irreversible**) → child refuses → node stranded by a gate looking at a different object |
| key set, not exported | ignored by both; the point-in-time request becomes a silent no-op |

That second shape is *verbatim* the hazard the adjacent line already guards for `SKIP_FOREIGN_SEAL`, in a comment explaining why explicit forwarding matters. The key now rides along the same way, and the parent gates the **named** object.

## The foreign-seal hatch discarded the operator's named snapshot

Reproduced against the two lines verbatim:

```
bucket   2026-08-01T000000Z-gcpckms.snap   ← operator names this
         2026-09-05T214320Z-awskms.snap
restored 2026-09-05T214320Z-awskms.snap    ← the newest
```

The option exists for *"give me yesterday's"* and restored **today's**. The refusal one branch up *advises* setting that flag, and a mixed-seal bucket is the only state where the hatch is legitimate — so on exactly the buckets it was written for, the hatch and point-in-time restore silently cancelled.

**Fixed by refusing, not substituting.** The softer option (newest-not-newer-than-named) was considered and rejected: it still answers a question nobody asked.

## Smaller, still real

- **An empty snapshot uploaded cleanly**, became the lineage's newest object, and left `OpenBaoSnapshotStale` green. Guarded, both clouds. (The precondition — `bao` exiting 0 with a bad artefact — is unproven; the guard is two lines.)
- **The argv guard was pointed at one directory.** Widening it found a live `ACTIONS_ID_TOKEN_REQUEST_TOKEN` on curl's argv in the drill workflow (fixed with the `-K` pattern) and an IMDSv2 token in a startup script (exempted — anyone who can read argv there can mint their own).
- **An unused read grant** on the snapshot pod, and **a leaf-certificate pin** the sibling file had deliberately removed.
- A stale comment left by #1996, and a gate message labelling the *selected* object "newest object".

## Test gaps the fixes close

- `test-openbao-snapshot-key.sh` exercised `select_snapshot()` alone, single-seal, and **never the gate that runs after** — which is why F1 shipped. The gate is now a function and the suite drives it.
- That suite used `absent()` without defining it: bash printed "command not found", left `fail` untouched, and it reported **"all checks passed" with an assertion that never ran**. Added, plus an up-front helper-existence check. (An `ERR` trap was tried and reverted — this suite deliberately runs failing commands.)

## The one that came out of fixing the others

Writing tests for the fix above surfaced a defect **it had introduced**.
`verify_pki_present()` answered 0 or 1, and 1 covered five different situations —
unreachable, sealed, non-2xx, not-a-certificate, and **an issuer that parses
perfectly but chains to a different root**. The new tolerant branch read all five as
"the snapshot predates the PKI, carry on".

That fifth case is a node holding the **wrong lineage's data**, and it is invisible to
every other signal: up, unsealed, serving a well-formed CA certificate, and the stored
root token authenticates against it — the token store restored fine, it is the *root*
that is wrong.

The older caller had the mirror-image bug, and it predates this branch: any failure fell
through to the logic ending in *"destroy and redeploy with
`TM_OPENBAO_SKIP_SNAPSHOT=true`"*. For a wrong-root node that discards real data along
with the pre-destroy snapshot. Same missing distinction, opposite direction.

Now three outcomes — `0` present-and-chains, `2` a clean 404 (**the only** failure a
caller may continue past), `1` everything else — and both callers act on it.

## Docs that describe a platform the code left behind

`opentofu/aws/openbao/cluster/README.md`, which `foundations/aws.md:126` sends readers to
"for the operational detail", carried three false claims:

| It said | The code |
|---|---|
| `on_demand_base_capacity = 0`, "every voter is interruptible" | `autoscaling_group.tf:210` sets **3**; the comment above records the 2026-08-19 `InsufficientInstanceCapacity` failure that changed it |
| "Keep the Root CA offline. ⚠️ Not currently the case" | `management/README.md` — the file that line links to — says the opposite in a green callout |
| "the only identity is the root token… the `admin` policy is bound to nothing" | ZITADEL OIDC (`oidc.tf`, ADR-0034), userpass admin bound to `admin`+`pki-admin` (`auth.tf`), three JWT machine roles |

Believing the second is the expensive one: re-running the ceremony builds a chain under a
second root nothing trusts, succeeds quietly, and surfaces days later when the drill's
`openssl verify` fails.

The MFA bullet **keeps** its warning. A first draft marked it resolved because OIDC
exists; grepping `security/`, `opentofu/` and `scripts/` for MFA enforcement returns
nothing, so OIDC only moves MFA from an OpenBao question to a ZITADEL login-policy one and
nobody has set it. Trading a false warning for a false all-clear is not an improvement.

Each correction states what the line used to claim — these are security-posture statements
that were read and believed, and a silent flip leaves no way to tell which version someone
acted on. Same reason `pki.tf`'s header now carries a date and a re-check rather than an
assertion: it has now been wrong in *both* directions.

### Two more found by diffing the documented interface against the code

Not by reading for sense — by extracting every flag and env var each document
mentions and diffing it against every one the script reads. That found:

- **`container-images/openbao-snapshot/README.md` never learned about
  `OPENBAO_SNAPSHOT_KEY`.** It still said `restore` "selects the newest object" as
  though that were the whole rule. This is the README `openbao-config.sh` names in its
  error messages, so it is read mid-incident — and the one thing an operator may
  urgently need is *"yesterday's, not today's"*. Now documented, including the
  interaction that was a real bug rather than a footnote: the foreign-seal hatch
  **refusing** to combine with a named key, because "newest" is the exact opposite of
  what a named key asks for.
- **ADR-0033 sized Stage 2 at "about 36 secrets".** Counted from the repo: **19**
  distinct keys across the 25 committed `ExternalSecret`s, minus the two CA-chain
  entries that must stay in the cloud store — nothing can fetch OpenBao's own CA *from*
  OpenBao — plus the few a claim renders. **About 20.** Being out by 16 on the number
  Stage 2 gets planned against is the difference between a session and a project. The
  derivation now sits in the ADR, so the next reader recounts instead of trusting.

Checked and found **clean**: the env-gate polarity table (including the inverted
`TM_OPENBAO_SKIP_SNAPSHOT`), the failover guide's tofu outputs, tfvars names, bucket
names and replica region, the operator restore block's five required exports and both
secret names, and all 16 config-script flags.

## Tests, because these branches are unreachable without a full bootstrap

Two new suites, both offline, both wired into the CI job's **explicit** list — that list is
explicit because `test-no-secret-argv.sh` existed, worked, and was failing on two live
root-token leaks with nothing running it.

- **28 checks** across the root-token probe (21) and the PKI contract (7).
- The PKI suite generates **real throwaway CAs** rather than stubbing `openssl`: the case
  under test is one where the bytes *are* a valid certificate, so a stub answering
  valid/invalid would assume the answer.
- Mutation-checked — reverting the 404 split fails it with `expected 2 got 1`.

The probe suite immediately caught the function breaking its own documented contract
(returning `bao`'s raw exit code, not `1`). Fixed in the function, not papered over in the
test.

## Still needing your call — not silently skipped

- **Environment-scoping the AWS drill role.** Needs an `openbao-drill` GitHub environment
  to exist first; `gh api …/environments` returns only `github-pages` and no stack manages
  environments. Changing the trust ahead of that **breaks the drill**. The GCP half had no
  such dependency and is done here — with the coupling noted in the code, since scoping the
  drill later changes `sub` to `…:environment:<name>` and both clouds must move together.
- **A CloudTrail alarm on `openbao-standby-seal`** (expected steady-state count: zero).
  There is no trail, no CloudWatch alarm, and no CloudWatch→VictoriaMetrics path in the
  repo. It needs either a full trail→log-group→metric-filter→SNS pipeline or an exporter —
  new infrastructure with a cost and a notification-destination choice, which by this
  repo's own rule wants an ADR.

## Verification

Five OpenBao suites (two new) + the full 13-suite CI loop pass · `validate-manifests.sh` all gates
passed, **Valid: 2110, Invalid: 0, Skipped: 0** · `validate-doc-claims.sh` 24/24 across 43
page checks · `validate-links.sh` 0 broken · `tofu validate` clean · `trivy config` 0
misconfigurations · repo-wide `shellcheck -x -S warning` exit 0 · the drill workflow and
`ci.yaml` parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKVG4wKP2V7z4Ftnb1cNV6

