### PR TITLE
fix(observability): the Query button lands in vmui, not Grafana Explore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,12 +437,19 @@ config with `amtool check-config`; renders every templated string in the Slack r
 `amtool template render`, golden-comparing the result; and asserts every `VMAlert` carries an
 **absolute** `external.url`.
 
-That last assertion is not theoretical. vmalert shipped with `external.url: "http://"` — the chart
-derives it from `.Values.external.grafana.host`, which was unset, and only falls back to the Grafana
-*ingress* host, which this platform does not use. Every `generatorURL` was therefore `http:/explore?…`
-with no host, and Slack silently drops an attachment action whose URL is invalid, so the Query button
-never rendered on any alert on either cluster. It sat in the bundle the whole time and no gate could
-fail on it: `flux schema validate` sees a valid string, polaris never reads `extraArgs`.
+That last assertion is not theoretical. vmalert shipped with `external.url: "http://"`, so every
+`generatorURL` was `http:/explore?…` with no host, and Slack silently drops an attachment action
+whose URL is invalid — the Query button never rendered on any alert on either cluster. It sat in the
+bundle the whole time and no gate could fail on it: `flux schema validate` sees a valid string,
+polaris never reads `extraArgs`.
+
+Both of vmalert's URL args are now set **explicitly** in `vm-common-helm-values-configmap.yaml`, so
+the Query button lands in **vmui** with the alert's own expression pre-filled rather than in Grafana
+Explore — the Dashboard button is already the Grafana link, and two of them on one message is one too
+many. The chart only fills these when absent (`if not (index $output.extraArgs …)`), so an explicit
+value wins. Note the escaping trap: the chart pipes the whole vmalert spec through Helm's `tpl`
+(`_helpers.tpl:291`), so `{{.Expr|queryEscape}}` must be written `{{ "{{" }}…{{ "}}" }}` or Helm
+evaluates it, finds no `queryEscape` function, and the render dies with a bare "invalid YAML".
 
 It validates **structure, not semantics**. A typo'd `equal` label (`clustre`) is a syntactically
 valid label name and passes; so do a shadowing route and an over-broad inhibit rule. Rendering

--- a/observability/base/victoria-metrics-k8s-stack/vm-common-helm-values-configmap.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vm-common-helm-values-configmap.yaml
@@ -72,6 +72,41 @@ data:
           env: "${environment}"
           cloud: "${cloud}"
           region: "${region}"
+        # The Query button lands in vmui with the alert's own expression already
+        # in the box, not in Grafana Explore.
+        #
+        # Two Grafana links on one message is one too many -- the Dashboard
+        # button is already Grafana, and it is the one carrying the Grafana
+        # icon. Query is the "show me the data behind this alert" button, and
+        # VictoriaMetrics' own UI answers that directly: vmui reads
+        # `g0.expr` and executes it on load.
+        #
+        # Both keys are set EXPLICITLY because the chart only fills them when
+        # they are absent (`if not (index $output.extraArgs ...)`,
+        # _helpers.tpl:186-198). Setting them here wins over the Grafana Explore
+        # form the chart would otherwise compose from external.grafana.host.
+        #
+        # Verified against the running vmui (VictoriaMetrics 2.24.0, vmui
+        # v1.151.0) rather than assumed: loading
+        # `/vmui/#/?g0.expr=vault_autopilot_failure_tolerance&g0.range_input=1h`
+        # pre-fills the query box and returns the series. Guessing at this URL
+        # shape is what shipped a dead Query button in the first place.
+        #
+        # TWO ESCAPES, both load-bearing, both of which fail loudly rather than
+        # quietly -- which is the only reason they are easy to get right:
+        #
+        # 1. SINGLE QUOTES, because the value contains `#`. Unquoted, YAML reads
+        #    it as a comment and the argument truncates to `vmui/`.
+        # 2. `{{ "{{" }}` / `{{ "}}" }}`, because the chart pipes the whole
+        #    vmalert spec through Helm's `tpl` (_helpers.tpl:291). A bare
+        #    `{{.Expr|queryEscape}}` is therefore evaluated by HELM, which has no
+        #    `queryEscape` function -- the render dies with "invalid YAML" and no
+        #    hint as to which value caused it. These escapes make Helm emit the
+        #    literal braces so vmalert, which does have `queryEscape`, receives
+        #    `{{.Expr|queryEscape}}` and expands it per alert.
+        extraArgs:
+          external.url: "https://vm.${private_domain_name}"
+          external.alert.source: 'vmui/#/?g0.expr={{ "{{" }}.Expr|queryEscape{{ "}}" }}&g0.range_input=1h'
 
     # vmalert's `-external.url`, and the reason the Query button in every Slack
     # alert has been dead since the day it was added.
@@ -93,6 +128,10 @@ data:
     # Include the scheme: the helper prefixes `http://` to anything without one.
     # `private_domain_name` is defined in both clusters' ConfigMaps, so one value
     # is correct on aws-0 and gcp-0 alike.
+    # Kept, but it no longer decides the Query button -- see the vmalert
+    # extraArgs below. Its remaining job is the dashboard sync-job's
+    # `grafanaUrl` (sync-job/config.yaml:126), which reads the same helper and
+    # was equally empty before this key existed.
     external:
       grafana:
         host: "https://grafana.${private_domain_name}"

--- a/scripts/alertmanager-fixtures/critical-single.json
+++ b/scripts/alertmanager-fixtures/critical-single.json
@@ -4,8 +4,22 @@
   "version": "4",
   "groupKey": "{}/{}:{alertname=\"OpenBaoRaftQuorumAtRisk\", cluster=\"aws-0\"}",
   "externalURL": "https://vmalertmanager-aws-0.priv.aws.ogenki.io",
