### PR TITLE
fix(observability): make the trace/log/metric cross-links actually work

### DIFF
--- a/apps/platform/image-gallery/loadgen.yaml
+++ b/apps/platform/image-gallery/loadgen.yaml
@@ -58,6 +58,8 @@ spec:
                   value: http://victoria-traces-vt-single-server.observability.svc.cluster.local:10428/insert/opentelemetry/v1/traces
                 - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
                   value: http://vmsingle-victoria-metrics-k8s-stack.observability.svc.cluster.local:8428/opentelemetry/v1/metrics
+                - name: USER
+                  value: loadgen # required for OTEL resource detector; user.Current() needs $USER or cgo
               resources:
                 requests:
                   cpu: 100m

--- a/observability/base/grafana-operator/dashboards/app-all-in-one.yaml
+++ b/observability/base/grafana-operator/dashboards/app-all-in-one.yaml
@@ -12,8 +12,8 @@ spec:
   json: |
     {
       "title": "Observability Demo - All in One",
-      "description": "RED metrics with exemplar-based trace correlation and log context",
-      "tags": ["observability", "traces", "metrics", "exemplars", "demo"],
+      "description": "RED metrics, trace search and service map, and log context",
+      "tags": ["observability", "traces", "metrics", "demo"],
       "timezone": "browser",
       "editable": true,
       "graphTooltip": 1,
@@ -111,6 +111,19 @@ spec:
             ],
             "skipUrlSync": false,
             "type": "constant"
+          },
+          {
+            "name": "min_trace_duration",
+            "label": "Min Trace Duration",
+            "type": "textbox",
+            "query": "",
+            "current": {
+              "selected": false,
+              "text": "",
+              "value": ""
+            },
+            "hide": 0,
+            "skipUrlSync": false
           }
         ]
       },
