### PR TITLE
fix(openbao): request the scopes the OIDC login actually reads

### DIFF
--- a/opentofu/aws/openbao/management/oidc.tf
+++ b/opentofu/aws/openbao/management/oidc.tf
@@ -129,6 +129,18 @@ resource "vault_jwt_auth_backend_role" "oidc_default" {
 
   allowed_redirect_uris = local.oidc_redirect_uris
   user_claim            = "email"
+
+  # Without this the method requests `openid` and nothing else, ZITADEL issues a
+  # token carrying neither `email` nor `groups`, and the login dies on
+  # `claim "email" not found in token` at the end of an otherwise healthy round
+  # trip -- user_claim below asks for a claim that was never requested.
+  #
+  # Same trap, same values, as the OIDC_SCOPES the registration script sets for
+  # every other consumer (HEADLAMP_OIDC_SCOPES in scripts/zitadel-oidc-clients.sh):
+  # `groups` is what makes ZITADEL run the groupsFromRoles Action, and `email` is
+  # what user_claim reads. `openid` is always sent by the auth method itself and
+  # must not be repeated here.
+  oidc_scopes = ["profile", "email", "groups"]
   # THE FIELD THAT DECIDES WHETHER ANY OF THIS WORKS.
   #
   # ZITADEL has no groups; it has project roles, emitted as a NESTED object


### PR DESCRIPTION
## Problem

OIDC login into OpenBao failed with:

```
OpenBao login failed. claim "email" not found in token
```

## Cause

The role set `user_claim = "email"` and `groups_claim = "groups"` — the latter with a long comment about the two silent failure modes around it — but never set **`oidc_scopes`**:

```
$ bao read auth/oidc/role/default
groups_claim   groups
oidc_scopes    <nil>      <-- here
user_claim     email
```

So the method requested `openid` and nothing else, ZITADEL issued a token carrying neither `email` nor `groups`, and the role asked for a claim that was never requested. The OIDC round trip itself is healthy right up to the last step, which is what makes it confusing.

This is the same trap `OIDC_SCOPES` hit for Headlamp on 2026-08-29, recorded in `tooling/base/headlamp/helmrelease.yaml`.

## Fix

```hcl
oidc_scopes = ["profile", "email", "groups"]
```

Same values the registration script already sets for every other consumer (`HEADLAMP_OIDC_SCOPES` in `scripts/zitadel-oidc-clients.sh`). `groups` is what makes ZITADEL run the `groupsFromRoles` Action; `email` is what `user_claim` reads. `openid` is sent by the auth method itself and must not be repeated.

## Verification

Applied to the live mount — `Apply complete! Resources: 0 added, 1 changed, 0 destroyed.`

The authorize request built by the mount, before and after:

```
before:  scope = openid
after:   scope = openid profile groups email
```

`tofu fmt` and `tofu validate` pass.