-  "groupLabels": {"alertname": "OpenBaoRaftQuorumAtRisk", "cluster": "aws-0", "severity": "critical", "namespace": "security"},
-  "commonLabels": {"alertname": "OpenBaoRaftQuorumAtRisk", "cluster": "aws-0", "env": "dev", "cloud": "aws", "region": "eu-west-3", "severity": "critical", "namespace": "security", "job": "openbao"},
+  "groupLabels": {
+    "alertname": "OpenBaoRaftQuorumAtRisk",
+    "cluster": "aws-0",
+    "severity": "critical",
+    "namespace": "security"
+  },
+  "commonLabels": {
+    "alertname": "OpenBaoRaftQuorumAtRisk",
+    "cluster": "aws-0",
+    "env": "dev",
+    "cloud": "aws",
+    "region": "eu-west-3",
+    "severity": "critical",
+    "namespace": "security",
+    "job": "openbao"
+  },
   "commonAnnotations": {
     "summary": "OpenBao raft cluster cannot tolerate a node failure.",
     "description": "Failure tolerance has been below 1 for 15 minutes: losing one more\nnode loses quorum, and a cluster without quorum cannot issue a\ncertificate or read a secret. If OpenBaoRaftNodeLost fired first\nand was not acted on, this is that same dead peer plus a real one.",
@@ -15,7 +29,17 @@
   "alerts": [
     {
       "status": "firing",
-      "labels": {"alertname": "OpenBaoRaftQuorumAtRisk", "cluster": "aws-0", "env": "dev", "cloud": "aws", "region": "eu-west-3", "severity": "critical", "namespace": "security", "job": "openbao", "instance": "10.0.12.44:8200"},
+      "labels": {
+        "alertname": "OpenBaoRaftQuorumAtRisk",
+        "cluster": "aws-0",
+        "env": "dev",
+        "cloud": "aws",
+        "region": "eu-west-3",
+        "severity": "critical",
+        "namespace": "security",
+        "job": "openbao",
+        "instance": "10.0.12.44:8200"
+      },
       "annotations": {
         "summary": "OpenBao raft cluster cannot tolerate a node failure.",
         "description": "Failure tolerance has been below 1 for 15 minutes: losing one more\nnode loses quorum, and a cluster without quorum cannot issue a\ncertificate or read a secret. If OpenBaoRaftNodeLost fired first\nand was not acted on, this is that same dead peer plus a real one.",
@@ -24,7 +48,7 @@
       },
       "startsAt": "2026-09-12T09:06:00Z",
       "endsAt": "0001-01-01T00:00:00Z",
-      "generatorURL": "https://grafana.priv.aws.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22vault_autopilot_failure_tolerance+%3C+1%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789203960000\",\"to\":\"now\"}}",
+      "generatorURL": "https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=vault_autopilot_failure_tolerance%7Bjob%3D%22openbao%22%7D%20%3C%201&g0.range_input=1h",
       "fingerprint": "0000000000000001"
     }
   ]

--- a/scripts/alertmanager-fixtures/degenerate.json
+++ b/scripts/alertmanager-fixtures/degenerate.json
@@ -4,16 +4,122 @@
   "version": "4",
   "groupKey": "{}/{}:{alertname=\"NodeFilesystemAlmostOutOfSpace\"}",
   "externalURL": "https://vmalertmanager-aws-0.priv.aws.ogenki.io",
-  "groupLabels": {"alertname": "NodeFilesystemAlmostOutOfSpace"},
-  "commonLabels": {"alertname": "NodeFilesystemAlmostOutOfSpace", "cluster": "aws-0", "env": "", "cloud": "", "region": ""},
+  "groupLabels": {
+    "alertname": "NodeFilesystemAlmostOutOfSpace"
+  },
+  "commonLabels": {
+    "alertname": "NodeFilesystemAlmostOutOfSpace",
+    "cluster": "aws-0",
+    "env": "",
+    "cloud": "",
+    "region": ""
+  },
   "commonAnnotations": {},
   "alerts": [
-    {"status": "firing", "labels": {"alertname": "NodeFilesystemAlmostOutOfSpace", "cluster": "aws-0", "instance": "10.0.1.11:9100"}, "annotations": {"description": "Filesystem on /dev/nvme0n1p1 at 10.0.1.11:9100 has only 3.24% available space left and is filling up fast. This host has been reporting steadily decreasing free space for the last six hours and will run out within the day at the current rate, which will evict pods and wedge the kubelet."}, "startsAt": "2026-09-12T07:00:00Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "https://grafana.priv.aws.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22node_filesystem_avail_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2F+node_filesystem_size_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2A+100+%3C+5%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789196400000\",\"to\":\"now\"}}", "fingerprint": "e1"},
-    {"status": "firing", "labels": {"alertname": "NodeFilesystemAlmostOutOfSpace", "cluster": "aws-0", "instance": "10.0.1.12:9100"}, "annotations": {"description": "Filesystem at 10.0.1.12:9100 has only 4.10% available space left."}, "startsAt": "2026-09-12T07:01:00Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "https://grafana.priv.aws.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22node_filesystem_avail_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2F+node_filesystem_size_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2A+100+%3C+5%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789196460000\",\"to\":\"now\"}}", "fingerprint": "e2"},
-    {"status": "firing", "labels": {"alertname": "NodeFilesystemAlmostOutOfSpace", "cluster": "aws-0", "instance": "10.0.1.13:9100"}, "annotations": {"description": "Filesystem at 10.0.1.13:9100 has only 4.55% available space left."}, "startsAt": "2026-09-12T07:02:00Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "https://grafana.priv.aws.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22node_filesystem_avail_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2F+node_filesystem_size_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2A+100+%3C+5%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789196520000\",\"to\":\"now\"}}", "fingerprint": "e3"},
-    {"status": "firing", "labels": {"alertname": "NodeFilesystemAlmostOutOfSpace", "cluster": "aws-0", "instance": "10.0.1.14:9100"}, "annotations": {"description": "Filesystem at 10.0.1.14:9100 has only 4.70% available space left."}, "startsAt": "2026-09-12T07:03:00Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "https://grafana.priv.aws.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22node_filesystem_avail_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2F+node_filesystem_size_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2A+100+%3C+5%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789196580000\",\"to\":\"now\"}}", "fingerprint": "e4"},
-    {"status": "firing", "labels": {"alertname": "NodeFilesystemAlmostOutOfSpace", "cluster": "aws-0", "instance": "10.0.1.15:9100"}, "annotations": {"description": "Filesystem at 10.0.1.15:9100 has only 4.81% available space left."}, "startsAt": "2026-09-12T07:04:00Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "https://grafana.priv.aws.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22node_filesystem_avail_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2F+node_filesystem_size_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2A+100+%3C+5%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789196640000\",\"to\":\"now\"}}", "fingerprint": "e5"},
-    {"status": "firing", "labels": {"alertname": "NodeFilesystemAlmostOutOfSpace", "cluster": "aws-0", "instance": "10.0.1.16:9100"}, "annotations": {"description": "Filesystem at 10.0.1.16:9100 has only 4.92% available space left."}, "startsAt": "2026-09-12T07:05:00Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "https://grafana.priv.aws.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22node_filesystem_avail_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2F+node_filesystem_size_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2A+100+%3C+5%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789196700000\",\"to\":\"now\"}}", "fingerprint": "e6"},
-    {"status": "firing", "labels": {"alertname": "NodeFilesystemAlmostOutOfSpace", "cluster": "aws-0", "instance": "10.0.1.17:9100"}, "annotations": {"description": "Filesystem at 10.0.1.17:9100 has only 4.99% available space left."}, "startsAt": "2026-09-12T07:06:00Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "https://grafana.priv.aws.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22node_filesystem_avail_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2F+node_filesystem_size_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2A+100+%3C+5%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789196760000\",\"to\":\"now\"}}", "fingerprint": "e7"}
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "NodeFilesystemAlmostOutOfSpace",
+        "cluster": "aws-0",
+        "instance": "10.0.1.11:9100"
+      },
+      "annotations": {
+        "description": "Filesystem on /dev/nvme0n1p1 at 10.0.1.11:9100 has only 3.24% available space left and is filling up fast. This host has been reporting steadily decreasing free space for the last six hours and will run out within the day at the current rate, which will evict pods and wedge the kubelet."
+      },
+      "startsAt": "2026-09-12T07:00:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=node_filesystem_avail_bytes%7Binstance%3D%2210.0.1.11%3A9100%22%7D%20%2F%20node_filesystem_size_bytes%20%3C%200.05&g0.range_input=1h",
+      "fingerprint": "e1"
+    },
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "NodeFilesystemAlmostOutOfSpace",
+        "cluster": "aws-0",
+        "instance": "10.0.1.12:9100"
+      },
+      "annotations": {
+        "description": "Filesystem at 10.0.1.12:9100 has only 4.10% available space left."
+      },
+      "startsAt": "2026-09-12T07:01:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=node_filesystem_avail_bytes%7Binstance%3D%2210.0.1.12%3A9100%22%7D%20%2F%20node_filesystem_size_bytes%20%3C%200.05&g0.range_input=1h",
+      "fingerprint": "e2"
+    },
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "NodeFilesystemAlmostOutOfSpace",
+        "cluster": "aws-0",
+        "instance": "10.0.1.13:9100"
+      },
+      "annotations": {
+        "description": "Filesystem at 10.0.1.13:9100 has only 4.55% available space left."
+      },
+      "startsAt": "2026-09-12T07:02:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=node_filesystem_avail_bytes%7Binstance%3D%2210.0.1.13%3A9100%22%7D%20%2F%20node_filesystem_size_bytes%20%3C%200.05&g0.range_input=1h",
+      "fingerprint": "e3"
+    },
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "NodeFilesystemAlmostOutOfSpace",
+        "cluster": "aws-0",
+        "instance": "10.0.1.14:9100"
+      },
+      "annotations": {
+        "description": "Filesystem at 10.0.1.14:9100 has only 4.70% available space left."
+      },
+      "startsAt": "2026-09-12T07:03:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=node_filesystem_avail_bytes%7Binstance%3D%2210.0.1.14%3A9100%22%7D%20%2F%20node_filesystem_size_bytes%20%3C%200.05&g0.range_input=1h",
+      "fingerprint": "e4"
+    },
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "NodeFilesystemAlmostOutOfSpace",
+        "cluster": "aws-0",
+        "instance": "10.0.1.15:9100"
+      },
+      "annotations": {
+        "description": "Filesystem at 10.0.1.15:9100 has only 4.81% available space left."
+      },
+      "startsAt": "2026-09-12T07:04:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=node_filesystem_avail_bytes%7Binstance%3D%2210.0.1.15%3A9100%22%7D%20%2F%20node_filesystem_size_bytes%20%3C%200.05&g0.range_input=1h",
+      "fingerprint": "e5"
+    },
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "NodeFilesystemAlmostOutOfSpace",
+        "cluster": "aws-0",
+        "instance": "10.0.1.16:9100"
+      },
+      "annotations": {
+        "description": "Filesystem at 10.0.1.16:9100 has only 4.92% available space left."
+      },
+      "startsAt": "2026-09-12T07:05:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=node_filesystem_avail_bytes%7Binstance%3D%2210.0.1.16%3A9100%22%7D%20%2F%20node_filesystem_size_bytes%20%3C%200.05&g0.range_input=1h",
+      "fingerprint": "e6"
+    },
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "NodeFilesystemAlmostOutOfSpace",
+        "cluster": "aws-0",
+        "instance": "10.0.1.17:9100"
+      },
+      "annotations": {
+        "description": "Filesystem at 10.0.1.17:9100 has only 4.99% available space left."
+      },
+      "startsAt": "2026-09-12T07:06:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=node_filesystem_avail_bytes%7Binstance%3D%2210.0.1.17%3A9100%22%7D%20%2F%20node_filesystem_size_bytes%20%3C%200.05&g0.range_input=1h",
+      "fingerprint": "e7"
+    }
   ]
 }

