### PR TITLE
fix(gcp): pin the workforce provider to the headlamp-proxy client, not the project

### DIFF
--- a/opentofu/gcp/workforce-identity/main.tf
+++ b/opentofu/gcp/workforce-identity/main.tf
@@ -42,22 +42,26 @@ resource "google_iam_workforce_pool_provider" "zitadel" {
   oidc {
     issuer_uri = local.identity_provider_url
 
-    # The ZITADEL PROJECT id, not a per-cluster OIDC client id. ZITADEL includes
-    # the project id in the aud of every token issued for that project, and STS
-    # accepts it (measured 2026-09-02). Pinning the project rather than an app
-    # is what lets this stack run before any OIDC client exists.
+    # A BOOTSTRAP PLACEHOLDER. The real value is the OIDC client id of the app
+    # whose token is exchanged (headlamp-proxy), and it is set out of band by
+    # `reconcile_workforce_audience` in scripts/zitadel-oidc-clients.sh once that
+    # app exists. Read that function's header comment before changing anything
+    # here -- it carries the measurement this design rests on.
     #
-    # THAT ONLY HOLDS WHEN THE PROJECT ID IS KNOWN IN ADVANCE, which is true for
-    # an AWS-hosted ZITADEL because its rebuilds restore from a seed and keep
-    # their ids. A GCP-primary bootstrap mints a brand-new instance with a new
-    # project id, so the value cannot be committed ahead of time -- see
-    # `resolve_workforce_audience` in scripts/zitadel-oidc-clients.sh, which
-    # reconciles it once the project exists.
+    # This field held the ZITADEL PROJECT id until 2026-09-12, on the reasoning
+    # that ZITADEL puts the project id in the aud of every token the project
+    # issues, so any client would be accepted and the pool could be created
+    # before a single OIDC app existed. The aud claim does carry it. But asking
+    # for the project audience scope makes aud MULTI-VALUED, and OIDC Core
+    # 3.1.3.7 then requires azp to equal the relying party's client id -- which
+    # Google STS enforces. azp is the client the token was issued TO, never the
+    # project, so the exchange failed `invalid_grant` on every single request
+    # from the day it shipped, with every component reporting healthy.
     #
-    # lifecycle.ignore_changes keeps that script's update from being reverted by
-    # the next apply. The alternative -- tofu overwriting the live audience with
-    # a stale committed value -- fails as a bare `invalid_grant` with every
-    # component reporting healthy.
+    # Keeping a project id here is therefore harmless only because the field is
+    # ignore_changes'd and the script owns the live value; it is NOT a working
+    # configuration on its own. A fresh bootstrap has a non-functional provider
+    # until that script runs, exactly as it did before.
     client_id = var.zitadel_project_id
 
     web_sso_config {

--- a/scripts/test-zitadel-workforce-audience.sh
+++ b/scripts/test-zitadel-workforce-audience.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 #
-# The workforce provider's audience is the ZITADEL PROJECT id. That value is
-# committable while AWS is primary -- its ZITADEL restores from a seed and keeps
-# its ids -- but a GCP-primary bootstrap mints a new instance with a generated
-# id, so the committed value is wrong and the failure is
-# `token exchange 400: invalid_grant` with every component reporting healthy.
+# The workforce provider's audience is the OIDC CLIENT ID of the app whose token
+# is exchanged (headlamp-proxy) -- not the ZITADEL project id.
+#
+# It was the project id until 2026-09-12, on the reasoning that ZITADEL stamps
+# the project id into the `aud` of every token the project issues. It does. But
+# the project audience scope makes `aud` MULTI-VALUED, and OIDC Core 3.1.3.7
+# then requires `azp` to equal the relying party's client id -- which Google STS
+# enforces. `azp` is the client the token was issued TO, never the project, so
+# the exchange returned `invalid_grant` on every request from the day it shipped
+# while every component reported healthy. This test now pins the corrected
+# contract.
 #
 # reconcile_workforce_audience() closes that loop. What this test protects is
 # mostly its SKIP paths: it runs inside a script that configures every OIDC
@@ -13,11 +19,13 @@
 # The function is LIFTED verbatim out of zitadel-oidc-clients.sh via sed, the
 # same technique test-zitadel-oidc-clients-project.sh uses -- the script itself
 # is not sourceable, since it parses argv and demands --cluster/--cloud at the
-# top of the file. A change there is therefore a change under test.
-# WORKFORCE_POOL, APPLY and the STUB_* values are read ONLY by the eval'''d
-# function bodies lifted from the script under test, which shellcheck cannot see
-# through. File-wide because they are set at nearly every test case; the same
-# directive, for the same reason, as test-zitadel-oidc-clients-project.sh.
+# top of the file. A change there is therefore a change under test. That lift is
+# also why the function spells out the app name inline instead of reading a
+# module-level constant: anything outside the body is unbound here under set -u.
+# WORKFORCE_POOL, APPLY, APP_SUFFIX and the STUB_* values are read ONLY by the
+# eval'''d function bodies lifted from the script under test, which shellcheck
+# cannot see through. File-wide because they are set at nearly every test case;
+# the same directive, for the same reason, as test-zitadel-oidc-clients-project.sh.
 # shellcheck disable=SC2034
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -60,8 +68,21 @@ kubectl() {
         *patch*)       return "${STUB_PATCH_RC:-0}" ;;
     esac
 }
+# The ZITADEL side of the lookup. Empty STUB_APP_ID models "the app does not
+# exist yet"; empty STUB_CLIENT_ID models an app whose OIDC config ZITADEL
+# returned without one. Both must SKIP rather than pin a nonsense audience.
+app_id_by_name() {
+    printf 'app_id_by_name %s\n' "$*" >> "$CALLS"
+    printf '%s' "${STUB_APP_ID-app-1}"
+}
+app_get() {
+    printf 'app_get %s\n' "$*" >> "$CALLS"
+    printf '{"app":{"oidcConfig":{"clientId":"%s"}}}' "${STUB_CLIENT_ID-client-abc}"
+}
 calls() { cat "$CALLS" 2>/dev/null; }
 reset_calls() { : > "$CALLS"; }
+
+APP_SUFFIX=""
 
 # ── 1. no workforce pool configured -> do nothing at all ───────────────────
 # This is the AWS-only case, and the common one. It must not warn, fail, or
@@ -76,39 +97,53 @@ WORKFORCE_POOL="ogenki-zitadel"; APPLY="true"; reset_calls; out="$(reconcile_wor
 check "dry-run project: returns success"    "0"  "$rc"
 check "dry-run project: never calls gcloud" ""   "$(calls)"
 
-# ── 3. audience already correct -> no update ───────────────────────────────
+# ── 3. audience already correct -> no update, but still check the other end ─
+# THE AUDIENCE IS THE APP CLIENT ID, not the project id: passing "proj-123" as
+# the project must still pin "client-abc". If this ever passes with the project
+# id again, the 2026-09-12 regression is back.
 WORKFORCE_POOL="ogenki-zitadel"; APPLY="true"; reset_calls
-STUB_CURRENT_AUDIENCE="proj-123"
+STUB_CURRENT_AUDIENCE="client-abc"; STUB_CM_AUDIENCE="proj-123"
 out="$(reconcile_workforce_audience "proj-123" 2>&1)"; rc=$?
 check "already correct: returns success"    "0"  "$rc"
 case "$(calls)" in
     *update-oidc*) check "already correct: does NOT update" "no-update" "updated" ;;
     *)             check "already correct: does NOT update" "no-update" "no-update" ;;
 esac