@@ -123,21 +136,19 @@ spec:
         },
         {
           "type": "timeseries",
-          "title": "HTTP Request Rate (requests/sec) [Click exemplar dots to view traces]",
+          "title": "HTTP Request Rate (requests/sec)",
           "gridPos": {"x": 0, "y": 1, "w": 12, "h": 8},
           "datasource": {"type": "prometheus", "uid": "$${datasource}"},
           "targets": [
             {
-              "expr": "sum(rate(http.server.request.count{service.name=\"$service\",http.route!~\"/healthz|/readyz\"}[1m]))",
+              "expr": "sum(rate(http.server.request.duration_count{service.name=\"$service\",http.route!~\"/healthz|/readyz\"}[1m]))",
               "legendFormat": "Total requests/sec",
-              "refId": "A",
-              "exemplar": true
+              "refId": "A"
             },
             {
-              "expr": "sum by (http.response.status_code) (rate(http.server.request.count{service.name=\"$service\",http.route!~\"/healthz|/readyz\"}[1m]))",
+              "expr": "sum by (http.response.status_code) (rate(http.server.request.duration_count{service.name=\"$service\",http.route!~\"/healthz|/readyz\"}[1m]))",
               "legendFormat": "{{http.response.status_code}}",
-              "refId": "B",
-              "exemplar": true
+              "refId": "B"
             }
           ],
           "fieldConfig": {
@@ -151,13 +162,7 @@ spec:
                 "lineWidth": 2,
                 "showPoints": "auto"
               },
-              "unit": "reqps",
-              "links": [
-                {
-                  "title": "View trace for this exemplar",
-                  "url": "/explore?left={\"datasource\":\"$${trace_datasource}\",\"queries\":[{\"query\":\"$${__value.labels.trace_id}\",\"refId\":\"A\"}]}"
-                }
-              ]
+              "unit": "reqps"
             }
           },
           "options": {
@@ -167,21 +172,19 @@ spec:
         },
         {
           "type": "timeseries",
-          "title": "Response Time (P95 latency) [Click exemplar dots to view traces]",
+          "title": "Response Time (P95 latency)",
           "gridPos": {"x": 12, "y": 1, "w": 12, "h": 8},
           "datasource": {"type": "prometheus", "uid": "$${datasource}"},
           "targets": [
             {
               "expr": "histogram_quantile(0.95, sum(rate(http.server.request.duration_bucket{service.name=\"$service\",http.route!~\"/healthz|/readyz\"}[1m])) by (vmrange, http.route))",
               "legendFormat": "P95 - {{http.route}}",
-              "refId": "A",
-              "exemplar": true
+              "refId": "A"
             },
             {
               "expr": "histogram_quantile(0.50, sum(rate(http.server.request.duration_bucket{service.name=\"$service\",http.route!~\"/healthz|/readyz\"}[1m])) by (vmrange))",
               "legendFormat": "P50 (median)",
-              "refId": "B",
-              "exemplar": true
+              "refId": "B"
             }
           ],
           "fieldConfig": {
@@ -197,8 +200,8 @@ spec:
               "unit": "s",
               "links": [
                 {
-                  "title": "View trace for this exemplar",
-                  "url": "/explore?left={\"datasource\":\"$${trace_datasource}\",\"queries\":[{\"query\":\"$${__value.labels.trace_id}\",\"refId\":\"A\"}]}"
+                  "title": "View traces for this time range",
+                  "url": "?viewPanel=1000&var-min_trace_duration=500ms&$${__url_time_range}"
                 }
               ]
             }
@@ -215,7 +218,7 @@ spec:
           "datasource": {"type": "prometheus", "uid": "$${datasource}"},
           "targets": [
             {
-              "expr": "sum(rate(http.server.request.count{service.name=\"$service\",http.route!~\"/healthz|/readyz\",http.response.status_code=~\"5..\"}[1m])) / sum(rate(http.server.request.count{service.name=\"$service\",http.route!~\"/healthz|/readyz\"}[1m])) * 100",
+              "expr": "sum(rate(http.server.request.duration_count{service.name=\"$service\",http.route!~\"/healthz|/readyz\",http.response.status_code=~\"5..\"}[1m])) / sum(rate(http.server.request.duration_count{service.name=\"$service\",http.route!~\"/healthz|/readyz\"}[1m])) * 100",
               "refId": "A"
             }
           ],
@@ -248,7 +251,7 @@ spec:
           "datasource": {"type": "prometheus", "uid": "$${datasource}"},
           "targets": [
             {
-              "expr": "sum(rate(http.server.request.count{service.name=\"$service\",http.route!~\"/healthz|/readyz\"}[1m]))",
+              "expr": "sum(rate(http.server.request.duration_count{service.name=\"$service\",http.route!~\"/healthz|/readyz\"}[1m]))",
               "refId": "A"
             }
           ],
@@ -305,7 +308,7 @@ spec:
           "datasource": {"type": "prometheus", "uid": "$${datasource}"},
           "targets": [
             {
-              "expr": "sum(increase(http.server.request.count{service.name=\"$service\",http.route!~\"/healthz|/readyz\",http.response.status_code=~\"5..\"}[5m]))",
+              "expr": "sum(increase(http.server.request.duration_count{service.name=\"$service\",http.route!~\"/healthz|/readyz\",http.response.status_code=~\"5..\"}[5m]))",
               "refId": "A"
             }
           ],
@@ -331,15 +334,14 @@ spec:
         },
         {
           "type": "timeseries",
-          "title": "Request Count by Status Code [Click exemplar dots to view traces]",
+          "title": "Request Count by Status Code",
           "gridPos": {"x": 0, "y": 13, "w": 24, "h": 6},
           "datasource": {"type": "prometheus", "uid": "$${datasource}"},
           "targets": [
             {
-              "expr": "sum by (http.response.status_code) (rate(http.server.request.count{service.name=\"$service\",http.route!~\"/healthz|/readyz\"}[1m]))",
+              "expr": "sum by (http.response.status_code) (rate(http.server.request.duration_count{service.name=\"$service\",http.route!~\"/healthz|/readyz\"}[1m]))",
               "legendFormat": "HTTP {{http.response.status_code}}",
-              "refId": "A",
-              "exemplar": true
+              "refId": "A"
             }
           ],
           "fieldConfig": {
@@ -351,13 +353,7 @@ spec:
                 "lineWidth": 2,
                 "stacking": {"mode": "normal"}
               },
-              "unit": "reqps",
-              "links": [
-                {
-                  "title": "View trace for this exemplar",
-                  "url": "/explore?left={\"datasource\":\"$${trace_datasource}\",\"queries\":[{\"query\":\"$${__value.labels.trace_id}\",\"refId\":\"A\"}]}"
-                }
-              ]
+              "unit": "reqps"
             },
             "overrides": [
               {
@@ -414,6 +410,53 @@ spec:
               "custom": {}
             }
           }