--- a/scripts/alertmanager-fixtures/golden/critical-single.txt
+++ b/scripts/alertmanager-fixtures/golden/critical-single.txt
@@ -35,7 +35,7 @@ https://openbao.org/docs/internals/telemetry/
 https://grafana.priv.aws.ogenki.io/dashboards
 
 ==> action:Query :mag:
-https://grafana.priv.aws.ogenki.io/explore?left={"datasource":"VictoriaMetrics","queries":[{"expr":%22vault_autopilot_failure_tolerance+%3C+1%22,"refId":"A"}],"range":{"from":"1789203960000","to":"now"}}
+https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=vault_autopilot_failure_tolerance%7Bjob%3D%22openbao%22%7D%20%3C%201&g0.range_input=1h
 
 ==> action:Silence :no_bell:
 https://vmalertmanager-aws-0.priv.aws.ogenki.io/#/silences/new?filter=%7Bcloud%3D"aws"%2C%20cluster%3D"aws-0"%2C%20env%3D"dev"%2C%20job%3D"openbao"%2C%20namespace%3D"security"%2C%20region%3D"eu-west-3"%2C%20severity%3D"critical"%2C%20alertname%3D"OpenBaoRaftQuorumAtRisk"%7D

--- a/scripts/alertmanager-fixtures/golden/degenerate.txt
+++ b/scripts/alertmanager-fixtures/golden/degenerate.txt
@@ -8,7 +8,7 @@
 :question: FIRING · 7 — NodeFilesystemAlmostOutOfSpace
 
 ==> title_link
