### PR TITLE
fix(observability): let Headlamp's prometheus plugin discover VictoriaMetrics

### DIFF
--- a/observability/base/victoria-metrics-k8s-stack/kustomization.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/kustomization.yaml
@@ -21,6 +21,8 @@ resources:
   # VM Single
   - helmrelease-vmsingle.yaml
   - httproute-vmsingle.yaml
+  # Label-only alias so Headlamp's prometheus plugin can discover vmsingle
+  - service-headlamp-prometheus.yaml
   # VM Cluster
   # - helmrelease-vmcluster.yaml
   # - httproute-vmcluster.yaml

--- a/observability/base/victoria-metrics-k8s-stack/service-headlamp-prometheus.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/service-headlamp-prometheus.yaml
@@ -1,0 +1,40 @@
+# Headlamp's shipped `prometheus` plugin finds its query backend by label, and
+# the only two it looks for are `headlamp-prometheus=true` -- checked first, on
+# pods then services -- and `app.kubernetes.io/name=prometheus` as the fallback.
+# VictoriaMetrics sets neither: the operator labels its service
+# `app.kubernetes.io/name: vmsingle`. No Service in the cluster carried either
+# label, so the plugin resolved no backend and every metrics chart in Headlamp
+# rendered empty, with nothing logged to say why.
+#
+# This is a thin alias rather than a label patch on the operator's own service.
+# VMSingle only exposes `spec.serviceSpec`, whose `spec` is required and whose
+# `useAsDefault` semantics are undocumented in the CRD, so patching through it
+# risks overriding ports the operator owns. Keeping the plugin's naming
+# expectations in their own file also means reverting is a deletion, and the
+# metrics stack's definition stays about metrics.
+#
+# No `subPath` is needed: VMSingle serves the Prometheus API at the bare path
+# (`/api/v1/query` returns 200), not only under `/prometheus`.
+#
+# The selector targets the VMSingle pods. If this cluster ever switches to the
+# VMCluster release (commented out in kustomization.yaml), this must point at
+# vmselect instead.
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp-prometheus
+  namespace: observability
+  labels:
+    headlamp-prometheus: "true"
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/instance: victoria-metrics-k8s-stack
+    app.kubernetes.io/name: vmsingle
+    managed-by: vm-operator
+  ports:
+    - name: http
+      port: 8428
+      targetPort: 8428
+      protocol: TCP


### PR DESCRIPTION
## Problem

Every metrics chart in Headlamp rendered empty, with nothing logged to explain it.

## Cause

Headlamp's shipped `prometheus` plugin resolves its query backend **purely by label**. From the bundle:

```js
const e = await Pe("pods",     "headlamp-prometheus=true"); if (e.type!=="none") return e;
const a = await Pe("services", "headlamp-prometheus=true"); if (a.type!=="none") return a;
// ... then falls back to app.kubernetes.io/name=prometheus
```

VictoriaMetrics sets neither label — the operator labels its service `app.kubernetes.io/name: vmsingle` — and `kubectl get svc -A -l app.kubernetes.io/name=prometheus` returns **No resources found**. So the plugin resolved no backend and drew nothing. The bundle contains 41 references to `prometheus` and **zero** to `vmsingle` or `victoria`.

## Fix

A label-only `Service` aliasing the VMSingle pods, carrying the plugin's documented opt-in label `headlamp-prometheus: "true"`.

Deliberately **not** a patch on the operator's own service: VMSingle exposes only `spec.serviceSpec`, whose `spec` is required and whose `useAsDefault` semantics the CRD leaves undocumented, so patching through it risks overriding ports the operator manages. A separate file also keeps the plugin's naming expectations out of the metrics stack's own definition, and reverting is a deletion.

No `subPath` needed — VMSingle answers the Prometheus API at the bare path:

```
/api/v1/query?query=up             -> 200  (live samples)
/prometheus/api/v1/query?query=up  -> 200
```

## Verification

- `./scripts/validate-manifests.sh` → exit 0, `Valid: 2116, Invalid: 0, Skipped: 0`, `All gates passed`
- Service renders into both the base and `aws-0` overlay bundles
- Selector matches exactly one live pod, `vmsingle-victoria-metrics-k8s-stack-58d6d5489d-s46pf` (`Running`), whose container port is `8428/http` — matching `targetPort`
- pre-commit: all hooks passed

## Note

Unrelated to Headlamp's built-in CPU/memory columns, which read `metrics.k8s.io` — that API is `Available=True` and `kubectl top nodes` works today.

If the cluster ever switches to the VMCluster release (commented out in `kustomization.yaml`), this selector must point at vmselect instead; the file says so.