+# Reconciling the consumer only after an UPDATE meant a correct provider left
+# the ConfigMap unexamined -- the half-fixed state that fails exactly like the
+# unfixed one.
+case "$(calls)" in
+    *kubectl*) check "already correct: still checks the consumer" "checked" "checked" ;;
+    *)         check "already correct: still checks the consumer" "checked" "$(calls)" ;;
+esac
 
 # ── 4. audience differs, but not --apply -> report only ────────────────────
 # The whole script is dry-run by default; this must respect that or a plan
 # would mutate the platform.
 WORKFORCE_POOL="ogenki-zitadel"; APPLY="false"; reset_calls
-STUB_CURRENT_AUDIENCE="old-proj"
+STUB_CURRENT_AUDIENCE="old-client"
 out="$(reconcile_workforce_audience "proj-123" 2>&1)"
 case "$(calls)" in
     *update-oidc*) check "dry-run: does NOT update" "no-update" "updated" ;;
     *)             check "dry-run: does NOT update" "no-update" "no-update" ;;
 esac
 case "$out" in
-    *"old-proj -> proj-123"*) check "dry-run: reports the change" "reported" "reported" ;;
-    *)                        check "dry-run: reports the change" "reported" "$out" ;;
+    *"old-client -> client-abc"*) check "dry-run: reports the change" "reported" "reported" ;;
+    *)                            check "dry-run: reports the change" "reported" "$out" ;;
 esac
 