-https://grafana.priv.aws.ogenki.io/explore?left={"datasource":"VictoriaMetrics","queries":[{"expr":%22node_filesystem_avail_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2F+node_filesystem_size_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2A+100+%3C+5%22,"refId":"A"}],"range":{"from":"1789196400000","to":"now"}}
+https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=node_filesystem_avail_bytes%7Binstance%3D%2210.0.1.11%3A9100%22%7D%20%2F%20node_filesystem_size_bytes%20%3C%200.05&g0.range_input=1h
 
 ==> text
 `aws-0`
@@ -40,7 +40,7 @@ https://cnref.ogenki.io/docs/platform/observability/dashboards-and-alerts/
 https://grafana.priv.cluster.local/dashboards
 
 ==> action:Query :mag:
-https://grafana.priv.aws.ogenki.io/explore?left={"datasource":"VictoriaMetrics","queries":[{"expr":%22node_filesystem_avail_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2F+node_filesystem_size_bytes%7Bjob%3D%5C%22node-exporter%5C%22%2Cfstype%21%3D%5C%22%5C%22%7D+%2A+100+%3C+5%22,"refId":"A"}],"range":{"from":"1789196400000","to":"now"}}
+https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=node_filesystem_avail_bytes%7Binstance%3D%2210.0.1.11%3A9100%22%7D%20%2F%20node_filesystem_size_bytes%20%3C%200.05&g0.range_input=1h
 
 ==> action:Silence :no_bell:
 https://vmalertmanager-aws-0.priv.aws.ogenki.io/#/silences/new?filter=%7Bcloud%3D""%2C%20cluster%3D"aws-0"%2C%20env%3D""%2C%20region%3D""%2C%20alertname%3D"NodeFilesystemAlmostOutOfSpace"%7D

--- a/scripts/alertmanager-fixtures/golden/mixed-firing-resolved.txt
+++ b/scripts/alertmanager-fixtures/golden/mixed-firing-resolved.txt
@@ -8,7 +8,7 @@
 :information_source: FIRING · 2 — CPUThrottlingHigh
 
 ==> title_link
-https://grafana.priv.aws.ogenki.io/explore?left={"datasource":"VictoriaMetrics","queries":[{"expr":%22sum+by+%28container%2C+pod%2C+namespace%29+%28increase%28container_cpu_cfs_throttled_periods_total%5B5m%5D%29%29+%2F+sum+by+%28container%2C+pod%2C+namespace%29+%28increase%28container_cpu_cfs_periods_total%5B5m%5D%29%29+%3E+0.25%22,"refId":"A"}],"range":{"from":"1789202400000","to":"now"}}
+https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=rate%28container_cpu_cfs_throttled_periods_total%7Bpod%3D%22xplane-harbor-valkey-0%22%7D%5B5m%5D%29%20%3E%200.25&g0.range_input=1h
 
 ==> text
 `aws-0 · dev`
@@ -36,7 +36,7 @@ https://cnref.ogenki.io/docs/platform/observability/dashboards-and-alerts/
 https://grafana.priv.cluster.local/dashboards
 
 ==> action:Query :mag:
-https://grafana.priv.aws.ogenki.io/explore?left={"datasource":"VictoriaMetrics","queries":[{"expr":%22sum+by+%28container%2C+pod%2C+namespace%29+%28increase%28container_cpu_cfs_throttled_periods_total%5B5m%5D%29%29+%2F+sum+by+%28container%2C+pod%2C+namespace%29+%28increase%28container_cpu_cfs_periods_total%5B5m%5D%29%29+%3E+0.25%22,"refId":"A"}],"range":{"from":"1789202400000","to":"now"}}
+https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=rate%28container_cpu_cfs_throttled_periods_total%7Bpod%3D%22xplane-harbor-valkey-0%22%7D%5B5m%5D%29%20%3E%200.25&g0.range_input=1h
 
 ==> action:Silence :no_bell:
 https://vmalertmanager-aws-0.priv.aws.ogenki.io/#/silences/new?filter=%7Bcloud%3D"aws"%2C%20cluster%3D"aws-0"%2C%20env%3D"dev"%2C%20namespace%3D"tooling"%2C%20region%3D"eu-west-3"%2C%20severity%3D"info"%2C%20alertname%3D"CPUThrottlingHigh"%7D

--- a/scripts/alertmanager-fixtures/golden/resolved.txt
+++ b/scripts/alertmanager-fixtures/golden/resolved.txt
@@ -35,7 +35,7 @@ https://cnref.ogenki.io/docs/platform/observability/dashboards-and-alerts/
 https://grafana.priv.aws.ogenki.io/dashboards
 
 ==> action:Query :mag:
-https://grafana.priv.aws.ogenki.io/explore?left={"datasource":"VictoriaMetrics","queries":[{"expr":%22100+%2A+%28count+by+%28job%2C+namespace%2C+service%29+%28up+%3D%3D+0%29+%2F+count+by+%28job%2C+namespace%2C+service%29+%28up%29%29+%3E+10%22,"refId":"A"}],"range":{"from":"1789203900000","to":"now"}}
+https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=up%7Bjob%3D%22core-dns%22%7D%20%3D%3D%200&g0.range_input=1h
 
 ==> action:Silence :no_bell:
 https://vmalertmanager-aws-0.priv.aws.ogenki.io/#/silences/new?filter=%7Bcloud%3D"aws"%2C%20cluster%3D"aws-0"%2C%20env%3D"dev"%2C%20job%3D"core-dns"%2C%20namespace%3D"kube-system"%2C%20region%3D"eu-west-3"%2C%20severity%3D"warning"%2C%20alertname%3D"TargetDown"%7D

--- a/scripts/alertmanager-fixtures/golden/warning-group-of-3.txt
+++ b/scripts/alertmanager-fixtures/golden/warning-group-of-3.txt
@@ -8,7 +8,7 @@ warning
 :warning: FIRING · 3 — KubePodCrashLooping
 
 ==> title_link
-https://grafana.priv.gcp.ogenki.io/explore?left={"datasource":"VictoriaMetrics","queries":[{"expr":%22max_over_time%28kube_pod_container_status_waiting_reason%7Breason%3D%5C%22CrashLoopBackOff%5C%22%2Cjob%3D%5C%22kube-state-metrics%5C%22%7D%5B5m%5D%29+%3E%3D+1%22,"refId":"A"}],"range":{"from":"1789204320000","to":"now"}}
+https://vm.priv.gcp.ogenki.io/vmui/#/?g0.expr=rate%28kube_pod_container_status_restarts_total%7Bpod%3D%22podinfo-7d8f%22%7D%5B10m%5D%29%20%3E%200&g0.range_input=1h
 
 ==> text
 `gcp-0 · dev`
@@ -37,7 +37,7 @@ https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping
 https://grafana.priv.cluster.local/dashboards
 
 ==> action:Query :mag:
-https://grafana.priv.gcp.ogenki.io/explore?left={"datasource":"VictoriaMetrics","queries":[{"expr":%22max_over_time%28kube_pod_container_status_waiting_reason%7Breason%3D%5C%22CrashLoopBackOff%5C%22%2Cjob%3D%5C%22kube-state-metrics%5C%22%7D%5B5m%5D%29+%3E%3D+1%22,"refId":"A"}],"range":{"from":"1789204320000","to":"now"}}
+https://vm.priv.gcp.ogenki.io/vmui/#/?g0.expr=rate%28kube_pod_container_status_restarts_total%7Bpod%3D%22podinfo-7d8f%22%7D%5B10m%5D%29%20%3E%200&g0.range_input=1h
 
 ==> action:Silence :no_bell:
 https://vmalertmanager-gcp-0.priv.gcp.ogenki.io/#/silences/new?filter=%7Bcloud%3D"gcp"%2C%20cluster%3D"gcp-0"%2C%20env%3D"dev"%2C%20namespace%3D"apps"%2C%20region%3D"europe-west1"%2C%20severity%3D"warning"%2C%20alertname%3D"KubePodCrashLooping"%7D

--- a/scripts/alertmanager-fixtures/mixed-firing-resolved.json
+++ b/scripts/alertmanager-fixtures/mixed-firing-resolved.json
@@ -4,12 +4,90 @@
   "version": "4",
   "groupKey": "{}/{}:{alertname=\"CPUThrottlingHigh\", cluster=\"aws-0\"}",
   "externalURL": "https://vmalertmanager-aws-0.priv.aws.ogenki.io",
