### PR TITLE
feat(secrets): move ZITADEL onto OpenBao, and fix the break-glass login it depends on

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -214,7 +214,7 @@
         "filename": "security/base/zitadel/externalsecret-zitadel-masterkey.yaml",
         "hashed_secret": "33965a6f72cb380df8b01eceb0cc6b040fc23978",
         "is_verified": false,
-        "line_number": 7
+        "line_number": 14
       }
     ],
     "security/base/zitadel/helmrelease.yaml": [
@@ -282,5 +282,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-08T10:50:06Z"
+  "generated_at": "2026-09-10T19:58:39Z"
 }

--- a/opentofu/aws/openbao/management/auth.tf
+++ b/opentofu/aws/openbao/management/auth.tf
@@ -46,8 +46,19 @@ resource "vault_generic_endpoint" "admin_user" {
   disable_delete       = false
   ignore_absent_fields = true
 
+  # `secrets-admin` is here for the same reason the other two are: this is the
+  # break-glass login, and it must be able to read what it would be used to
+  # recover. Without it the login succeeds and every read of the `platform/` and
+  # `apps/` mounts returns 403 — the wrong moment to discover a missing grant,
+  # because the alternative route to those mounts is the ZITADEL OIDC login, and
+  # the credential that IdP boots from now lives in `platform/zitadel/envvars`.
+  #
+  # The grant went to the `openbao-admin` identity group when the mounts were
+  # created, and only there. `admin.hcl` predicted the gap in a comment — "any
+  # kv mount later created *in* root would need it back" — and both new mounts
+  # are in root.
   data_json = jsonencode({
-    policies      = [vault_policy.admin.name, vault_policy.pki_admin.name]
+    policies      = [vault_policy.admin.name, vault_policy.pki_admin.name, vault_policy.secrets_admin.name]
     password      = random_password.admin.result
     token_ttl     = 3600
     token_max_ttl = 28800

--- a/security/base/zitadel/externalsecret-zitadel-envvars.yaml
+++ b/security/base/zitadel/externalsecret-zitadel-envvars.yaml
@@ -1,3 +1,17 @@
+# Read from OpenBao rather than the cloud managed store (ADR-0033 Stage 2).
+#
+# Last of the platform keys to move, and deliberately so: this secret boots the
+# IdP behind the OIDC login that reaches OpenBao itself, so a mistake here costs
+# the console route to the store holding the fix. It moves only once the
+# break-glass path is known good — `bao login -method=userpass username=admin`
+# now carries `secrets-admin` as well as `admin`/`pki-admin`, so it can read
+# this key back without ZITADEL being involved at all.
+#
+# `zitadel-masterkey` selects a property of this same key and must move with it;
+# splitting them would read one secret from two stores.
+#
+# `key` carries no mount prefix. The store is already scoped to the `platform`
+# mount, so `zitadel/envvars` here resolves to platform/data/zitadel/envvars.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -6,11 +20,11 @@ spec:
   dataFrom:
     - extract:
         conversionStrategy: Default
-        key: zitadel-envvars
+        key: zitadel/envvars
   refreshInterval: 20m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/security/base/zitadel/externalsecret-zitadel-masterkey.yaml
+++ b/security/base/zitadel/externalsecret-zitadel-masterkey.yaml
@@ -1,3 +1,10 @@
+# Read from OpenBao rather than the cloud managed store (ADR-0033 Stage 2).
+#
+# Moves in the same commit as `zitadel-envvars`: both read the one key, and
+# leaving this one behind would split a single secret across two stores.
+#
+# `property` is honoured by the vault provider the same way the managed store
+# honoured it, so only the store and the key path change here.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -6,12 +13,12 @@ spec:
   data:
     - secretKey: ZITADEL_MASTERKEY
       remoteRef:
-        key: zitadel-envvars
+        key: zitadel/envvars
         property: ZITADEL_MASTERKEY
   refreshInterval: 20m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: clustersecretstore
+    name: openbao-platform
   target:
     template:
       engineVersion: v2


### PR DESCRIPTION
Phase 3 Task 9's deliberate carve-out. `zitadel-envvars` and `zitadel-masterkey` were the two platform documents #2015 held back, because the key they share boots the IdP behind the OIDC login that reaches OpenBao itself.

It moves now — but not before fixing something that made the stated precondition hollow.

## The precondition was satisfied in letter only

#2015 said ZITADEL moves "after confirming `bao login -method=userpass username=admin` works, so a mistake is recoverable". The login worked. It could not read the secret it would be used to recover:

```
$ bao token lookup            policies ["admin","default","pki-admin"]
$ bao kv get platform/zitadel/envvars
Code: 403. Errors:
  * preflight capability check returned 403, please ensure client's
    policies grant access to path "platform/zitadel/envvars/"
```

`secrets-admin` was written when the two mounts were created (#2013) and attached **only** to the `openbao-admin` identity group — which is reached through ZITADEL. So the one path that exists for when ZITADEL is unavailable was the one path that could not read the credential ZITADEL boots from. A circular dependency that only shows up on the day it matters.

`admin.hcl` had already predicted it, in a comment written before the mounts existed:

> NOTE: there is deliberately no `secret/*` grant. […] **Any kv mount later created *in* root would need it back.**

Both new mounts are in root. First commit adds `secrets-admin` to the break-glass login; `tofu plan` was `0 to add, 1 to change, 0 to destroy` and is applied:

```
after   policies ["admin","default","pki-admin","secrets-admin"]
        bao kv get platform/zitadel/envvars  ->  10 keys
```

## Then the repoint

Both documents move in one commit — they read the same key, and splitting them would source one secret from two stores. `zitadel-masterkey` keeps its `property: ZITADEL_MASTERKEY` selector, which the vault provider honours as the managed store did.

Verified before changing anything:

```
bao vs aws, all 10 keys   hash e78746b4770defb9 == e78746b4770defb9
ZITADEL_MASTERKEY         identical
```

Then the read path, through a **disposable** `ExternalSecret` against `openbao-platform`, so the live object was never touched:

```
Ready=True SecretSynced "secret synced"
live  (AWS)     values hash 81e5be6e2ae30f34
probe (OpenBao) values hash 81e5be6e2ae30f34   -> VALUES IDENTICAL
```

The probe was deleted afterwards; its Secret went with it.

Gates: `validate-manifests.sh` → `Valid: 2122, Invalid: 0, Skipped: 0`; `check-substitution.py` → 68 Kustomizations consistent.

## What is left on the managed store after this

Bootstrap tier (`openbao-ca` ×2 — repointing it is circular, it produces the CA these stores verify against), the three runtime-generated `cnpg/*` keys (Task 11), the three app keys (Task 10, blocked on a composition change), and the keys belonging to components not running on `aws-0`.

Every source key still exists. Nothing is deleted here.

## After merge

Watch both reach `SecretSynced`, then the real assertion — that a ZITADEL login still completes, since a Secret existing is not the same as its contents being right. The recovery path if it does not: `bao login -method=userpass username=admin`, which now reads `platform/zitadel/envvars` directly.