+        },
+        {
+          "type": "row",
+          "title": "🔍 TRACES: Search & Service Map",
+          "gridPos": {"x": 0, "y": 30, "w": 24, "h": 1},
+          "collapsed": false
+        },
+        {
+          "id": 1000,
+          "type": "traces",
+          "title": "Recent Traces (pick a slow one to open the waterfall)",
+          "description": "Trace search against VictoriaTraces via the Jaeger-compatible API, filtered to this service. Linked from the P95 latency panel, which sets a minimum duration to land on the slow traces.",
+          "gridPos": {"x": 0, "y": 31, "w": 12, "h": 10},
+          "datasource": {"type": "jaeger", "uid": "$${trace_datasource}"},
+          "targets": [
+            {
+              "queryType": "search",
+              "service": "$${service}",
+              "operation": "",
+              "tags": "",
+              "minDuration": "$${min_trace_duration}",
+              "maxDuration": "",
+              "limit": 20,
+              "refId": "A"
+            }
+          ],
+          "options": {}
+        },
+        {
+          "type": "nodeGraph",
+          "title": "Service Map",
+          "description": "Derived from the same trace search via the datasource's serviceMap/nodeGraph support.",
+          "gridPos": {"x": 12, "y": 31, "w": 12, "h": 10},
+          "datasource": {"type": "jaeger", "uid": "$${trace_datasource}"},
+          "targets": [
+            {
+              "queryType": "search",
+              "service": "$${service}",
+              "operation": "",
+              "tags": "",
+              "minDuration": "",
+              "maxDuration": "",
+              "limit": 20,
+              "refId": "A"
+            }
+          ],
+          "options": {}
         }
       ]
     }

--- a/observability/base/victoria-logs/grafana-datasource.yaml
+++ b/observability/base/victoria-logs/grafana-datasource.yaml
@@ -6,6 +6,16 @@ metadata:
 spec:
   allowCrossNamespaceImport: true
   datasource:
+    # Pinned so the traces datasource can reference this one; without it the
+    # operator assigns a random uid (this instance had
+    # 6ac62907-95e4-444c-972a-db2f0672bda4) and a reference written as the
+    # literal "VictoriaLogs" matched nothing.
+    #
+    # Deliberately the DEPRECATED `spec.datasource.uid` rather than `spec.uid`:
+    # the latter is immutable and is rejected on an already-created object, so
+    # Flux would fail every reconcile. See the same note in
+    # victoria-traces/grafana-datasource.yaml.
+    uid: victorialogs
     access: proxy
     type: victoriametrics-logs-datasource
     name: VictoriaLogs
@@ -14,11 +24,29 @@ spec:
     # Cluster
     # url: http://victoria-logs-victoria-logs-cluster-vlselect.observability:9471
     jsonData:
+      # This is the link the observability demo actually depends on: click a log
+      # line, land on its trace.
+      #
+      # It was previously a regex over the rendered line
+      # (`"log\.trace_id":"([0-9a-f]+)"`) and could never match. What Grafana
+      # renders per row is `_msg`, which holds only the message text ("Failed to
+      # create image"); the trace id is a separate structured FIELD. No
+      # correction to that pattern could have worked.
+      #
+      # `matcherType: label` matches a field instead of the line. The field is
+      # `log.trace_id` rather than `trace_id` because the `log.` prefix is added
+      # by `unpack_json`, which the dashboard's logs query pipes -- see
+      # observability/base/grafana-operator/dashboards/app-all-in-one.yaml. A
+      # query that does NOT unpack has no such field and simply gets no link.
+      #
+      # `datasourceUid`, never `datasourceName`: the latter is in no schema and
+      # fails silently.
       derivedFields:
         - name: "TraceID"
-          matcherRegex: "\"log\\.trace_id\":\"([0-9a-f]+)\""
+          matcherType: "label"
+          matcherRegex: "log.trace_id"
           url: "$${__value.raw}"
-          datasourceName: "VictoriaTraces"
+          datasourceUid: "victoriatraces"
           urlDisplayLabel: "View Trace"
   instanceSelector:
     matchLabels:

--- a/observability/base/victoria-traces/grafana-datasource.yaml
+++ b/observability/base/victoria-traces/grafana-datasource.yaml
@@ -6,31 +6,69 @@ metadata:
 spec:
   allowCrossNamespaceImport: true
   datasource:
+    # Pinned so the OTHER datasource can reference this one. Without it the
+    # operator assigns a random uid (this instance had
+    # 76f17555-0d1f-4012-b448-1a34896b7861), so every cross-reference written as
+    # the literal string "VictoriaTraces" resolved to nothing and every link
+    # silently did nothing.
+    #
+    # Deliberately the DEPRECATED `spec.datasource.uid` rather than `spec.uid`,
+    # which the CRD prefers: `spec.uid` is immutable, so setting it on these
+    # already-created objects is rejected outright --
+    #   The GrafanaDatasource "vt-datasource" is invalid: spec: Invalid value:
+    #   spec.uid is immutable
+    # and Flux would fail the same way on every reconcile. Server-side dry-run
+    # confirms the deprecated path applies cleanly in place. The alternative was
+    # renaming both objects so they are re-created; that churns live datasources
+    # for no gain. Revisit if the deprecated field is removed.
+    uid: victoriatraces
     access: proxy
     type: jaeger
     name: VictoriaTraces
     url: http://victoria-traces-vt-single-server.observability:10428/select/jaeger
     jsonData:
-      tracesToLogs:
-        datasourceName: VictoriaLogs
-        tags: ['trace_id', 'traceId', 'traceID']
-        mappedTags:
-          - key: service.name
-            value: service_name
+      # The key is `datasourceUid`, NEVER `datasourceName` -- no Grafana schema
+      # has ever accepted the latter, so these links silently did nothing on
+      # both clusters until 2026-09-13. A wrong key here fails invisibly: the
+      # datasource still loads, the link just never appears.
+      #
+      # `tracesToLogsV2`, not `tracesToLogs`: v1 is superseded and current
+      # Grafana (13.1.4 here) reads v2. Correcting keys inside the v1 block
+      # would have looked like a fix and changed nothing.
+      tracesToLogsV2:
+        datasourceUid: victorialogs
         spanStartTimeShift: '-1h'
         spanEndTimeShift: '1h'
         filterByTraceID: true
         filterBySpanID: false
+        # UNVERIFIED against a live Grafana. VictoriaLogs speaks LogsQL, not
+        # LogQL, so `filterByTraceID` may not translate into a query it accepts;
+        # if this direction stays empty, the fix is `customQuery: true` plus a
+        # LogsQL `query` keyed on the span's trace id. The reverse direction
+        # (logs -> trace) is configured in the VictoriaLogs datasource and is
+        # the one the demo relies on.
       tracesToMetrics:
-        datasourceName: VictoriaMetrics
-        tags: ['service.name', 'http.method', 'http.status_code']
+        datasourceUid: VictoriaMetrics
+        # Objects, not bare strings -- the schema is Array<{key, value?}>. `key`
+        # is the span attribute; omit `value` when the metric label has the same
+        # name. These are OTel semconv v2 names, verified against live series:
+        # `http.method` / `http.status_code` do not exist.
+        tags:
+          - key: service.name
+          - key: http.request.method
+          - key: http.response.status_code
         queries:
+          # Real series names. `http_server_requests_total` and
+          # `http_server_duration_seconds_bucket` never existed here; the app
+          # emits dot-named OTel metrics and VictoriaMetrics stores histograms
+          # with `vmrange` labels, so a quantile must aggregate by vmrange --
+          # same shape as the VMRules in apps/platform/image-gallery/app.yaml.
           - name: 'Request rate'
-            query: 'rate(http_server_requests_total{$$__tags}[5m])'
-          - name: 'Request duration'
-            query: 'histogram_quantile(0.95, rate(http_server_duration_seconds_bucket{$$__tags}[5m]))'
+            query: 'sum(rate(http.server.request.duration_count{$$__tags}[5m]))'
+          - name: 'Request duration (p95)'
+            query: 'histogram_quantile(0.95, sum(rate(http.server.request.duration_bucket{$$__tags}[5m])) by (vmrange))'
       serviceMap:
-        datasourceName: VictoriaMetrics
+        datasourceUid: VictoriaMetrics
       nodeGraph:
         enabled: true
   instanceSelector:

--- a/website/content/docs/decisions/0010-victoriametrics-over-prometheus.md
+++ b/website/content/docs/decisions/0010-victoriametrics-over-prometheus.md
@@ -222,6 +222,29 @@ GitOps patterns should not default to.
     drift; the remaining variant-specific values are still a diff to check
     by hand, not something CI enforces.
 
+- **The cross-signal linking named above was misconfigured from the day it
+  was written, and silently did nothing until 2026-09-13.** "One Grafana,
+  three signals, cross-linked out of the box" was the intent; the
+  implementation used a key — `datasourceName` — that appears in no Grafana
+  schema, inside a `tracesToLogs` block that current Grafana no longer reads
+  (it reads `tracesToLogsV2`), referencing datasources by a literal name when
+  neither had a pinned `uid`, so the reference resolved to nothing. The
+  logs-side `TraceID` derived field matched a regex against the rendered log
+  line, where the trace id has never appeared — it is a structured field, and
+  `_msg` carries only the message text. Trace-to-logs, trace-to-metrics,
+  log-to-trace and the service map were all inert, on both clusters, for the
+  life of the configuration.
+  - *Mitigation*: fixed in the datasource CRs, with the reasoning recorded at
+    the point of failure in each file and the corrected shape shown on the
+    [Dashboards and alerts]({{< relref "/docs/platform/observability/dashboards-and-alerts.md" >}})
+    page. The deeper lesson is not mitigated and is worth stating plainly:
+    **nothing in CI can catch this class of defect.** `flux schema validate`
+    sees a well-formed map, polaris does not read datasource config, and a
+    documentation claim only fails when it pins the exact value. The failure
+    is invisible at every layer — the datasource loads, the dashboard renders,
+    and the link simply never appears — so it is only ever found by using the
+    feature or by reading the vendor's schema.
+
 ### Neutral
 
 - Traces are not queried through a VictoriaMetrics-specific query

--- a/website/content/docs/platform/observability/dashboards-and-alerts.md
+++ b/website/content/docs/platform/observability/dashboards-and-alerts.md
@@ -113,22 +113,43 @@ release silently kept — ×30 the intent — until the suffix was added on
 ```yaml
 # observability/base/victoria-traces/grafana-datasource.yaml
 datasource:
+  uid: victoriatraces            # pinned; see below
   type: jaeger
   url: http://victoria-traces-vt-single-server.observability:10428/select/jaeger
   jsonData:
-    tracesToLogs:
-      datasourceName: VictoriaLogs
-      tags: ['trace_id', 'traceId', 'traceID']
+    tracesToLogsV2:
+      datasourceUid: victorialogs
     tracesToMetrics:
-      datasourceName: VictoriaMetrics
+      datasourceUid: VictoriaMetrics
+      tags:
+        - key: service.name
     nodeGraph:
       enabled: true
 ```
 