-  "groupLabels": {"alertname": "CPUThrottlingHigh", "cluster": "aws-0", "severity": "info", "namespace": "tooling"},
-  "commonLabels": {"alertname": "CPUThrottlingHigh", "cluster": "aws-0", "env": "dev", "cloud": "aws", "region": "eu-west-3", "severity": "info", "namespace": "tooling"},
-  "commonAnnotations": {"summary": "Processes are being throttled by their CPU limit."},
+  "groupLabels": {
+    "alertname": "CPUThrottlingHigh",
+    "cluster": "aws-0",
+    "severity": "info",
+    "namespace": "tooling"
+  },
+  "commonLabels": {
+    "alertname": "CPUThrottlingHigh",
+    "cluster": "aws-0",
+    "env": "dev",
+    "cloud": "aws",
+    "region": "eu-west-3",
+    "severity": "info",
+    "namespace": "tooling"
+  },
+  "commonAnnotations": {
+    "summary": "Processes are being throttled by their CPU limit."
+  },
   "alerts": [
-    {"status": "resolved", "labels": {"alertname": "CPUThrottlingHigh", "cluster": "aws-0", "env": "dev", "cloud": "aws", "region": "eu-west-3", "severity": "info", "namespace": "tooling", "pod": "xplane-harbor-jobservice-7a", "container": "jobservice"}, "annotations": {"summary": "Processes are being throttled by their CPU limit.", "description": "26.10% throttling of CPU"}, "startsAt": "2026-09-12T08:20:00Z", "endsAt": "2026-09-12T08:55:00Z", "generatorURL": "https://grafana.priv.aws.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22sum+by+%28container%2C+pod%2C+namespace%29+%28increase%28container_cpu_cfs_throttled_periods_total%5B5m%5D%29%29+%2F+sum+by+%28container%2C+pod%2C+namespace%29+%28increase%28container_cpu_cfs_periods_total%5B5m%5D%29%29+%3E+0.25%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789201200000\",\"to\":\"now\"}}", "fingerprint": "d3"},
-    {"status": "firing", "labels": {"alertname": "CPUThrottlingHigh", "cluster": "aws-0", "env": "dev", "cloud": "aws", "region": "eu-west-3", "severity": "info", "namespace": "tooling", "pod": "xplane-harbor-valkey-0", "container": "metrics"}, "annotations": {"summary": "Processes are being throttled by their CPU limit.", "description": "27.78% throttling of CPU"}, "startsAt": "2026-09-12T08:40:00Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "https://grafana.priv.aws.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22sum+by+%28container%2C+pod%2C+namespace%29+%28increase%28container_cpu_cfs_throttled_periods_total%5B5m%5D%29%29+%2F+sum+by+%28container%2C+pod%2C+namespace%29+%28increase%28container_cpu_cfs_periods_total%5B5m%5D%29%29+%3E+0.25%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789202400000\",\"to\":\"now\"}}", "fingerprint": "d1"},
-    {"status": "firing", "labels": {"alertname": "CPUThrottlingHigh", "cluster": "aws-0", "env": "dev", "cloud": "aws", "region": "eu-west-3", "severity": "info", "namespace": "tooling", "pod": "xplane-harbor-core-5f", "container": "core"}, "annotations": {"summary": "Processes are being throttled by their CPU limit.", "description": "31.02% throttling of CPU"}, "startsAt": "2026-09-12T08:41:00Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "https://grafana.priv.aws.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22sum+by+%28container%2C+pod%2C+namespace%29+%28increase%28container_cpu_cfs_throttled_periods_total%5B5m%5D%29%29+%2F+sum+by+%28container%2C+pod%2C+namespace%29+%28increase%28container_cpu_cfs_periods_total%5B5m%5D%29%29+%3E+0.25%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789202460000\",\"to\":\"now\"}}", "fingerprint": "d2"}
+    {
+      "status": "resolved",
+      "labels": {
+        "alertname": "CPUThrottlingHigh",
+        "cluster": "aws-0",
+        "env": "dev",
+        "cloud": "aws",
+        "region": "eu-west-3",
+        "severity": "info",
+        "namespace": "tooling",
+        "pod": "xplane-harbor-jobservice-7a",
+        "container": "jobservice"
+      },
+      "annotations": {
+        "summary": "Processes are being throttled by their CPU limit.",
+        "description": "26.10% throttling of CPU"
+      },
+      "startsAt": "2026-09-12T08:20:00Z",
+      "endsAt": "2026-09-12T08:55:00Z",
+      "generatorURL": "https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=rate%28container_cpu_cfs_throttled_periods_total%7Bpod%3D%22xplane-harbor-jobservice-7a%22%7D%5B5m%5D%29%20%3E%200.25&g0.range_input=1h",
+      "fingerprint": "d3"
+    },
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "CPUThrottlingHigh",
+        "cluster": "aws-0",
+        "env": "dev",
+        "cloud": "aws",
+        "region": "eu-west-3",
+        "severity": "info",
+        "namespace": "tooling",
+        "pod": "xplane-harbor-valkey-0",
+        "container": "metrics"
+      },
+      "annotations": {
+        "summary": "Processes are being throttled by their CPU limit.",
+        "description": "27.78% throttling of CPU"
+      },
+      "startsAt": "2026-09-12T08:40:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=rate%28container_cpu_cfs_throttled_periods_total%7Bpod%3D%22xplane-harbor-valkey-0%22%7D%5B5m%5D%29%20%3E%200.25&g0.range_input=1h",
+      "fingerprint": "d1"
+    },
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "CPUThrottlingHigh",
+        "cluster": "aws-0",
+        "env": "dev",
+        "cloud": "aws",
+        "region": "eu-west-3",
+        "severity": "info",
+        "namespace": "tooling",
+        "pod": "xplane-harbor-core-5f",
+        "container": "core"
+      },
+      "annotations": {
+        "summary": "Processes are being throttled by their CPU limit.",
+        "description": "31.02% throttling of CPU"
+      },
+      "startsAt": "2026-09-12T08:41:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=rate%28container_cpu_cfs_throttled_periods_total%7Bpod%3D%22xplane-harbor-core-5f%22%7D%5B5m%5D%29%20%3E%200.25&g0.range_input=1h",
+      "fingerprint": "d2"
+    }
   ]
 }

--- a/scripts/alertmanager-fixtures/resolved.json
+++ b/scripts/alertmanager-fixtures/resolved.json
@@ -4,10 +4,49 @@
   "version": "4",
   "groupKey": "{}/{}:{alertname=\"TargetDown\", cluster=\"aws-0\"}",
   "externalURL": "https://vmalertmanager-aws-0.priv.aws.ogenki.io",
