### PR TITLE
fix(gcp): pass the workforce pool id to the adopt step without a shell syntax error

### DIFF
--- a/opentofu/gcp/workforce-identity/workflows.tm.hcl
+++ b/opentofu/gcp/workforce-identity/workflows.tm.hcl
@@ -44,7 +44,7 @@ script "deploy" {
         # undeletes and imports whatever is already there; it is a no-op on a
         # genuinely fresh org. See scripts/gcp-adopt-workforce-pool.sh.
         bash "${terramate.root.path.fs.absolute}/scripts/gcp-adopt-workforce-pool.sh" \
-          --pool "$$(awk -F= '/workforce_pool_id/{gsub(/[ "]/,"",$$2); print $$2}' variables.tfvars)" \
+          --pool "$(awk -F= '/workforce_pool_id/{gsub(/[ "]/,"",$2); print $2}' variables.tfvars)" \
           --apply
         ${global.provisioner} apply -auto-approve -var-file=variables.tfvars -var='deploy_identity_provider=${global.deploy_identity_provider_gcp}'
       BASH


### PR DESCRIPTION
## Summary

Every GCP deploy has failed at the `gcp/workforce-identity` stack since #1958 (2026-09-04). The step that adopts a soft-deleted workforce pool never ran.

```
/usr/bin/bash: -c: line 17: syntax error near unexpected token `)'
 (in /opentofu/gcp/workforce-identity): exit status 2
```

## Root cause

The deploy script passed the pool id as:

```
--pool "$$(awk -F= '/workforce_pool_id/{gsub(/[ "]/,"",$$2); print $$2}' variables.tfvars)"
```

In HCL, only `${` interpolates, and `$${` is its escape. A bare `$$` is not an escape, so it reaches bash literally. There, `$$` expands to the shell's PID followed by a subshell, and the `"` inside `[ "]` ends the double-quoted string, which causes the syntax error.

## Fix

Use plain `$(` and `$2`, which need no escaping in a Terramate heredoc. This is a one-line change.

## Testing

- `terramate fmt --check` on the file passes.
- `terramate -C opentofu/gcp/workforce-identity script info deploy` now renders `--pool "$(awk -F= '/workforce_pool_id/{gsub(/[ "]/,"",$2); print $2}' variables.tfvars)"`.
- Standalone, the `awk` returns `ogenki-zitadel`.
- Live, on the GCP-only test branch: the adopt step ran. It found `ogenki-zitadel` soft-deleted, undeleted the pool and its `zitadel` provider, imported both, and the stack applied.
