### PR TITLE
fix(openbao): serve the full certificate chain, not just the leaf

### DIFF
--- a/opentofu/aws/openbao/cluster/scripts/startup_script.sh
+++ b/opentofu/aws/openbao/cluster/scripts/startup_script.sh
@@ -80,7 +80,19 @@ TLS_SECRET=$("$AWS" secretsmanager get-secret-value \
   --query SecretString --output text)
 
 umask 077
+# tls.crt must hold the FULL chain, not just the leaf. A TLS listener sends
+# exactly what is in this file, and a client cannot fetch an intermediate it was
+# never given: a browser that trusts the offline root still rejects
+# bao.priv.<domain> when the "Ogenki <cloud> Intermediate CA" is missing, because
+# there is nothing to bridge leaf to root. Measured 2026-09-10 -- this endpoint
+# presented 1 certificate while the Gateway-served hosts presented 2, which is
+# why importing the root CA into a browser never cleared the warning.
+#
+# `.ca` is the intermediate followed by the root, so appending it whole keeps
+# this correct regardless of that ordering. A self-signed root inside the chain
+# is legal and clients ignore it -- RFC 8446 4.4.2 makes omitting it a MAY.
 printf '%s' "$TLS_SECRET" | jq -r '.cert' > /opt/openbao/tls/tls.crt
+printf '%s' "$TLS_SECRET" | jq -r '.ca' >> /opt/openbao/tls/tls.crt
 printf '%s' "$TLS_SECRET" | jq -r '.key' > /opt/openbao/tls/tls.key
 printf '%s' "$TLS_SECRET" | jq -r '.ca' > /opt/openbao/tls/ca.pem
 unset TLS_SECRET

--- a/opentofu/gcp/openbao/cluster/scripts/startup-script.sh
+++ b/opentofu/gcp/openbao/cluster/scripts/startup-script.sh
@@ -86,7 +86,12 @@ TLS_SECRET=$(gcloud secrets versions access latest \
   --secret "${server_cert_secret_name}" --project "${project_id}")
 
 umask 077
+# Full chain, not just the leaf -- see the long comment on the same lines in
+# opentofu/aws/openbao/cluster/scripts/startup_script.sh. Both clouds chain to
+# one offline root, so a client that trusts it still needs the per-cloud
+# intermediate from the server to bridge leaf to root.
 printf '%s' "$TLS_SECRET" | jq -r '.cert' > /opt/openbao/tls/tls.crt
+printf '%s' "$TLS_SECRET" | jq -r '.ca'  >> /opt/openbao/tls/tls.crt
 printf '%s' "$TLS_SECRET" | jq -r '.key'  > /opt/openbao/tls/tls.key
 printf '%s' "$TLS_SECRET" | jq -r '.ca'   > /opt/openbao/tls/ca.pem
 unset TLS_SECRET


### PR DESCRIPTION
## Problem

OpenBao's TLS listener presents **one** certificate — the leaf. A client that trusts our offline root still rejects `bao.priv.aws.ogenki.io:8200`, because nothing bridges the leaf to the root. Importing the root CA into a browser cannot fix this, which is exactly how it surfaced.

The contrast on the same PKI:

| Host | Certs presented | Browser trusting only the root |
|---|---|---|
| `headlamp.priv.aws.ogenki.io` (Gateway) | 2 — leaf + `Ogenki AWS Intermediate CA` | trusted |
| `bao.priv.aws.ogenki.io:8200` | **1** — leaf only | **untrusted** |

## Cause

The secret `certificates/priv.aws.ogenki.io/openbao` holds `cert` (1 block) and `ca` (2 blocks: intermediate + root) separately. The startup script wrote only `cert` to `tls.crt`, and sent `ca` to a `ca.pem` that clients never receive.

## Fix

Append `ca` to `tls.crt` so the listener sends the chain. Appending it whole keeps this correct regardless of the order inside `ca`; a self-signed root in the chain is legal and clients ignore it (RFC 8446 §4.4.2 makes omitting it a MAY).

## Verification

Against the live secret, with the root as the **only** trust anchor:

```
leaf alone          -> error 20 at 0 depth lookup: unable to get local issuer certificate
leaf + intermediate -> leaf.pem: OK
```

`error 20` is the same failure `curl` reported as `ssl_verify=20` and what the browser shows. New `tls.crt` contains 3 certificate blocks (was 1).

- `bash -n` passes on both scripts
- `trivy config` reports **zero** findings on either changed file (the repo's pre-existing `dagger-engine` finding is untouched)
- pre-commit: all hooks passed

## Scope

Both clouds had the identical defect and chain to the same offline root, so `opentofu/gcp/openbao/cluster/scripts/startup-script.sh` is fixed alongside the AWS one.

Takes effect on instance replacement — the cert files are written from user_data at boot.