### PR TITLE
feat(secrets): OpenBao-backed secret stores, and the first key read from them

### DIFF
--- a/security/aws-0/openbao/kustomization.yaml
+++ b/security/aws-0/openbao/kustomization.yaml
@@ -41,3 +41,4 @@ resources:
   - clustersecretstore.yaml
   - openbao-ca-externalsecret.yaml
   - openbao-clusterissuer.yaml
+  - ../../base/openbao-stores

--- a/security/base/openbao-stores/clustersecretstore-apps.yaml
+++ b/security/base/openbao-stores/clustersecretstore-apps.yaml
@@ -1,0 +1,39 @@
+# Reads the `apps/` kv-v2 mount, where each application owns its own prefix
+# (ADR-0036).
+#
+# A SECOND store rather than a second path on the first one: the vault provider
+# takes exactly one mount per store (spec.provider.vault.path), so the split is
+# what lets the two audiences carry different policies without prefix gymnastics
+# inside a single policy document.
+#
+# Identity, endpoint and CA rationale are identical to
+# clustersecretstore-platform.yaml -- repeated here in full rather than
+# cross-referenced, because a reader may open either file first.
+#
+# Note that External Secrets is read-only on this mount too. Humans write here,
+# through the per-app OpenBao groups; the controller only reads.
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: openbao-apps
+spec:
+  provider:
+    vault:
+      server: "https://openbao.security.svc.cluster.local:8200"
+      path: "apps"
+      version: "v2"
+      caProvider:
+        type: Secret
+        name: openbao-ca
+        namespace: security
+        key: ca.crt
+      auth:
+        jwt:
+          path: "jwt/${cluster_name}"
+          role: "external-secrets"
+          kubernetesServiceAccountToken: # pragma: allowlist secret
+            serviceAccountRef:
+              name: external-secrets
+              namespace: security
+            audiences:
+              - openbao

--- a/security/base/openbao-stores/clustersecretstore-platform.yaml
+++ b/security/base/openbao-stores/clustersecretstore-platform.yaml
@@ -1,0 +1,46 @@
+# Reads the `platform/` kv-v2 mount as External Secrets' own cluster identity
+# (ADR-0033 Stage 2).
+#
+# Auth is the per-cluster JWT mount Stage 1 created, not an AppRole: the
+# controller presents a projected ServiceAccount token with audience `openbao`
+# and gets back a token carrying the read-only `external-secrets` policy. No
+# long-lived credential exists anywhere in this path, and the policy grants no
+# write verb on any mount -- the controller reads with its OWN identity rather
+# than the requester's, so write access would let anything able to create a
+# namespaced ExternalSecret launder a value into another app's prefix.
+#
+# `openbao.security.svc.cluster.local` is an ExternalName Service pointing at
+# the cloud's OpenBao. Dialling it is safe because the server certificate names
+# it in a SAN alongside bao.priv.<cloud>.ogenki.io -- the same URL the openbao
+# ClusterIssuer already uses.
+#
+# The CA comes from the `openbao-ca` Secret, which is produced by an
+# ExternalSecret reading the CLOUD managed store. That is deliberate and must
+# not be "tidied up" into reading OpenBao: this store cannot verify OpenBao's
+# certificate without a CA obtained before OpenBao was usable. The CA stays
+# bootstrap tier for exactly that reason.
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: openbao-platform
+spec:
+  provider:
+    vault:
+      server: "https://openbao.security.svc.cluster.local:8200"
+      path: "platform"
+      version: "v2"
+      caProvider:
+        type: Secret
+        name: openbao-ca
+        namespace: security
+        key: ca.crt
+      auth:
+        jwt:
+          path: "jwt/${cluster_name}"
+          role: "external-secrets"
+          kubernetesServiceAccountToken: # pragma: allowlist secret
+            serviceAccountRef:
+              name: external-secrets
+              namespace: security
+            audiences:
+              - openbao

--- a/security/base/openbao-stores/kustomization.yaml
+++ b/security/base/openbao-stores/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# The OpenBao-backed ClusterSecretStores, shared by both clouds.
+#
+# Cloud-neutral by construction: the only per-cluster value is the JWT mount,
+# written as `jwt/${cluster_name}` and substituted by Flux from each cluster's
+# own vars ConfigMap. That is why these live in base/ while the MANAGED-store
+# ClusterSecretStore stays in each cloud's overlay -- that one names a provider
+# (`aws` or `gcpsm`) that cannot be shared.
+#
+# Listed from each cloud's `openbao` overlay, so they land in the
+# `security-openbao` Kustomization rather than `security`. That boundary is not
+# cosmetic: everything here has to be ADMITTED by the external-secrets webhook
+# before it can exist, and `security` is what installs that webhook. See the
+# long note in security/gcp-0/openbao/kustomization.yaml, where the race was
+# actually reproduced.
+resources:
+  - clustersecretstore-platform.yaml
+  - clustersecretstore-apps.yaml

