### PR TITLE
fix(crossplane): bump to v0.6.2 so the core XRD carries the store field

### DIFF
--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -232,7 +232,7 @@ spec:
         - clone
         - --depth=1
         - --single-branch
-        - --branch=v0.6.1
+        - --branch=v0.6.2
         - https://github.com/Smana/crossplane-configuration.git
         - /repo/crossplane-configuration
       securityContext:

--- a/infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration-aws/configuration-packages.yaml
@@ -12,4 +12,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-aws
 spec:
-  package: ghcr.io/smana/crossplane-configuration-aws:v0.6.1
+  package: ghcr.io/smana/crossplane-configuration-aws:v0.6.2

--- a/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
+++ b/infrastructure/base/crossplane/configuration-gcp/configuration-packages.yaml
@@ -13,4 +13,4 @@ kind: Configuration
 metadata:
   name: crossplane-configuration-gcp
 spec:
-  package: ghcr.io/smana/crossplane-configuration-gcp:v0.6.1
+  package: ghcr.io/smana/crossplane-configuration-gcp:v0.6.2


### PR DESCRIPTION
#2018 gave App claims a `store` field and used it. It was rejected by the cluster, and the reason is a dependency floor.

The field is on the **App XRD**, which ships in the **core** package. Both cloud packages declared `dependsOn: core >=v0.3.0`, and core v0.6.0 satisfies that — so Crossplane upgraded `aws` to v0.6.1 and left core where it was:

```
App/apps/app-wizard dry-run failed: failed to create typed patch object
  (apps/app-wizard; cloud.ogenki.io/v1alpha1, Kind=App): errors:
  .spec.externalSecrets[0].store: field not declared in schema
  .spec.externalSecrets[1].store: field not declared in schema
```

The whole `apps` Kustomization went `READY=False` behind that, while **every signal a person would check said healthy**:

```
configuration crossplane-configuration-aws        Healthy=True  v0.6.1
configuration smana-crossplane-configuration-core Healthy=True  v0.6.0   <-- left behind
compositionrevision xapps...-739c229              REVISION 2
xrd/crd apps.cloud.ogenki.io  externalSecrets:    name,refreshInterval,remoteRef
```

[crossplane-configuration#24](https://github.com/Smana/crossplane-configuration/pull/24) raises the floor to `>=v0.6.1` in both cloud packages; **v0.6.2** carries it. That PR also rewrites the comment above the constraint: it had already described this exact failure for the `objectStore` migration, and was read as history rather than as an instruction, so it now leads with *RAISE THIS FLOOR* and lists both occurrences.

Bumps the two package pins **and** the App Wizard clone tag together, as the coupling note in `app.yaml` requires.

## Gate

```
validate-manifests.sh   Valid: 2122, Invalid: 0, Skipped: 0   (against the v0.6.2 XRDs)
```

## After merge

The `apps` Kustomization should go Ready, and the three app `ExternalSecret`s flip to `openbao-apps` and reach `SecretSynced` — the verification #2018 could not complete.