### PR TITLE
fix(secrets): seed image-gallery's role credential on GCP too

### DIFF
--- a/scripts/secret-store.sh
+++ b/scripts/secret-store.sh
@@ -618,32 +618,39 @@ GENERATABLE=(
     "observability-victoria-metrics-k8s-stack-grafana-envvars"
     "cnpg${_cnpg_sep}xplane-harbor${_cnpg_sep}roles${_cnpg_sep}harbor"
     "cnpg${_cnpg_sep}xplane-zitadel${_cnpg_sep}superuser"
+    "cnpg${_cnpg_sep}xplane-image-gallery${_cnpg_sep}roles${_cnpg_sep}image-gallery-app"
 )
 
-# image-gallery's role credential, AWS-ONLY -- appended rather than listed above
-# because it is the one entry here that does not exist on both clouds.
+# image-gallery's role credential is listed above unconditionally, like the two
+# cnpg entries beside it and for the reason the comment above GENERATABLE gives:
+# they are "seeded here so a rebuild does not depend on someone remembering".
 #
-# apps/base/complete is deliberately absent from apps/gcp-0/kustomization.yaml:
-# the application talks to S3 through an S3 SDK with the bucket hardcoded in its
-# container environment, so gcp-0 has no image-gallery, no SQLInstance for it,
-# and no ExternalSecret reading this key. Listing it unconditionally would make
-# `seed --cloud gcp` create a secret that cloud can never consume -- a paid,
-# permanently-unread entry, and a misleading one for anyone auditing the store.
+# It used to be appended under `if [ "$CLOUD" = "aws" ]`, and that was correct
+# when written: apps/base/complete was absent from apps/gcp-0/kustomization.yaml,
+# the application reached S3 with the bucket hardcoded in its container
+# environment, and so gcp-0 had no image-gallery, no SQLInstance for it and no
+# ExternalSecret reading this key. Seeding it there would have created a paid,
+# permanently-unread entry.
 #
-# It belongs here for exactly the reason the comment above GENERATABLE gives for
-# the other two cnpg entries: they are "seeded here so a rebuild does not depend
-# on someone remembering". This one was not, so it did. Nothing in this
-# repository creates it -- the SQLInstance Composition only ASKS for it -- so if
-# it were ever lost, a rebuild would fail the way that comment describes, naming
-# neither the key nor the cause: External Secrets reporting `could not get
-# secret data from provider` while the pod sits in CreateContainerConfigError
-# naming a Kubernetes Secret.
+# image-gallery v2 (#2022) made every clause of that false. apps/gcp-0 now
+# includes ../base/complete, the app selects its backend with
+# STORAGE_PROVIDER=gcs against a real GCS bucket, and gcp-0 does have both the
+# SQLInstance and the ExternalSecret. The stale gate then produced precisely the
+# failure the GENERATABLE comment warns about, observed on gcp-0 2026-09-13:
+# External Secrets could not read
+# `cnpg-xplane-image-gallery-roles-image-gallery-app` while both app replicas
+# AND the CNPG initdb pod sat in CreateContainerConfigError naming a Kubernetes
+# Secret.
 #
-# `if`, not `[ ... ] && ...`: under `set -o errexit` a trailing && test that
-# evaluates false makes the whole script exit here, on GCP, before doing anything.
-if [ "$CLOUD" = "aws" ]; then
-    GENERATABLE+=( "cnpg/xplane-image-gallery/roles/image-gallery-app" )
-fi
+# initdb needing it is what makes this a deadlock rather than an ordering
+# problem, and the distinction is worth keeping: CNPG cannot seed a credential
+# it requires in order to start, so nothing converges on its own.
+#
+# `seed_body` needed no change -- its case pattern is
+# `cnpg?xplane-image-gallery?roles?image-gallery-app`, where `?` matches either
+# separator, so the generator half was cloud-agnostic all along. Only this list
+# excluded GCP. Note the ORDER MATTERS warning in that arm: CNPG fixes the role
+# password when it CREATES the cluster, so seed before the claim reconciles.
 
 # 32 bytes of urandom, base64, punctuation removed so no consumer has to worry
 # about quoting it in a connection string or an env file.


### PR DESCRIPTION
## What

`GENERATABLE` in `scripts/secret-store.sh` gated image-gallery's CNPG role credential behind `if [ "$CLOUD" = "aws" ]`. This lists it unconditionally, so it resolves through `_cnpg_sep` on both clouds.

## Why

The gate was correct when written — `apps/base/complete` was absent from `apps/gcp-0/kustomization.yaml`, the app reached S3 with its bucket hardcoded in the container environment, and gcp-0 had no image-gallery, no SQLInstance for it and no ExternalSecret reading the key. Seeding it there would have created a paid, permanently-unread secret.

**image-gallery v2 (#2022) falsified every clause of that.** `apps/gcp-0` now includes `../base/complete`, the app selects its backend with `STORAGE_PROVIDER=gcs` against a real GCS bucket, and gcp-0 has both the SQLInstance and the ExternalSecret.

## Observed

On gcp-0 today, after #2022 reached the cluster: External Secrets could not read `cnpg-xplane-image-gallery-roles-image-gallery-app`, and **both app replicas and the CNPG `initdb` pod** sat in `CreateContainerConfigError` naming a Kubernetes Secret.

`initdb` needing that credential is what makes this a **deadlock rather than an ordering problem**: CNPG cannot seed a secret it requires in order to start, so nothing converges on its own. That is precisely the failure the comment above `GENERATABLE` warns about — "seeded here so a rebuild does not depend on someone remembering".

## Scope

`seed_body` needed no change. Its case pattern is `cnpg?xplane-image-gallery?roles?image-gallery-app`, where `?` matches either separator, so the generator half was cloud-agnostic all along. Only the list excluded GCP. No `bao_target_for` entry either: like the other two `cnpg/*` keys, this one stays in the cloud store because the SQLInstance composition hardcodes `secretStoreRef.name: clustersecretstore`, and `migrate` reports unmapped keys as `skipped (unmapped)`.

## Verification

- `seed --cloud gcp` (dry-run) resolves to `cnpg-xplane-image-gallery-roles-image-gallery-app` — character-for-character the key the cluster asked for.
- `seed --cloud aws` keeps the slash spelling, unchanged for aws-0.
- `shellcheck -x -S warning` clean; the two info-level findings (SC1091, SC2016 at lines 81 and 287) are identical before and after and predate this change.
- `test-cloud-secret-store.sh` and `test-cnpg-promote-seed.sh` both pass.

## After merge

`scripts/secret-store.sh seed --cloud gcp --apply` creates the secret. It never overwrites an existing one, so it is safe to re-run. Note the ORDER MATTERS warning in `seed_body`: CNPG fixes the role password when it creates the cluster — currently safe, because `initdb` has not run.