-  "groupLabels": {"alertname": "TargetDown", "cluster": "aws-0", "severity": "warning", "namespace": "kube-system"},
-  "commonLabels": {"alertname": "TargetDown", "cluster": "aws-0", "env": "dev", "cloud": "aws", "region": "eu-west-3", "severity": "warning", "namespace": "kube-system", "job": "core-dns"},
-  "commonAnnotations": {"summary": "One or more targets are unreachable.", "description": "100% of the core-dns/victoria-metrics-k8s-stack-core-dns targets in kube-system namespace are down.", "dashboard": "https://grafana.priv.aws.ogenki.io/dashboards"},
+  "groupLabels": {
+    "alertname": "TargetDown",
+    "cluster": "aws-0",
+    "severity": "warning",
+    "namespace": "kube-system"
+  },
+  "commonLabels": {
+    "alertname": "TargetDown",
+    "cluster": "aws-0",
+    "env": "dev",
+    "cloud": "aws",
+    "region": "eu-west-3",
+    "severity": "warning",
+    "namespace": "kube-system",
+    "job": "core-dns"
+  },
+  "commonAnnotations": {
+    "summary": "One or more targets are unreachable.",
+    "description": "100% of the core-dns/victoria-metrics-k8s-stack-core-dns targets in kube-system namespace are down.",
+    "dashboard": "https://grafana.priv.aws.ogenki.io/dashboards"
+  },
   "alerts": [
-    {"status": "resolved", "labels": {"alertname": "TargetDown", "cluster": "aws-0", "env": "dev", "cloud": "aws", "region": "eu-west-3", "severity": "warning", "namespace": "kube-system", "job": "core-dns"}, "annotations": {"summary": "One or more targets are unreachable.", "description": "100% of the core-dns/victoria-metrics-k8s-stack-core-dns targets in kube-system namespace are down.", "dashboard": "https://grafana.priv.aws.ogenki.io/dashboards"}, "startsAt": "2026-09-12T09:05:00Z", "endsAt": "2026-09-12T09:11:00Z", "generatorURL": "https://grafana.priv.aws.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22100+%2A+%28count+by+%28job%2C+namespace%2C+service%29+%28up+%3D%3D+0%29+%2F+count+by+%28job%2C+namespace%2C+service%29+%28up%29%29+%3E+10%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789203900000\",\"to\":\"now\"}}", "fingerprint": "c1"}
+    {
+      "status": "resolved",
+      "labels": {
+        "alertname": "TargetDown",
+        "cluster": "aws-0",
+        "env": "dev",
+        "cloud": "aws",
+        "region": "eu-west-3",
+        "severity": "warning",
+        "namespace": "kube-system",
+        "job": "core-dns"
+      },
+      "annotations": {
+        "summary": "One or more targets are unreachable.",
+        "description": "100% of the core-dns/victoria-metrics-k8s-stack-core-dns targets in kube-system namespace are down.",
+        "dashboard": "https://grafana.priv.aws.ogenki.io/dashboards"
+      },
+      "startsAt": "2026-09-12T09:05:00Z",
+      "endsAt": "2026-09-12T09:11:00Z",
+      "generatorURL": "https://vm.priv.aws.ogenki.io/vmui/#/?g0.expr=up%7Bjob%3D%22core-dns%22%7D%20%3D%3D%200&g0.range_input=1h",
+      "fingerprint": "c1"
+    }
   ]
 }

--- a/scripts/alertmanager-fixtures/warning-group-of-3.json
+++ b/scripts/alertmanager-fixtures/warning-group-of-3.json
@@ -4,12 +4,91 @@
   "version": "4",
   "groupKey": "{}/{}:{alertname=\"KubePodCrashLooping\", cluster=\"gcp-0\"}",
   "externalURL": "https://vmalertmanager-gcp-0.priv.gcp.ogenki.io",
-  "groupLabels": {"alertname": "KubePodCrashLooping", "cluster": "gcp-0", "severity": "warning", "namespace": "apps"},
-  "commonLabels": {"alertname": "KubePodCrashLooping", "cluster": "gcp-0", "env": "dev", "cloud": "gcp", "region": "europe-west1", "severity": "warning", "namespace": "apps"},
-  "commonAnnotations": {"summary": "Pod is restarting repeatedly.", "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping"},
+  "groupLabels": {
+    "alertname": "KubePodCrashLooping",
+    "cluster": "gcp-0",
+    "severity": "warning",
+    "namespace": "apps"
+  },
+  "commonLabels": {
+    "alertname": "KubePodCrashLooping",
+    "cluster": "gcp-0",
+    "env": "dev",
+    "cloud": "gcp",
+    "region": "europe-west1",
+    "severity": "warning",
+    "namespace": "apps"
+  },
+  "commonAnnotations": {
+    "summary": "Pod is restarting repeatedly.",
+    "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping"
+  },
   "alerts": [
-    {"status": "firing", "labels": {"alertname": "KubePodCrashLooping", "cluster": "gcp-0", "env": "dev", "cloud": "gcp", "region": "europe-west1", "severity": "warning", "namespace": "apps", "pod": "podinfo-7d8f"}, "annotations": {"summary": "Pod is restarting repeatedly.", "description": "12 restarts in 10m", "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping"}, "startsAt": "2026-09-12T09:12:00Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "https://grafana.priv.gcp.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22max_over_time%28kube_pod_container_status_waiting_reason%7Breason%3D%5C%22CrashLoopBackOff%5C%22%2Cjob%3D%5C%22kube-state-metrics%5C%22%7D%5B5m%5D%29+%3E%3D+1%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789204320000\",\"to\":\"now\"}}", "fingerprint": "b1"},
-    {"status": "firing", "labels": {"alertname": "KubePodCrashLooping", "cluster": "gcp-0", "env": "dev", "cloud": "gcp", "region": "europe-west1", "severity": "warning", "namespace": "apps", "pod": "podinfo-9f2c"}, "annotations": {"summary": "Pod is restarting repeatedly.", "description": "8 restarts in 10m", "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping"}, "startsAt": "2026-09-12T09:12:00Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "https://grafana.priv.gcp.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22max_over_time%28kube_pod_container_status_waiting_reason%7Breason%3D%5C%22CrashLoopBackOff%5C%22%2Cjob%3D%5C%22kube-state-metrics%5C%22%7D%5B5m%5D%29+%3E%3D+1%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789204320000\",\"to\":\"now\"}}", "fingerprint": "b2"},
-    {"status": "firing", "labels": {"alertname": "KubePodCrashLooping", "cluster": "gcp-0", "env": "dev", "cloud": "gcp", "region": "europe-west1", "severity": "warning", "namespace": "apps", "pod": "podinfo-b1a4"}, "annotations": {"summary": "Pod is restarting repeatedly.", "description": "5 restarts in 10m", "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping"}, "startsAt": "2026-09-12T09:12:00Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "https://grafana.priv.gcp.ogenki.io/explore?left={\"datasource\":\"VictoriaMetrics\",\"queries\":[{\"expr\":%22max_over_time%28kube_pod_container_status_waiting_reason%7Breason%3D%5C%22CrashLoopBackOff%5C%22%2Cjob%3D%5C%22kube-state-metrics%5C%22%7D%5B5m%5D%29+%3E%3D+1%22,\"refId\":\"A\"}],\"range\":{\"from\":\"1789204320000\",\"to\":\"now\"}}", "fingerprint": "b3"}
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "KubePodCrashLooping",
+        "cluster": "gcp-0",
+        "env": "dev",
+        "cloud": "gcp",
+        "region": "europe-west1",
+        "severity": "warning",
+        "namespace": "apps",
+        "pod": "podinfo-7d8f"
+      },
+      "annotations": {
+        "summary": "Pod is restarting repeatedly.",
+        "description": "12 restarts in 10m",
+        "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping"
+      },
+      "startsAt": "2026-09-12T09:12:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "https://vm.priv.gcp.ogenki.io/vmui/#/?g0.expr=rate%28kube_pod_container_status_restarts_total%7Bpod%3D%22podinfo-7d8f%22%7D%5B10m%5D%29%20%3E%200&g0.range_input=1h",
+      "fingerprint": "b1"
+    },
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "KubePodCrashLooping",
+        "cluster": "gcp-0",
+        "env": "dev",
+        "cloud": "gcp",
+        "region": "europe-west1",
+        "severity": "warning",
+        "namespace": "apps",
+        "pod": "podinfo-9f2c"
+      },
+      "annotations": {
+        "summary": "Pod is restarting repeatedly.",
+        "description": "8 restarts in 10m",
+        "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping"
+      },
+      "startsAt": "2026-09-12T09:12:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "https://vm.priv.gcp.ogenki.io/vmui/#/?g0.expr=rate%28kube_pod_container_status_restarts_total%7Bpod%3D%22podinfo-9f2c%22%7D%5B10m%5D%29%20%3E%200&g0.range_input=1h",
+      "fingerprint": "b2"
+    },
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "KubePodCrashLooping",
+        "cluster": "gcp-0",
+        "env": "dev",
+        "cloud": "gcp",
+        "region": "europe-west1",
+        "severity": "warning",
+        "namespace": "apps",
+        "pod": "podinfo-b1a4"
+      },
+      "annotations": {
+        "summary": "Pod is restarting repeatedly.",
+        "description": "5 restarts in 10m",
+        "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping"
+      },
+      "startsAt": "2026-09-12T09:12:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "https://vm.priv.gcp.ogenki.io/vmui/#/?g0.expr=rate%28kube_pod_container_status_restarts_total%7Bpod%3D%22podinfo-b1a4%22%7D%5B10m%5D%29%20%3E%200&g0.range_input=1h",
+      "fingerprint": "b3"
+    }
   ]
 }


