### PR TITLE
feat(secrets): read the platform secrets from OpenBao

### DIFF
--- a/docs/superpowers/plans/2026-09-10-openbao-stage2-secrets-personas.md
+++ b/docs/superpowers/plans/2026-09-10-openbao-stage2-secrets-personas.md
@@ -1196,6 +1196,28 @@ One key per commit, so a bad one is a single revert.
 
 ### Task 10: Repoint the app secrets
 
+> **BLOCKED — found during execution (2026-09-10). Do not attempt this task from this repository.**
+>
+> App secrets are **not** standalone `ExternalSecret` manifests. They are declared inside the `App` claim as `spec.externalSecrets[].remoteRef`, and the Crossplane composition generates the `ExternalSecret` — hardcoding `secretStoreRef.name: clustersecretstore`. The XRD schema exposes no store field at all:
+>
+> ```
+> FIELD: externalSecrets <[]Object>
+>   name           -required-   Kubernetes Secret name
+>   refreshInterval
+>   remoteRef      -required-   Path to secret in AWS Secrets Manager
+> ```
+>
+> The description is explicit that the source is AWS Secrets Manager. Repointing therefore needs, in order:
+>
+> 1. A composition change in [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration): add an optional `store` (and probably `property`) to `externalSecrets`, defaulting to `clustersecretstore` so existing claims are unaffected.
+> 2. `task check` there, then a release.
+> 3. A pin bump in `infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml` **and** the matching app-wizard tag, which must move together.
+> 4. Only then, `store: openbao-apps` on the three claim entries.
+>
+> The three keys are already migrated and hash-verified in `apps/`, so the mount is ready and waiting. Nothing is lost by deferring.
+>
+> This also means **the `apps/` mount has no consumer yet**, and the per-app groups grant access to data only humans can reach. That is a coherent intermediate state, not a broken one.
+
 **Files:**
 - Modify: the `ExternalSecret` documents for `apps-app-wizard-llm`, `apps-app-wizard-oauth`, `apps/image-gallery/config`
 

--- a/flux/notifications/externalsecret-flux-slack-app.yaml
+++ b/flux/notifications/externalsecret-flux-slack-app.yaml
@@ -7,11 +7,11 @@ spec:
   dataFrom:
     - extract:
         conversionStrategy: Default
-        key: observability-flux-slack-app
+        key: flux/slack-app
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/flux/operator/externalsecret-flux-ui-oidc.yaml
+++ b/flux/operator/externalsecret-flux-ui-oidc.yaml
@@ -7,11 +7,11 @@ spec:
   dataFrom:
     - extract:
         conversionStrategy: Default
-        key: security-flux-ui-oidc
+        key: flux/ui-oidc
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/observability/base/runlore/externalsecret-credentials.yaml
+++ b/observability/base/runlore/externalsecret-credentials.yaml
@@ -12,11 +12,11 @@ spec:
   dataFrom:
     - extract:
         conversionStrategy: Default
-        key: runlore-credentials
+        key: runlore/credentials
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/observability/base/runlore/externalsecret-slack.yaml
+++ b/observability/base/runlore/externalsecret-slack.yaml
@@ -12,11 +12,11 @@ spec:
   dataFrom:
     - extract:
         conversionStrategy: Default
-        key: runlore-slack-app
+        key: runlore/slack-app
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/observability/base/runlore/externalsecret-webhook.yaml
+++ b/observability/base/runlore/externalsecret-webhook.yaml
@@ -13,12 +13,12 @@ spec:
   data:
     - secretKey: WEBHOOK_TOKEN  # pragma: allowlist secret
       remoteRef:
-        key: runlore-webhook
+        key: runlore/webhook
         property: token
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/observability/base/victoria-metrics-k8s-stack/externalsecret-alertmanager-slack-app.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/externalsecret-alertmanager-slack-app.yaml
@@ -7,11 +7,11 @@ spec:
   dataFrom:
     - extract:
         conversionStrategy: Default
-        key: observability-victoria-metrics-k8s-stack-alertmanager-slack-app
+        key: victoria-metrics/alertmanager-slack-app
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/observability/base/victoria-metrics-k8s-stack/externalsecret-grafana-envvars.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/externalsecret-grafana-envvars.yaml
@@ -7,11 +7,11 @@ spec:
   dataFrom:
     - extract:
         conversionStrategy: Default
-        key: observability-victoria-metrics-k8s-stack-grafana-envvars
+        key: victoria-metrics/grafana-envvars
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/observability/base/victoria-metrics-k8s-stack/externalsecret-runlore-webhook-token.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/externalsecret-runlore-webhook-token.yaml
@@ -12,12 +12,12 @@ spec:
   data:
     - secretKey: token  # pragma: allowlist secret
       remoteRef:
-        key: runlore-webhook
+        key: runlore/webhook
         property: token
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/security/base/tailscale-operator/oauth-client-externalsecret.yaml
+++ b/security/base/tailscale-operator/oauth-client-externalsecret.yaml
@@ -6,11 +6,11 @@ spec:
   dataFrom:
     - extract:
         conversionStrategy: Default