--- a/security/gcp-0/openbao/kustomization.yaml
+++ b/security/gcp-0/openbao/kustomization.yaml
@@ -35,3 +35,4 @@ resources:
   - clustersecretstore.yaml
   - openbao-ca-externalsecret.yaml
   - openbao-clusterissuer.yaml
+  - ../../base/openbao-stores

--- a/tooling/base/headlamp/externalsecret-headlamp-envvars.yaml
+++ b/tooling/base/headlamp/externalsecret-headlamp-envvars.yaml
@@ -1,3 +1,11 @@
+# Read from OpenBao rather than the cloud managed store (ADR-0033 Stage 2).
+#
+# The first key repointed, chosen as the proof case: one consumer, and a failure
+# is visible immediately -- Headlamp's OIDC login breaks -- without taking down
+# a dependency chain the way an observability or database secret would.
+#
+# `key` carries no mount prefix. The store is already scoped to the `platform`
+# mount, so `headlamp/envvars` here resolves to platform/data/headlamp/envvars.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -6,11 +14,11 @@ spec:
   dataFrom:
     - extract:
         conversionStrategy: Default
-        key: headlamp-envvars
+        key: headlamp/envvars
   refreshInterval: 20m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain


### PR DESCRIPTION
Phase 3 Tasks 7-8 of [the Stage 2 plan](docs/superpowers/plans/2026-09-10-openbao-stage2-secrets-personas.md). Deliberately **two tasks, not five**: this is the proof case, and the remaining repoints follow once it is verified on the merged cluster.

## What this does

1. **Two OpenBao-backed `ClusterSecretStore`s** — `openbao-platform` and `openbao-apps`, one per kv-v2 mount, because the vault provider takes exactly one mount per store.
2. **Repoints exactly one key**: `headlamp-envvars` → `platform/headlamp/envvars`.

Nothing else changes store. 15 other keys have been *copied* into OpenBao already (additive, sources untouched) but are still read from AWS Secrets Manager.

## Why one key

The parent design rejected a big-bang repoint, and Flux reconciling from `main` makes that easy to get wrong: every repoint lands at once on merge. `headlamp-envvars` is the right first key — one consumer, and a failure is immediately visible (Headlamp's OIDC login breaks) rather than cascading through a `dependsOn` chain the way an observability or database secret would.

## Verification, before asking for a merge

The stores were applied to the live cluster and both validated:

```
openbao-apps       Valid  Ready=True  "store validated"
openbao-platform   Valid  Ready=True  "store validated"
```

The read path was then proven with a **disposable** `ExternalSecret` against `openbao-platform` / `headlamp/envvars`, so the live object was never disturbed:

```
Ready=True SecretSynced "secret synced"

probe (from OpenBao) keys == live (from AWS) keys
probe values hash      bcc7b70b9da4778f
live  values hash      bcc7b70b9da4778f   -> VALUES IDENTICAL
```

The probe was deleted afterwards; its Secret went with it.

Migration output: `copied: 16, exists: 0, absent: 0, skipped: 4`. The 4 skipped are the CA chain and the three `cnpg/*` keys, which stay in the managed store by design.

Gates: `validate-manifests.sh` → `Valid: 2122, Invalid: 0, Skipped: 0`; `check-substitution.py` → 68 Kustomizations consistent.

## Notes

- **`cluster_name` resolves to `aws-0`** on the live cluster (confirmed against `eks-aws-0-vars`), so the stores authenticate against `jwt/aws-0`. The rendered bundle shows `jwt/foobar` — that is the validation harness's placeholder, exactly as the existing openbao `ClusterIssuer` renders.
- **The stores are a shared base** (`security/base/openbao-stores/`) rather than per-cloud overlays, because the only per-cluster value is the JWT mount name. The managed-store `ClusterSecretStore` stays per-cloud since it names a provider that cannot be shared.
- **They are listed from each cloud's `openbao` overlay**, so they land in `security-openbao` — behind the external-secrets webhook that `security` installs. That boundary is load-bearing; see the note in `security/gcp-0/openbao/kustomization.yaml` where the race was reproduced.
- **The `openbao-ca` ExternalSecret deliberately keeps reading the cloud store.** These stores cannot verify OpenBao's certificate without a CA obtained before OpenBao was usable, so repointing it would be circular. It stays bootstrap tier.
- **`gcp-0` gets the same base wired in but is not running**, so its live verification is outstanding and is not claimed here.

## After merge

Watch `kubectl get externalsecret headlamp-envvars -n tooling` reach `SecretSynced`, then confirm the real assertion — that a ZITADEL login to Headlamp still completes. The Secret existing is not the same as its contents being right.

Then Tasks 9-10 repoint the remaining keys, lowest blast radius first, with `zitadel-envvars` last: it is the IdP for the login that reaches OpenBao itself.