### PR TITLE
feat(headlamp): load the App view plugin and link the wizard to it

### DIFF
--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -38,7 +38,7 @@ spec:
     # Bump to the newest release tag. Do NOT use `v0.2` or `latest` — those float
     # by design and would let a reconcile change what is deployed.
     repository: ghcr.io/smana/app-wizard
-    tag: "v0.2.2"
+    tag: "v0.3.0"
     pullPolicy: IfNotPresent
 
   # Single stateless replica — the wizard holds no persistent state (sessions

--- a/apps/platform/app-wizard/wizard.yaml
+++ b/apps/platform/app-wizard/wizard.yaml
@@ -55,3 +55,23 @@ assists:
 auth:
   mode: github
   redirectUrl: https://app-wizard.priv.aws.ogenki.io/api/auth/callback
+
+# External links shown on each card in "My apps" (file-only; there is no
+# environment override, like branding.theme). The URL is a template over
+# {namespace}, {name} and {stack}, expanded in the browser and opened in a new
+# tab. An unknown placeholder or an unbalanced brace fails startup, naming the
+# entry — a link typo is meant to fail here rather than surface as a dead link
+# on click.
+#
+# One entry per cluster rather than a templated hostname: a placeholder is only
+# usable in the path, query or fragment, because its value is URL-encoded when
+# expanded and that would not protect a host. Both clusters run the platform
+# and demo stacks, so an app can exist on either and the card offers both.
+#
+# The wizard holds no cluster credentials. It builds the link from the app's
+# own namespace and name; everything live is Headlamp's side (ADR-0035).
+links:
+  - label: Headlamp (aws-0)
+    url: https://headlamp.priv.aws.ogenki.io/c/main/apps/{namespace}/{name}
+  - label: Headlamp (gcp-0)
+    url: https://headlamp.priv.gcp.ogenki.io/c/main/apps/{namespace}/{name}

--- a/container-images/headlamp-plugin-app/README.md
+++ b/container-images/headlamp-plugin-app/README.md
@@ -31,13 +31,12 @@ The links section reads an optional ConfigMap `headlamp-plugin-app` in the
 `{"label": "...", "url": "..."}` whose URL may use `{namespace}` and `{name}`.
 Absent or unreadable ⇒ the links section is hidden.
 
-**Not wired up yet.** This repo has no
-`tooling/base/headlamp/configmap-plugin-app.yaml`, and the plugin isn't loaded
-into a running Headlamp at all yet either — see the platform's GitOps page and
-ADR-0035 for the current deployment state. A later change adds that ConfigMap,
-rendered with `${private_domain_name}` substituted per cluster by Flux,
-alongside the init container wiring; until then the links section always
-renders hidden.
+It is rendered from `tooling/base/headlamp/configmap-plugin-app.yaml`, with
+`${private_domain_name}` substituted per cluster by Flux.
+
+A literal brace in one of those URLs must be percent-encoded as `%7B` / `%7D`:
+a bare brace is read as a placeholder, a malformed one fails the plugin's own
+parsing, and an encoded pair is passed through untouched rather than expanded.
 
 ## Development
 

--- a/tooling/base/headlamp/configmap-plugin-app.yaml
+++ b/tooling/base/headlamp/configmap-plugin-app.yaml
@@ -1,0 +1,34 @@
+# Jump-off links rendered by headlamp-plugin-app on an App's page. Optional by
+# design: the plugin hides the section when this ConfigMap is absent or the
+# viewer cannot read it, so a cluster without it loses nothing else.
+#
+# JSON rather than YAML because a ConfigMap value is a string either way, and
+# JSON needs no parser in the plugin bundle. `{namespace}` and `{name}` are
+# substituted by the plugin per app; `${private_domain_name}` is substituted by
+# Flux per cluster, which is what lets one manifest serve both clouds.
+#
+# A literal brace must be percent-encoded as %7B / %7D — the plugin treats a
+# bare brace as a placeholder and rejects a malformed one, and does not expand
+# an encoded pair. That matters for the VictoriaLogs entry below, whose query
+# is a LogsQL stream selector wrapped in braces.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headlamp-plugin-app
+  namespace: tooling
+data:
+  links.json: |
+    [
+      {
+        "label": "Logs (VictoriaLogs)",
+        "url": "https://vl.${private_domain_name}/select/vmui/?#/?query=%7Bkubernetes.pod_namespace%3D%22{namespace}%22%2Ckubernetes.pod_name%3D~%22{name}.%2A%22%7D"
+      },
+      {
+        "label": "Dashboards (Grafana)",
+        "url": "https://grafana.${private_domain_name}/dashboards"
+      },
+      {
+        "label": "Source (GitHub)",
+        "url": "https://github.com/Smana/cloud-native-ref/search?q=path%3Aapps+filename%3Aapp.yaml+{name}"
+      }
+    ]

