### PR TITLE
fix(openbao): keep the ZITADEL OIDC login across rebuilds

### DIFF
--- a/opentofu/aws/openbao/management/oidc.tf
+++ b/opentofu/aws/openbao/management/oidc.tf
@@ -19,8 +19,36 @@
 # app and writes {client_id, client_secret, endpoint} to the `openbao-oidc`
 # store key; this reads it back.
 
+# Existence check, so the secret id can stay SET in variables.tfvars.
+#
+# Reading the version directly is a hard error when the secret does not exist
+# yet, which is why the id used to ship commented out -- and why every rebuild
+# then applied with OIDC disabled and DESTROYED the auth mount, the role and the
+# identity group. Listing first turns "not bootstrapped yet" back into count = 0,
+# so a first deploy still converges with no OIDC method while an established
+# account keeps its login across rebuilds with no manual step.
+#
+# The `name` filter is a PREFIX match in the Secrets Manager API, so `contains`
+# on the returned names is what makes this exact -- a secret called
+# `openbao-oidc-staging` must not satisfy a lookup for `openbao-oidc`.
+data "aws_secretsmanager_secrets" "openbao_oidc" {
+  count = var.openbao_oidc_secret_id == "" ? 0 : 1
+
+  filter {
+    name   = "name"
+    values = [var.openbao_oidc_secret_id]
+  }
+}
+
+locals {
+  oidc_secret_present = var.openbao_oidc_secret_id != "" && contains(
+    try(data.aws_secretsmanager_secrets.openbao_oidc[0].names, []),
+    var.openbao_oidc_secret_id
+  )
+}
+
 data "aws_secretsmanager_secret_version" "openbao_oidc" {
-  count     = var.openbao_oidc_secret_id == "" ? 0 : 1
+  count     = local.oidc_secret_present ? 1 : 0
   secret_id = var.openbao_oidc_secret_id
 }
 

