### PR TITLE
fix(security): read the annotation prefix external-dns 0.22 actually uses

### DIFF
--- a/security/base/zitadel/gateway.yaml
+++ b/security/base/zitadel/gateway.yaml
@@ -14,7 +14,15 @@ spec:
       #
       # Leaving them in a shared base is the pattern that has bitten this repo
       # repeatedly: valid YAML on both clouds, meaningful on one.
-      external-dns.alpha.kubernetes.io/hostname: "auth.${public_domain_name}"
+      # NOTE the prefix. external-dns 0.22 made `external-dns.kubernetes.io/`
+      # the default and removed the `alpha` fallback entirely, so the older
+      # `external-dns.alpha.kubernetes.io/hostname` is now read by nothing.
+      # It fails silently and expensively: the Gateway still comes up healthy
+      # with a public IP, external-dns keeps logging "All records are already
+      # up to date", and the record is simply never created. Every SSO login
+      # then breaks, because this hostname IS the OIDC issuer. Do not revert
+      # to the alpha form.
+      external-dns.kubernetes.io/hostname: "auth.${public_domain_name}"
   listeners:
     - name: auth
       hostname: "auth.${public_domain_name}"


### PR DESCRIPTION
## What broke

SSO is down on the public hostname. `auth.<public_domain_name>` has **no DNS
record**, so the OIDC issuer is unreachable and every login that depends on it
fails -- Grafana included.

## Root cause

external-dns **0.22** changed the default annotation prefix to
`external-dns.kubernetes.io/` and **removed the `alpha` fallback**. The ZITADEL
Gateway sets `external-dns.alpha.kubernetes.io/hostname`, which 0.22 reads as
nothing at all.

The version moved underneath us: the HelmRelease shows revision 1 at appVersion
**0.21.0** and revision 2 at **0.22.0**, both from chart `1.22.0`. That is the
"it was working yesterday" event.

## Why nothing alerted

Every layer looks healthy:

- Gateway `PROGRAMMED=True` with a public IP
- the Service still carries the annotation Cilium copies from
  `spec.infrastructure.annotations`
- `external_dns_source_endpoints_total 30`, `source_errors_total 0`,
  `registry_errors_total 0`
- the log line every minute is `All records are already up to date`

The hosted zone contains **zero** records for the public sub-domain.

## Ruled out first

- **Annotation spelling** -- the zone still holds a TXT written from this exact
  Service and annotation by an older cluster, so the spelling was right before.
- **RBAC** -- `can-i list services -A` is `yes`; the hand-written ClusterRole
  covers services, endpoints, pods, nodes and the Gateway kinds.
- **Endpoint readiness** -- the Service's EndpointSlice is `ready: true`.
- **Zone/domain filter** -- one hosted zone, matched, with
  `--aws-zone-match-parent` already set.

## The change

One line, plus a comment so nobody reverts it. This is the only alpha-prefixed
annotation in the tree.

## Verification

- `kustomize build` on the base and both cluster overlays renders the new key,
  and the aws-0 patch still strategic-merges its four load-balancer annotations
  alongside it rather than replacing the map
- `./scripts/validate-doc-claims.sh` -> **exit 0**, 28 claims / 49 page checks
- no documentation page quotes this annotation

## After merge

Watch for the record to appear, then confirm the issuer resolves and a login
completes. **aws-0 could not be checked from here** (its private endpoint does
not resolve outside the tailnet) but it consumes the same shared base and pins
the same chart, so it is very likely affected identically -- worth confirming.