-# ── 5. audience differs under --apply -> update ────────────────────────────
+# ── 5. audience differs under --apply -> update to the APP CLIENT ID ───────
 WORKFORCE_POOL="ogenki-zitadel"; APPLY="true"; reset_calls
-STUB_CURRENT_AUDIENCE="old-proj"
+STUB_CURRENT_AUDIENCE="old-client"
 out="$(reconcile_workforce_audience "proj-123" 2>&1)"; rc=$?
 check "apply: returns success"              "0"  "$rc"
 case "$(calls)" in
-    *"update-oidc"*"--client-id=proj-123"*) check "apply: updates to the new id" "updated" "updated" ;;
-    *)                                      check "apply: updates to the new id" "updated" "$(calls)" ;;
+    *"update-oidc"*"--client-id=client-abc"*) check "apply: pins the app client id" "updated" "updated" ;;
+    *)                                        check "apply: pins the app client id" "updated" "$(calls)" ;;
+esac
+case "$(calls)" in
+    *"--client-id=proj-123"*) check "apply: never pins the project id" "never" "pinned-the-project" ;;
+    *)                        check "apply: never pins the project id" "never" "never" ;;
 esac
 
 # ── 6. provider does not exist yet -> skip, do not fail the whole sync ─────
@@ -125,14 +160,58 @@ esac
 
 # ── 7. the update itself fails -> warn, but do not abort the sync ──────────
 WORKFORCE_POOL="ogenki-zitadel"; APPLY="true"; reset_calls
-STUB_CURRENT_AUDIENCE="old-proj"; STUB_UPDATE_RC=1
+STUB_CURRENT_AUDIENCE="old-client"; STUB_UPDATE_RC=1
 out="$(reconcile_workforce_audience "proj-123" 2>&1)"; rc=$?
 check "update fails: still returns success" "0"  "$rc"
 case "$out" in
     *invalid_grant*) check "update fails: names the consequence" "named" "named" ;;
     *)               check "update fails: names the consequence" "named" "$out" ;;
 esac
+STUB_UPDATE_RC=0
 