--- a/tooling/base/headlamp/helmrelease.yaml
+++ b/tooling/base/headlamp/helmrelease.yaml
@@ -98,6 +98,29 @@ spec:
           - mountPath: /build/plugins
             name: headlamp-plugins
 
+      # The App view (ADR-0035): a page per cloud.ogenki.io App claim, with a
+      # graph of exactly the resources that claim composed. Unlike the three
+      # above it is built in this repo, under container-images/headlamp-plugin-app;
+      # the tag comes from ARG HEADLAMP_PLUGIN_APP_VERSION in its Dockerfile.
+      #
+      # It needs the chart at 0.45.0 or later — that release is the first to
+      # export the resource map's graph renderer to plugins. The page degrades
+      # to a link rather than breaking on an older one, and .doc-claims.yaml
+      # pins the version claim so a rollback fails a check instead of silently
+      # dropping the graph.
+      - name: app-plugin
+        command:
+          - /bin/sh
+          - -c
+          - mkdir -p /build/plugins && cp -r /plugins/* /build/plugins/
+        image: ghcr.io/smana/headlamp-plugin-app:v0.1.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+          - mountPath: /build/plugins
+            name: headlamp-plugins
+
     resources:
       limits:
         memory: 256Mi

--- a/tooling/base/headlamp/kustomization.yaml
+++ b/tooling/base/headlamp/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: tooling
 resources:
+  - configmap-plugin-app.yaml
   - externalsecret-headlamp-envvars.yaml
   - helmrelease.yaml
   - httproute.yaml

--- a/website/content/docs/decisions/0035-own-headlamp-plugin-for-the-app-view.md
+++ b/website/content/docs/decisions/0035-own-headlamp-plugin-for-the-app-view.md
@@ -138,16 +138,11 @@ renderer itself is still reached through a runtime global, which is the one
 temporary shim here.
 
 Source in `container-images/headlamp-plugin-app/`, published by the repo's
-container-image workflow. The intended shape mirrors the Flux and cert-manager
-plugins already wired up: a fourth init container on the Headlamp HelmRelease
-loads it, and its jump-off links come from an optional ConfigMap in `tooling`,
-substituted per cluster by Flux.
-
-**Neither has landed yet.** The image builds, but nothing loads it into a
-running Headlamp, and the ConfigMap does not exist in this repo. Both arrive
-together in a later change — see the platform's GitOps page, which carries the
-same "not loaded yet" note as the one source of truth for deployment state
-rather than restating it as a fact here.
+container-image workflow and loaded by a fourth init container on the Headlamp
+HelmRelease, exactly like the Flux and cert-manager plugins. Its jump-off links
+come from an optional ConfigMap in `tooling`, substituted per cluster by Flux —
+optional because the plugin hides that section when the ConfigMap is absent or
+the viewer cannot read it, so a cluster without one loses nothing else.
 
 ---
 

--- a/website/content/docs/platform/developer-platform/app-wizard.md
+++ b/website/content/docs/platform/developer-platform/app-wizard.md
@@ -245,6 +245,27 @@ Stated rather than left to be discovered, in line with how the rest of the
 site records what it could not verify.
 {{< /callout >}}
 
+## From a card to the running app
+
+Once the pull request is merged and Flux has reconciled it, the app appears in
+**My apps** as a card. Each card carries an **Open** action pointing at
+Headlamp's App view for that app: its Ready and Synced conditions, a graph of
+exactly the resources the claim composed — the nested `SQLInstance` and its
+own children included — the pods, the events, and links onward to Grafana and
+VictoriaLogs.
+
+Both clusters run the `platform` and `demo` stacks, so an app can exist on
+either and the card offers one entry per cluster for you to pick from. The
+wizard itself never contacts a cluster: it builds the link from the app's
+namespace and name and opens it in a new tab. Everything live is Headlamp's
+side, under your own identity and your own RBAC.
+
+The links are configured in `apps/platform/app-wizard/wizard.yaml` under
+`links`, and validated when the wizard starts — a malformed placeholder stops
+it there rather than surfacing later as a link that goes nowhere. See
+[ADR-0035]({{< relref "/docs/decisions/0035-own-headlamp-plugin-for-the-app-view.md" >}})
+for why the view is a plugin this platform owns.
+
 ## Which should I use?
 
 - **New to the platform, or not sure what's available?** Use the

--- a/website/content/docs/platform/gitops/_index.md
+++ b/website/content/docs/platform/gitops/_index.md
@@ -482,10 +482,11 @@ the release that first exports the map's graph renderer to plugins, and which is
 what the HelmRelease pins. See
 [ADR-0035]({{< relref "/docs/decisions/0035-own-headlamp-plugin-for-the-app-view.md" >}}).
 
-**It is not loaded yet.** The plugin's source and its image build live here, but
-the init container that copies it into the running Headlamp, and the App Wizard
-links that open it, both land with a later change. Until then the plugin exists
-in the repository and not on the clusters.
+It is loaded by a fourth init container on the HelmRelease, the same way the
+other three are, and its jump-off links come from a ConfigMap in `tooling`
+rendered per cluster. An App Wizard card opens it directly: the wizard builds
+the URL from the app's own namespace and name and never contacts a cluster
+itself.
 
 The two differ in what they can show *per person*. The Flux UI impersonates on
 both clusters. Headlamp does on `aws-0`, where EKS is configured to trust


### PR DESCRIPTION
Turns the App view on. [#2005](https://github.com/Smana/cloud-native-ref/pull/2005) shipped the plugin's source, its image build and its record; this loads it and points the App Wizard at it.

## What changes

- **A fourth init container** on the Headlamp HelmRelease pinning `ghcr.io/smana/headlamp-plugin-app:v0.1.0`, alongside the three third-party plugins and shaped exactly like them.
- **`configmap-plugin-app.yaml`** — the plugin's jump-off links, with `${private_domain_name}` substituted per cluster so one manifest serves both clouds. Optional by design: the plugin hides that section when the ConfigMap is absent or the viewer cannot read it.
- **The App Wizard moves to `v0.3.0`** and gains one Headlamp link per cluster.
- **Four documents that said this was not wired up now say it is**, and the App Wizard page gains the "From a card to the running app" section that was deliberately withheld while the flow did not work.

## Two decisions worth knowing

**One entry per cluster, not a templated hostname.** A placeholder is only usable in the path, query or fragment. Its value is URL-encoded when expanded, which neutralises delimiters there but could not stop a value in a host from redirecting the link somewhere else. The wizard rejects a placeholder in the authority for that reason, so the per-cluster entries are literal.

**The VictoriaLogs query percent-encodes its braces.** The plugin reads a bare brace as a placeholder and rejects a malformed one; an encoded pair is passed through untouched. That is what lets a LogsQL stream selector survive into the link.

## Verification

| Check | Result |
|---|---|
| `./scripts/validate-manifests.sh` | exit 0 — 2113 resources, `Invalid: 0, Skipped: 0`, all gates passed |
| Rendered init containers | 4, the new one with `allowPrivilegeEscalation: false` |
| Per-cluster substitution | resolves to a real host on both clusters; no literal `${private_domain_name}` anywhere in the bundle |
| `./scripts/validate-doc-claims.sh` | exit 0 — 25 claims, 44 page checks |
| `./scripts/validate-links.sh` | exit 0 |

The links block was also run against the **published `v0.3.0` wizard image**, not a local build: it loads this configuration, and rejects a deliberately broken variant with `links[0] (Headlamp (aws-0)): unknown placeholder {namspace}` at configuration load, before the schema is even read.

## What is still unverified

**Nothing here has been exercised against a running Headlamp.** The graph renderer is reached through a runtime global because the newest published plugin toolkit predates its export, and the page falls back to a link if it is absent. Once this reconciles, the checks worth doing in order are: the plugin appears under Settings → Plugins; an app's page loads and its graph draws; hovering a node does not throw; and a card in the wizard opens the right page on the right cluster.

The plugin image is published by the container-image workflow from the merge of #2005. Confirm it exists before merging — the init container pins it by tag.