-        key: tailscale-k8s-operator-oauth-client
+        key: tailscale/operator-oauth-client
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/tooling/base/harbor/externalsecret-admin-password.yaml
+++ b/tooling/base/harbor/externalsecret-admin-password.yaml
@@ -6,11 +6,11 @@ spec:
   dataFrom:
     - extract:
         conversionStrategy: Default
-        key: harbor-admin-password
+        key: harbor/admin-password
   refreshInterval: 20m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/tooling/base/harbor/externalsecret-oidc.yaml
+++ b/tooling/base/harbor/externalsecret-oidc.yaml
@@ -22,11 +22,11 @@ spec:
   dataFrom:
     - extract:
         conversionStrategy: Default
-        key: harbor-oidc
+        key: harbor/oidc
   refreshInterval: 20m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/tooling/base/harbor/externalsecret-valkey-password.yaml
+++ b/tooling/base/harbor/externalsecret-valkey-password.yaml
@@ -6,11 +6,11 @@ spec:
   dataFrom:
     - extract:
         conversionStrategy: Default
-        key: harbor-valkey-password
+        key: harbor/valkey-password
   refreshInterval: 20m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain


### PR DESCRIPTION
Phase 3 Task 9 of [the Stage 2 plan](docs/superpowers/plans/2026-09-10-openbao-stage2-secrets-personas.md). Eleven keys, twelve `ExternalSecret` documents, moved from the cloud managed store to the `platform/` mount.

Follows #2014, which proved the mechanism on `headlamp-envvars` — now live and healthy (`SecretSynced`, value hash unchanged, Headlamp serving 200).

## Two things deliberately NOT in this PR

**ZITADEL.** `zitadel-envvars` and `zitadel-masterkey` read the same key and must move together — and that key backs the IdP for the OIDC login that reaches OpenBao itself. It moves alone, after confirming `bao login -method=userpass username=admin` works, so a mistake is recoverable rather than an incident.

**App secrets (Task 10) — blocked, and the plan now records why.** They are not standalone manifests: they are `spec.externalSecrets[].remoteRef` on the `App` claim, and the Crossplane composition generates the `ExternalSecret` with `secretStoreRef.name: clustersecretstore` hardcoded. The XRD exposes no store field:

```
FIELD: externalSecrets <[]Object>
  name           -required-
  refreshInterval
  remoteRef      -required-   Path to secret in AWS Secrets Manager
```

Repointing them needs a composition change in `Smana/crossplane-configuration` (an optional `store`, defaulting to the current value), a release, and a coordinated pin + app-wizard tag bump here. The three app keys are already migrated and hash-verified, so `apps/` is ready and waiting.

## Verification

Every migrated key was checked by comparing a hash of the AWS payload with the OpenBao one — **all 16 match**, including the three app keys and ZITADEL that are copied but not repointed:

```
platform/flux/slack-app                       MATCH
platform/flux/ui-oidc                         MATCH
platform/victoria-metrics/grafana-envvars     MATCH
platform/victoria-metrics/alertmanager-slack-app  MATCH
platform/runlore/{credentials,slack-app,webhook}  MATCH
platform/harbor/{admin-password,oidc,valkey-password}  MATCH
platform/tailscale/operator-oauth-client      MATCH
platform/headlamp/envvars                     MATCH
apps/app-wizard/{llm,oauth}                   MATCH
apps/image-gallery/config                     MATCH
platform/zitadel/envvars                      MATCH
```

Gates: `validate-manifests.sh` → `Valid: 2122, Invalid: 0, Skipped: 0`; `check-substitution.py` → 68 Kustomizations consistent.

## Details worth reviewing

- **`runlore-webhook` is read by two ExternalSecrets** in different namespaces (`observability/runlore-webhook-token` and `runlore/runlore-webhook`). Both move in this PR — leaving one behind would point it at a store that still has the key, but would split one secret across two sources. Both keep their `property: token` selector, which the vault provider honours the same way.
- **`tailscale` moves in `base/` only.** `gcp-0` overrides that file with its own key name (`tailscale-k8s-operator-oauth` — no `-client` suffix) against GCP Secret Manager, so it is untouched and stays consistent with its own store.
- **The managed store keeps more than the bootstrap tier for now**: the `cnpg/*` keys (runtime-generated), the CA chain, the three app keys pending Task 10, ZITADEL, plus everything belonging to components not running on `aws-0` (the suspended LLM platform, `gha-runners`, `promptfoo`, `openwebui`). The migration is driven by what the cluster actually asks for, so a suspended component keeps its managed-store key until it runs.
- **Nothing is deleted.** Every source key still exists; this PR only changes where the cluster reads from.

## After merge

Watch every repointed `ExternalSecret` reach `SecretSynced` and confirm the consuming workloads stay healthy — Harbor, Grafana, Alertmanager, the Flux UI, runlore and the Tailscale operator. Then ZITADEL goes on its own.