+# ── 7b. the app does not exist yet -> skip before touching gcloud ──────────
+# A FIRST sync creates headlamp-proxy inside the consumer loop, which is why
+# this function runs after it. If it is ever moved back above the loop, this is
+# the assertion that catches it: no app, no audience, and no failed run.
+WORKFORCE_POOL="ogenki-zitadel"; APPLY="true"; reset_calls
+STUB_APP_ID=""; STUB_CURRENT_AUDIENCE="old-client"
+out="$(reconcile_workforce_audience "proj-123" 2>&1)"; rc=$?
+check "no app yet: returns success"         "0"  "$rc"
+case "$(calls)" in
+    *update-oidc*) check "no app yet: does NOT update" "no-update" "updated" ;;
+    *)             check "no app yet: does NOT update" "no-update" "no-update" ;;
+esac
+case "$out" in
+    *"does not exist yet"*) check "no app yet: says which app" "named" "named" ;;
+    *)                      check "no app yet: says which app" "named" "$out" ;;
+esac
+STUB_APP_ID="app-1"
+
+# ── 7c. the app exists but carries no clientId -> skip, do not pin empty ───
+# Pinning an empty client id would make the provider reject every token, which
+# is strictly worse than leaving the stale one in place.
+WORKFORCE_POOL="ogenki-zitadel"; APPLY="true"; reset_calls
+STUB_CLIENT_ID=""; STUB_CURRENT_AUDIENCE="old-client"
+out="$(reconcile_workforce_audience "proj-123" 2>&1)"; rc=$?
+check "no clientId: returns success"        "0"  "$rc"
+case "$(calls)" in
+    *update-oidc*) check "no clientId: does NOT update" "no-update" "updated" ;;
+    *)             check "no clientId: does NOT update" "no-update" "no-update" ;;
+esac
+STUB_CLIENT_ID="client-abc"
+
+# ── 7d. a consuming cluster's app is suffixed -> look up the suffixed name ──
+# APP_SUFFIX is "-<cluster>" for a cluster that only CONSUMES this directory.
+# Looking up the bare name there finds nothing and silently leaves the provider
+# pinned to whatever it had.
+WORKFORCE_POOL="ogenki-zitadel"; APPLY="true"; reset_calls
+APP_SUFFIX="-gcp-0"; STUB_CURRENT_AUDIENCE="old-client"
+out="$(reconcile_workforce_audience "proj-123" 2>&1)"
+case "$(calls)" in
+    *"app_id_by_name proj-123 headlamp-proxy-gcp-0"*) check "suffixed app: looked up by suffixed name" "suffixed" "suffixed" ;;
+    *)                                                check "suffixed app: looked up by suffixed name" "suffixed" "$(calls)" ;;
+esac
+APP_SUFFIX=""
 
 # ── 8. consumer half: scope already correct -> no patch ────────────────────
 # Every AWS-primary run lands here, so a false patch would be constant churn.
@@ -145,8 +224,8 @@ case "$(calls)" in
 esac
 
 # ── 9. consumer half: scope stale -> patch it ──────────────────────────────
-# THE BUG THIS EXISTS FOR. Without it the pool expects the new project id while
-# oauth2-proxy keeps requesting the old one, and every exchange 400s forever
+# THE BUG THIS EXISTS FOR. Without it the pool expects one audience while
+# oauth2-proxy keeps requesting another, and every exchange 400s forever
 # while every component reports healthy.
 reset_calls; STUB_CM_AUDIENCE="old-proj"
 out="$(reconcile_consumer_audience "proj-123" 2>&1)"; rc=$?

--- a/scripts/zitadel-oidc-clients.sh
+++ b/scripts/zitadel-oidc-clients.sh
@@ -690,32 +690,67 @@ reconcile_consumer_audience() {
     fi
 }
 
-# THE WORKFORCE PROVIDER'S AUDIENCE IS THE ZITADEL PROJECT ID, and on some
-# topologies it cannot be committed ahead of time.
+# THE WORKFORCE PROVIDER'S AUDIENCE IS AN OIDC CLIENT ID, NOT THE PROJECT ID.
 #
-# opentofu/gcp/workforce-identity pins the provider's client_id to the project
-# id, because ZITADEL puts that id in the `aud` of every token the project
-# issues -- so any client is accepted and the pool can be created before a
-# single OIDC app exists. That trick relies on the id being KNOWN in advance,
-# which holds while AWS is primary: its ZITADEL restores from a seed and keeps
-# its ids across rebuilds.
+# This used to pin the provider's client_id to the ZITADEL project id, reasoning
+# that ZITADEL stamps the project id into the `aud` of every token the project
+# issues -- so any client would be accepted and the pool could exist before a
+# single OIDC app did. The `aud` part of that was measured correctly.
 #
-# A GCP-primary bootstrap mints a brand-new ZITADEL, whose project id is
-# generated. The committed value is then wrong, and the failure is the worst
-# kind: `token exchange 400: invalid_grant`, with oauth2-proxy, the exchange
-# proxy and the dashboard all reporting healthy.
+# What it missed is `azp`. Requesting the project audience scope makes `aud`
+# MULTI-VALUED (on gcp-0: six app client ids plus the project id), and for a
+# multi-audience token OIDC Core 3.1.3.7 requires `azp` to be present and to
+# equal the relying party's client id. Google STS enforces exactly that. `azp` is
+# always the client the token was ISSUED TO -- headlamp-proxy -- and never the
+# project, so a project-pinned client_id could not match it and every exchange
+# failed:
 #
