### PR TITLE
fix(secrets): image-gallery's role credential was the one cnpg entry seed did not cover

### DIFF
--- a/scripts/secret-store.sh
+++ b/scripts/secret-store.sh
@@ -443,6 +443,31 @@ GENERATABLE=(
     "cnpg${_cnpg_sep}xplane-zitadel${_cnpg_sep}superuser"
 )
 
+# image-gallery's role credential, AWS-ONLY -- appended rather than listed above
+# because it is the one entry here that does not exist on both clouds.
+#
+# apps/base/complete is deliberately absent from apps/gcp-0/kustomization.yaml:
+# the application talks to S3 through an S3 SDK with the bucket hardcoded in its
+# container environment, so gcp-0 has no image-gallery, no SQLInstance for it,
+# and no ExternalSecret reading this key. Listing it unconditionally would make
+# `seed --cloud gcp` create a secret that cloud can never consume -- a paid,
+# permanently-unread entry, and a misleading one for anyone auditing the store.
+#
+# It belongs here for exactly the reason the comment above GENERATABLE gives for
+# the other two cnpg entries: they are "seeded here so a rebuild does not depend
+# on someone remembering". This one was not, so it did. Nothing in this
+# repository creates it -- the SQLInstance Composition only ASKS for it -- so if
+# it were ever lost, a rebuild would fail the way that comment describes, naming
+# neither the key nor the cause: External Secrets reporting `could not get
+# secret data from provider` while the pod sits in CreateContainerConfigError
+# naming a Kubernetes Secret.
+#
+# `if`, not `[ ... ] && ...`: under `set -o errexit` a trailing && test that
+# evaluates false makes the whole script exit here, on GCP, before doing anything.
+if [ "$CLOUD" = "aws" ]; then
+    GENERATABLE+=( "cnpg/xplane-image-gallery/roles/image-gallery-app" )
+fi
+
 # 32 bytes of urandom, base64, punctuation removed so no consumer has to worry
 # about quoting it in a connection string or an env file.
 # No trailing `head` in the pipeline. `tr` reading /dev/urandom never ends on
@@ -490,6 +515,20 @@ seed_body() {
             # Must match spec.roles[].name on the claim: CNPG creates the role
             # under that name and Harbor connects as it.
             printf '%s' "$(gen_password)" | jq -Rs '{username: "harbor", password: .}' ;;
+        cnpg?xplane-image-gallery?roles?image-gallery-app)
+            # Same shape as harbor above, and the username is again load-bearing:
+            # `image-gallery-app` is spec.sqlInstance.roles[].name in
+            # apps/base/complete/app.yaml, and also the `owner` of the
+            # image-gallery database there.
+            #
+            # GENERATED, not derived -- unlike the zitadel arm below, this
+            # credential has exactly one owner. The claim carries `backup` but no
+            # `recovery`, so the database is always created fresh and a new
+            # password each rebuild is correct rather than merely tolerable.
+            # (The zitadel arm's ORDER MATTERS warning still applies: CNPG sets
+            # the role password when it CREATES the cluster, so seed before the
+            # claim reconciles.)
+            printf '%s' "$(gen_password)" | jq -Rs '{username: "image-gallery-app", password: .}' ;;
         cnpg?xplane-zitadel?superuser)
             # DERIVED, not generated -- the one arm here that reads rather than
             # rolls, and the reason is that this credential has two owners.


### PR DESCRIPTION
`cnpg/xplane-image-gallery/roles/image-gallery-app` is a credential the platform **needs** and **cannot recreate**. It is now seedable.

## How it surfaced

Cleaning up unused Secrets Manager entries, this one looked orphaned: nothing in this repository references it. Two checks said otherwise.

`LastAccessedDate` reported it **read on every day the platform ran** — while the two genuinely dead entries (`apps/outline/*`) showed a last read of 2026-07-18.

The reason a grep finds nothing is that the `SQLInstance` Composition only **asks** for the key — it renders the `ExternalSecret`, and it lives in [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration). A scan of this repo structurally cannot see it. It came within one command of being deleted.

## Why it belongs in `GENERATABLE`

The comment above that array says the cnpg entries are *"seeded here so a rebuild does not depend on someone remembering"*. This one was not, so it did — and the failure it would produce is the one recorded right above it, naming neither the key nor the cause:

> External Secrets says `could not get secret data from provider` while harbor-core sits in `CreateContainerConfigError` naming a Kubernetes Secret.

## Two decisions in the patch

**AWS-only, appended rather than listed inline.** `apps/base/complete` is deliberately absent from `apps/gcp-0/kustomization.yaml` — image-gallery talks to S3 through an S3 SDK with the bucket hardcoded in its container environment — so `gcp-0` has no image-gallery, no SQLInstance for it, and no ExternalSecret reading this key. Listing it unconditionally would make `seed --cloud gcp` create a paid, permanently-unread entry, and mislead anyone auditing that store.

**Generated, not derived.** Unlike the zitadel arm, this credential has one owner, and the claim carries `backup` but no `recovery` — the database is always created fresh, so a new password per rebuild is correct rather than merely tolerable. The username is load-bearing exactly as harbor's is: `image-gallery-app` is both `spec.sqlInstance.roles[].name` and the `owner` of the database, and the ExternalSecret reads `property: username` as well as `password`.

`if`, not a trailing `&&` test — under `set -o errexit` an `&&` that evaluates false exits the script at that line, on GCP, before doing anything.

## Verification

12 offline checks over both new paths: the glob arm selects on both cloud spellings and leaves the harbor and zitadel arms untouched; the list gains the entry for `aws` (6 names) and not for `gcp` (5). `test-secret-store-lint.sh` passed 15 failed 0 · `test-no-secret-argv.sh` clean · repo-wide `shellcheck -x -S warning` exit 0 · `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKVG4wKP2V7z4Ftnb1cNV6