--- a/opentofu/aws/openbao/management/variables.tf
+++ b/opentofu/aws/openbao/management/variables.tf
@@ -137,12 +137,13 @@ variable "mode" {
 
 # ZITADEL OIDC for human operators (ADR-0034)
 # -------------------------------------------
-# Empty disables the OIDC auth method entirely, which is the right state for a
-# cluster whose ZITADEL has not been bootstrapped yet. There is a genuine
-# ordering knot: `zitadel-oidc-clients.sh` must run before there is a client to
-# configure, that script needs a running ZITADEL, and ZITADEL needs secrets from
-# this stack. Gating on the value rather than trying to order the two lets a
-# first deploy converge without OIDC and pick it up on the next apply.
+# Empty disables the OIDC auth method entirely. So does a secret that does not
+# exist yet: oidc.tf lists before it reads, so naming a secret that has not been
+# created is not an error. There is a genuine ordering knot -- for
+# `zitadel-oidc-clients.sh` to register a client it needs a running ZITADEL, and
+# ZITADEL needs secrets from this stack -- and gating on the secret EXISTING
+# rather than on the variable being unset is what lets a first deploy converge
+# without OIDC, pick it up on the next apply, and keep it across rebuilds.
 variable "openbao_oidc_secret_id" {
   description = "AWS Secrets Manager secret holding {client_id, client_secret, endpoint} for OpenBao's ZITADEL OIDC client, as written by scripts/zitadel-oidc-clients.sh. Empty disables OIDC auth."
   type        = string

--- a/opentofu/aws/openbao/management/variables.tfvars
+++ b/opentofu/aws/openbao/management/variables.tfvars
@@ -22,34 +22,34 @@ tags = {
   owner   = "Smana"
 }
 
-# Human login through ZITADEL OIDC (ADR-0034) -- COMMENTED OUT ON PURPOSE, and
-# the comment is the instructions, because without them nothing ever sets this
-# and oidc.tf stays inert forever.
+# Human login through ZITADEL OIDC (ADR-0034).
 #
-# It cannot be set on a first deploy. There is a genuine ordering knot:
+# Safe to leave set even before ZITADEL exists. oidc.tf lists the secret before
+# reading it, so a missing secret means "not bootstrapped yet" (no OIDC method,
+# clean converge) rather than a plan error. That is what lets this stay
+# committed -- and it has to stay committed, because when it was commented out
+# every rebuild applied with OIDC disabled and DESTROYED the auth mount, the
+# role and the identity group that the previous cluster had.
+#
+# The ordering knot itself has not gone away:
 #
 #   this stack  ->  ZITADEL's secrets come from here
 #   ZITADEL     ->  must be running before a client can be registered in it
 #   the client  ->  is what this value points at
 #
-# So the sequence is, once the platform has converged:
+# So a brand-new platform still needs the client registered once, after the
+# platform converges. The store key IS the AWS secret name (see
+# scripts/lib/cloud-secret-store.sh -- `harbor-oidc` and `security-flux-ui-oidc`
+# are literal secret names, not prefixed keys):
 #
-#   1. Register the client. The store key IS the AWS secret name (see
-#      scripts/lib/cloud-secret-store.sh -- `harbor-oidc` and
-#      `security-flux-ui-oidc` are literal secret names, not prefixed keys):
+#   ./scripts/zitadel-oidc-clients.sh sync --cluster aws-0 --cloud aws \
+#     --region eu-west-3 --apply
 #
-#        ./scripts/zitadel-oidc-clients.sh sync --cluster aws-0 --cloud aws \
-#          --region eu-west-3 --apply
+# The next apply then picks the secret up on its own -- no edit here.
 #
-#   2. Uncomment the line below and re-apply THIS stack. oidc.tf is gated on the
-#      value being non-empty, so an apply before step 1 is not an error -- it
-#      simply creates no OIDC auth method, which is why a first deploy converges
-#      cleanly without this.
+# Granting a human the role the external group binds to remains a separate step,
+# because a human does not exist in ZITADEL until their first login:
 #
-#   3. Grant yourself the role the external group binds to. A human does not
-#      exist in ZITADEL until first login, so this cannot happen at bootstrap:
-#
-#        ./scripts/zitadel-oidc-clients.sh sync --cluster aws-0 --cloud aws \
-#          --region eu-west-3 --grant-admin <your-email> --apply
-#
-# openbao_oidc_secret_id = "openbao-oidc"
+#   ./scripts/zitadel-oidc-clients.sh sync --cluster aws-0 --cloud aws \
+#     --region eu-west-3 --grant-admin <your-email> --apply
+openbao_oidc_secret_id = "openbao-oidc"


### PR DESCRIPTION
## Problem

`openbao_oidc_secret_id` shipped **commented out**, so every rebuild applied with `oidc_enabled = 0` and *destroyed* the OIDC auth method the previous cluster had. This platform rebuild did exactly that — 4 resources removed:

```
vault_jwt_auth_backend.oidc[0]
vault_jwt_auth_backend_role.oidc_default[0]
vault_identity_group.oidc_admin[0]
vault_identity_group_alias.oidc_admin[0]
```

leaving `bao auth list` with only `jwt/aws-0/`, `token/` and `userpass/`, and no OIDC login. The `openbao-oidc` secret itself survived intact the whole time.

## Why it was commented out

For a real reason, not an oversight. `data "aws_secretsmanager_secret_version"` is a **hard error** when the secret does not exist, and it cannot exist on a first deploy — registering the client needs a running ZITADEL, and ZITADEL needs secrets from this stack. Gating on the variable let a first deploy converge; it also guaranteed the mount was destroyed on every rebuild.

## Fix

Gate on the secret **existing** instead of on the variable being unset:

```hcl
data "aws_secretsmanager_secrets" "openbao_oidc" {
  count  = var.openbao_oidc_secret_id == "" ? 0 : 1
  filter { name = "name"  values = [var.openbao_oidc_secret_id] }
}

locals {
  oidc_secret_present = var.openbao_oidc_secret_id != "" && contains(
    try(data.aws_secretsmanager_secrets.openbao_oidc[0].names, []), var.openbao_oidc_secret_id
  )
}
```

Listing before reading turns "not bootstrapped yet" back into `count = 0`. A first deploy still converges with no OIDC method; an established account keeps its login across rebuilds with no manual edit. The value is now committed uncommented.

`name` is a **prefix** match in the Secrets Manager API, so membership is tested with `contains` on the returned names — `openbao-oidc-staging` must not satisfy a lookup for `openbao-oidc`.

## Verification

Applied against the live cluster from this branch:

```
Plan: 4 to add, 0 to change, 0 to destroy
  + vault_identity_group.oidc_admin[0]
  + vault_identity_group_alias.oidc_admin[0]
  + vault_jwt_auth_backend.oidc[0]
  + vault_jwt_auth_backend_role.oidc_default[0]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
```

Exactly the four the rebuild had destroyed. `tofu validate`, `tofu fmt`, tflint and all pre-commit hooks pass.

## Still one-time steps

Registering the client on a brand-new platform, and granting a human the role the external group binds to (a human does not exist in ZITADEL until first login), remain manual. The tfvars comment carries both commands.