-# This script already resolves the project id and already runs after the cluster
-# exists, so it closes that loop. The tofu resource carries
-# `lifecycle.ignore_changes` on the same field so the next apply does not put
-# the stale value back.
+#   token exchange 400: invalid_grant
+#   (azp=388283282036425069 aud=[<six client ids>, 388252679236747629])
+#
+# Measured on gcp-0 2026-09-12: the exchange had never once succeeded since it
+# was deployed, while oauth2-proxy, the exchange proxy, Headlamp and every Flux
+# resource reported healthy -- the same silent failure the old comment warned
+# about, arriving through the very mechanism it recommended.
+#
+# So the provider's client_id must be the client id of the app whose token is
+# presented. That is knowable only after the app exists, which is why this runs
+# AFTER the consumer loop rather than before it, and why the tofu resource keeps
+# `lifecycle.ignore_changes` on the field.
+#
+# The consumer end is unchanged and still keyed on the PROJECT id: that scope is
+# what puts a shared audience in the token at all, and with `azp` now matching
+# the provider, a multi-valued `aud` is accepted.
 reconcile_workforce_audience() {
-    local project_id="$1" current
+    local project_id="$1" current app_name app_id app_json client_id
     [ -n "$WORKFORCE_POOL" ] || return 0
     [ "$project_id" != "DRYRUN-PROJECT" ] || return 0
 
     if ! command -v gcloud >/dev/null 2>&1; then
         echo "workforce: gcloud not available, skipping audience reconciliation" >&2
+        return 0
+    fi
+
+    # The app name is spelled out here rather than held in a module-level
+    # constant on purpose: test-zitadel-workforce-audience.sh LIFTS this function
+    # body out with sed and eval's it, so anything it reads from the enclosing
+    # file is an unbound variable under `set -u` in the harness.
+    #
+    # Suffixed exactly as the consumer loop builds it. A cluster that only
+    # CONSUMES this directory names the app "headlamp-proxy-<cluster>", so
+    # looking up the bare name there would find nothing and silently leave the
+    # provider pinned to whatever it already had.
+    app_name="headlamp-proxy${APP_SUFFIX:-}"
+    app_id="$(app_id_by_name "$project_id" "$app_name")" || return 0
+    if [ -z "$app_id" ]; then
+        echo "workforce: ${app_name} does not exist yet, skipping audience reconciliation" >&2
+        return 0
+    fi
+
+    app_json="$(app_get "$project_id" "$app_id")" || return 0
+    client_id="$(jq -r '.app.oidcConfig.clientId // empty' <<< "$app_json")"
+    if [ -z "$client_id" ]; then
+        echo "workforce: ${app_name} has no oidcConfig.clientId, skipping" >&2
         return 0
     fi
 
@@ -728,12 +763,17 @@ reconcile_workforce_audience() {
         return 0
     fi
 
-    if [ "$current" = "$project_id" ]; then
-        echo "workforce: audience already ${project_id}"
+    if [ "$current" = "$client_id" ]; then
+        echo "workforce: audience already ${client_id} (${app_name})"
+        # Still check the other end. Reconciling the consumer only after an
+        # update meant a correct provider left the ConfigMap unexamined, which
+        # is precisely the half-fixed state the comment above warns is worse
+        # than fixing neither end.
+        reconcile_consumer_audience "$project_id"
         return 0
     fi
 
-    echo "workforce: audience ${current} -> ${project_id}"
+    echo "workforce: audience ${current} -> ${client_id} (${app_name})"
     if [ "$APPLY" != "true" ]; then
         echo "workforce: (dry-run, not applied)"
         return 0
@@ -741,7 +781,7 @@ reconcile_workforce_audience() {
 
     if gcloud iam workforce-pools providers update-oidc zitadel \
          --workforce-pool="$WORKFORCE_POOL" --location=global \
-         --client-id="$project_id" >/dev/null 2>&1; then
+         --client-id="$client_id" >/dev/null 2>&1; then
         echo "workforce: audience updated"
         reconcile_consumer_audience "$project_id"
     else
@@ -773,7 +813,9 @@ cmd_sync() {
     [ -n "$project_id" ] || { echo "could not resolve or create the ZITADEL project" >&2; exit 1; }
 
     ensure_project_role_assertion "$project_id"
-    reconcile_workforce_audience "$project_id"
+    # reconcile_workforce_audience runs AFTER the consumer loop below: it needs
+    # the headlamp-proxy app's client id, which does not exist on a first sync
+    # until that loop creates it.
     ensure_project_roles "$project_id"
     grant_admin_role "$GRANT_ADMIN" "$project_id"
 
@@ -945,6 +987,12 @@ cmd_sync() {
         echo "[created] ${name} -> ${key} (client ${client_id})"
         created=$((created + 1))
     done
+
+    # Only now is headlamp-proxy guaranteed to exist, so only now can the
+    # workforce provider be pinned to its client id. Deliberately after the loop
+    # and not before it -- see the function's header comment for why the audience
+    # is an app client id rather than the project id.
+    reconcile_workforce_audience "$project_id"
 
     echo
     echo "created: ${created}, updated: ${updated}, unchanged: ${skipped}, converged: ${converged}"

--- a/website/content/docs/decisions/0032-workforce-identity-federation-for-gke-rbac.md
+++ b/website/content/docs/decisions/0032-workforce-identity-federation-for-gke-rbac.md
@@ -251,11 +251,25 @@ presents the user's token and needs no service account of its own.
     `opentofu/gcp/workforce-identity/variables.tfvars`, and pinned by the
     `workforce-pool-id` doc claim (see Implementation Notes) so the docs
     cannot drift from it silently.
-- The audience the workforce pool provider trusts is the whole ZITADEL
-  **project**, not one OIDC client — any token ZITADEL issues in that project
-  can be exchanged. This is acceptable because exchange only establishes
-  identity; a user without the `admin` role still gets a token that
-  authenticates and authorises nothing.
+- The audience the workforce pool provider trusts is a single OIDC client —
+  `headlamp-proxy`, the app whose token the shim presents.
+
+  It was originally the whole ZITADEL **project**, on the reasoning that any
+  token the project issued would then be exchangeable and the pool could be
+  created before a single OIDC app existed. **That never worked.** Requesting
+  the project audience scope makes `aud` multi-valued; OIDC Core 3.1.3.7 then
+  requires `azp` to be present and to equal the trusted client id; Google STS
+  enforces exactly that; and `azp` is always the client the token was issued
+  to — never the project. Every exchange returned `invalid_grant` from the day
+  it shipped until 2026-09-12, while oauth2-proxy, the shim, Headlamp and every
+  Flux resource reported healthy.
+
+  Narrowing to one client is therefore not a regression from the original
+  design but the only form of it that functions — and it is the tighter grant
+  besides. The client id is not knowable at apply time, so
+  `reconcile_workforce_audience` in `scripts/zitadel-oidc-clients.sh` sets it
+  once the app exists, and the tofu resource keeps `lifecycle.ignore_changes`
+  on the field so the next apply cannot revert it.
 - A new component (the shim) briefly holds user tokens in memory, which is
   why it runs default-deny CiliumNetworkPolicy, restricted PSS, and a
   never-log-a-token rule.


### PR DESCRIPTION
## The bug

Per-user Kubernetes RBAC on `gcp-0` has never worked. The Headlamp token exchange returned
`token exchange 400: invalid_grant` on **every request since it was deployed**, while oauth2-proxy,
the exchange proxy, Headlamp and every Flux resource reported healthy — the exact silent shape
ADR-0032 was written to avoid.

## Root cause

The workforce pool provider's `oidc.client_id` was the ZITADEL **project** id. The reasoning in the
original comment was that ZITADEL stamps the project id into the `aud` of every token the project
issues, so any client would be accepted and the pool could be created before a single OIDC app
existed.

`aud` does carry it. What the reasoning missed is `azp`.

Requesting the project audience scope (`urn:zitadel:iam:org:project:id:<project>:aud`, set at
`tooling/gcp-0/headlamp/oauth2-proxy.yaml:124`) makes `aud` **multi-valued**. For a multi-audience
token, OIDC Core 3.1.3.7 requires `azp` to be present and to equal the relying party's client id,
and Google STS enforces exactly that. `azp` is always the client the token was *issued to* — never
the project.

Measured on `gcp-0` 2026-09-12, from the exchange proxy's own logs:

```
token exchange failed: token exchange 400: invalid_grant
  (subject iss=https://auth.gcp.cloud.ogenki.io
   azp=388283282036425069
   aud=["388252679706509677","388252685159170413","388252690209112429",
        "388283282036425069","388298628894097773","390316263164871415",
        "388252679236747629"])
```

`388283282036425069` is the `headlamp-proxy` app. `388252679236747629` is the project, and was the
provider's `client_id`. Those two can never be equal, so the check could never pass.

## The fix

`reconcile_workforce_audience` now resolves `headlamp-proxy`'s OIDC client id and pins the provider
to that.

- **Moved after the consumer loop.** On a first sync the app does not exist until that loop creates
  it, so resolving the client id beforehand is impossible. A regression test asserts the skip path.
- **The consumer end is unchanged** and still keyed on the project id: that scope is what puts a
  shared audience in the token at all, and with `azp` now matching the provider, a multi-valued
  `aud` is accepted.
- **The consumer end is now reconciled even when the provider is already correct.** Previously
  `reconcile_consumer_audience` ran only after a successful *update*, so a correct provider left the
  ConfigMap unexamined — the half-fixed state the function's own comment calls worse than fixing
  neither end.
- **Narrower grant.** The provider now trusts one OIDC client instead of every app in the project.
  ADR-0032's audience bullet is corrected accordingly.

## Verification

| Gate | Result |
|---|---|
| `scripts/test-zitadel-workforce-audience.sh` | 31/31 assertions, `rc=0` |
| The other 6 ZITADEL suites + `test-no-secret-argv.sh` | all `rc=0` |
| `shellcheck -x -S warning` (CI's exact invocation) | exit 0 |
| `./scripts/validate-doc-claims.sh` | 28/28 claims, 49 page checks |
| `./scripts/validate-links.sh` | all relative links resolve |
| Terraform fmt / validate / tflint | passed in the pre-commit hook |

The test previously asserted the old contract (`--client-id=proj-123`), so it is rewritten to the
new one and gains two regression guards — *pins the app client id* and *never pins the project id* —
plus cases for the app not existing yet, an app with no `clientId`, and the suffixed name a
consuming cluster uses.

## Still to do out of band

The tofu resource keeps `lifecycle.ignore_changes` on this field and the script owns the live value,
so **merging this does not fix the running cluster**. The live provider still reads the project id:

```
gcloud iam workforce-pools providers update-oidc zitadel \
  --workforce-pool=ogenki-zitadel --location=global \
  --client-id=388283282036425069
```

or re-run `scripts/zitadel-oidc-clients.sh ... --apply`, which now computes that value itself.

## Deliberately not changed

`zitadel_project_id = "388445486190712688"` in both `opentofu/gcp/gke/configure/variables.tfvars`
and `opentofu/gcp/workforce-identity/variables.tfvars` looks like drift — that project holds zero
apps in the GCP ZITADEL. It is not drift: `opentofu/config.tm.hcl:45` sets `primary_cloud = "aws"`,
so the committed value is the **AWS** ZITADEL's project id and is correct for the declared topology.

The real inconsistency is larger and is left for a separate change: the repo declares AWS-primary
while `gcp-0` is actually running its own ZITADEL at `https://auth.gcp.cloud.ogenki.io`, which is
why the live provider was reconciled to the GCP project id. Worth deciding deliberately rather than
patching a tfvars line underneath it.