-`tracesToLogs`/`tracesToMetrics` are what let a Grafana user pivot from a
-trace span straight to the matching log lines (via `log.trace_id`, per the
+`tracesToLogsV2`/`tracesToMetrics` are what let a Grafana user pivot from a
+trace span to the matching log lines (via `log.trace_id`, per the
 [LogsQL rules]({{< relref "/docs/platform/observability/logs.md#logsql-syntax-rules" >}}))
-or request-rate/latency panels, without re-typing a query by hand. The
+or request-rate/latency panels, without re-typing a query by hand.
+
+**Three details here are load-bearing, and all three were wrong until
+2026-09-13 — every cross-link silently did nothing from the day it was
+written:**
+
+- **`datasourceUid`, never `datasourceName`.** No Grafana schema has ever
+  accepted the latter. There is no error: the datasource loads and the link
+  simply never appears.
+- **`tracesToLogsV2`, not `tracesToLogs`.** v1 is superseded and current
+  Grafana reads v2, so correcting keys inside a v1 block changes nothing.
+- **A pinned `uid`.** Without one the operator assigns a random uid, so a
+  reference written as the literal string `VictoriaLogs` matches no
+  datasource. Note it is set at `spec.datasource.uid`, the field the CRD
+  marks deprecated, and deliberately: `spec.uid` is immutable and the API
+  server rejects it outright on an already-created object, which would fail
+  every Flux reconcile.
+
+None of this is caught by CI — `flux schema validate` sees a well-formed
+map, and no documentation claim pins these values. The
 manifest doesn't configure an explicit receiver protocol (no OTLP toggles) —
 VictoriaTraces' chart defaults apply unmodified, so which ingest protocols
 are actually enabled isn't determinable from this repo alone.

--- a/website/content/docs/platform/observability/logs.md
+++ b/website/content/docs/platform/observability/logs.md
@@ -66,10 +66,13 @@ queries that silently return nothing, not an error:
    ```
 2. **After `| unpack_json`, fields are prefixed `log.`** — `log.level`,
    `log.trace_id`, not the bare field name. Confirmed by the trace-correlation
-   derived field on the Grafana datasource:
+   derived field on the Grafana datasource, which matches the FIELD rather
+   than the rendered line — `_msg` holds only the message text, so a regex
+   over the line could never match it:
    ```yaml
    # observability/base/victoria-logs/grafana-datasource.yaml
-   matcherRegex: "\"log\\.trace_id\":\"([0-9a-f]+)\""
+   matcherType: "label"
+   matcherRegex: "log.trace_id"
    ```
 3. **Grafana dashboard JSON needs `$${var}` (double dollar), not `${var}`,**
    to survive Flux `postBuild` substitution — Flux collapses `$${` to `${`
@@ -79,7 +82,9 @@ queries that silently return nothing, not an error:
    url: "$${__value.raw}"
    ```
    and in VictoriaTraces' datasource (`tracesToMetrics` queries use
-   `rate(http_server_requests_total{$$__tags}[5m])`).
+   `sum(rate(http.server.request.duration_count{$$__tags}[5m]))` — dot-named,
+   because the app emits OTel semconv metrics; `http_server_requests_total`
+   never existed here).
 
 **Worked example**, combining rules 1 and 2:
 


### PR DESCRIPTION
## What you see today

Five panels on the "All in One" demo dashboard say **No data**, and three more
advertise "click exemplar dots to view traces" — an interaction that cannot
happen. Investigating that turned up something wider: **every cross-datasource
link in this platform has silently done nothing since it was written**, on both
clusters.

## Four independent defects, none visible to CI

| Defect | Why nothing caught it |
|---|---|
| 6 panel expressions query `http.server.request.count`, removed by the semconv v2 migration | the alert rules were migrated at the time, the dashboard was not; P95 kept working because it reads `duration_bucket` |
| `datasourceName` is in **no** Grafana schema — only `datasourceUid` is | the datasource loads fine, the link just never appears |
| `tracesToLogs` v1 is superseded by `tracesToLogsV2`, which is what Grafana reads | correcting keys inside a block nothing reads looks like a fix and is not one |
| neither datasource pinned a `uid`, so references to the literal names matched nothing | the operator assigns a random uid; the reference silently resolves to nothing |

`flux schema validate` sees a well-formed map, polaris never reads datasource
config, and a documentation claim only fails when it pins the exact value.

## Exemplars: ruled out, permanently

The dashboard's trace correlation was built on exemplars. They cannot work here:

- `/api/v1/query_exemplars` is a **hardcoded stub** in `app/vmselect/main.go`
  returning `{"status":"success","data":[]}` — byte-identical to what the live
  cluster returns
- real support (PR #5982) was merged upstream 2024-05-07 and **reverted**
  2024-07-03, with a maintainer rationale rejecting exemplars as immature
- the OTLP ingestion parser contains **zero** references to exemplars, so
  switching from exponential to classic histograms would change nothing

No flag, no version bump, no ingestion change fixes this. The dead affordances
are removed rather than left as a promise the data cannot keep.

## What replaces them

A traces row — a search panel and a service map on the existing VictoriaTraces
datasource — plus a **data link** on the latency panel that opens that panel
filtered to slow traces over the clicked time range. Every referent verified:
the target panel id exists, the `min_trace_duration` variable is defined, and
the traces target actually reads it.

## One deliberate use of a deprecated field

The uid is pinned at `spec.datasource.uid`, which the CRD marks deprecated.
`spec.uid` is immutable and the API server rejects it outright on an
already-created object:

```
The GrafanaDatasource "vt-datasource" is invalid: spec: Invalid value: spec.uid is immutable
```

Flux would have hit that on every reconcile — a change that fixes dead links by
wedging the Kustomization that delivers them. Confirmed by server-side dry-run.
Renaming both objects so they are re-created was the alternative; it churns live
datasources for no gain. The reasoning is recorded in both files.

## Also fixed

The **load generator exported no telemetry at all** — resource detection failed
with `user: Current requires cgo or $USER set in environment`, so every trace
started at the server span rather than at the generator. The App composition
injects `USER` for the app containers; the plain CronJob manifest never got one.

## Documentation

`dashboards-and-alerts.md` reproduced the broken configuration **verbatim as the
pattern to copy**, so fixing only the manifests would have guaranteed it comes
back. `logs.md` cited the old regex and a nonexistent metric as evidence for two
rules that are themselves correct. **ADR-0010 is amended, not edited** — its
driver stays as the record of what was believed, with a dated note under
Consequences recording that the linking was inert.

## Verification

- `./scripts/validate-manifests.sh` -> **All gates passed**
- `./scripts/validate-doc-claims.sh` -> 28 claims / 49 page checks
- `./scripts/validate-links.sh` -> all resolve
- both datasource CRs -> `configured` on a server-side dry-run against the live CRD
- escaping invariant -> **0** bare `${name}` across all three YAML files

## Not verified, deliberately flagged

- **the traces/nodeGraph panels have not been seen rendering.** They use
  `queryType: search` against the Jaeger-type datasource; the shape is right but
  no live Grafana has displayed them, and nothing in CI can.
- **`tracesToLogsV2` semantics.** VictoriaLogs speaks LogsQL, not LogQL, so
  `filterByTraceID` may not translate; if that direction stays empty the fix is
  `customQuery` with a LogsQL expression. Noted in the file. The reverse
  direction — logs to trace — is the one the demo relies on and is fixed here.