### PR DESCRIPTION
Follow-up to #2033. Two Grafana links on one alert is one too many — the **Dashboard** button is already Grafana and is the one carrying the Grafana icon. **Query** is the "show me the data behind this alert" button, so it should open VictoriaMetrics' own UI.

## Before / after

```
  before   https://grafana.priv.gcp.ogenki.io/explore?left={"datasource":"VictoriaMetrics",…}
  after    https://vm.priv.gcp.ogenki.io/vmui/#/?g0.expr=vault_autopilot_failure_tolerance…&g0.range_input=1h
```

vmui reads `g0.expr` and executes it on load, so the button lands on the alert's own query with results already rendered.

## How

Both vmalert URL args are now set **explicitly**:

```yaml
vmalert:
  spec:
    extraArgs:
      external.url: "https://vm.${private_domain_name}"
      external.alert.source: 'vmui/#/?g0.expr={{ "{{" }}.Expr|queryEscape{{ "}}" }}&g0.range_input=1h'
```

The chart only fills these when absent (`if not (index $output.extraArgs …)`, `_helpers.tpl:186-198`), so explicit values win over the Grafana Explore form it composes from `external.grafana.host`. That key is **kept**: it still supplies the dashboard sync-job's `grafanaUrl` (`sync-job/config.yaml:126`), which was equally empty before #2033.

## Two escapes, both load-bearing

1. **Single quotes** — the value contains `#`. Unquoted, YAML reads it as a comment and the argument truncates to `vmui/`.
2. **`{{ "{{" }}` / `{{ "}}" }}`** — the chart pipes the whole vmalert spec through Helm's `tpl` (`_helpers.tpl:291`). A bare `{{.Expr|queryEscape}}` is evaluated by **Helm**, which has no `queryEscape` function, and the render dies with `FAIL HelmRelease/observability/victoria-metrics-k8s-stack: Use --debug flag to render out invalid YAML` — naming no value and no line. I hit exactly that before escaping it; both the trap and the symptom are documented at the value and in CLAUDE.md.

## Verified, not assumed

The URL shape was checked against the **running** vmui (VictoriaMetrics 2.24.0, vmui v1.151.0) by loading `/vmui/#/?g0.expr=vault_autopilot_failure_tolerance&g0.range_input=1h` in a browser: the query box pre-filled and the query executed, returning the live `cluster="gcp-0"` series. Guessing at this URL is precisely what shipped a dead Query button in the first place.

The join behaviour was checked too — a live `generatorURL` on `gcp-0` is currently `https://grafana.priv.gcp.ogenki.io/explore?left={…}`, scheme and double slash intact, so vmalert concatenates rather than URL-normalising and the `#` survives.

## Fixtures follow reality

All five fixtures now carry the vmui `generatorURL` vmalert actually emits, each alert with its own expression. Same reasoning as #2033: a fixture asserting a URL no cluster produces is what let a dead button survive a five-fixture gate.

A side benefit — `mixed-firing-resolved`'s discriminator is legible again. #2033 had to fall back to a 13-digit epoch buried in a 250-char URL; it is now the alert's own expression, so a broken firing-subset selection reads as a different query rather than a different timestamp.

## Verification

| Gate | Result |
|---|---|
| `./scripts/validate-manifests.sh` | exit 0 — `Valid: 2115, Invalid: 0, Skipped: 0`, `RENDER … failed=0` |
| Template gate | 3 configs accepted, 3 pairs (1 distinct), 13 strings × 5 fixtures match goldens |
| `validate-links.sh` / `validate-doc-claims.sh` | exit 0 / exit 0 (28 claims) |
| Mutation test | reverting `query_url` to `index .Alerts 0` → **exit 1** on `mixed-firing-resolved [action:Query]`; restored → exit 0 |

No cluster change is required to land this — it takes effect on the next reconcile.
